### PR TITLE
Monster Drops

### DIFF
--- a/data/definitions/items.yml
+++ b/data/definitions/items.yml
@@ -4940,6 +4940,7 @@ white_apron:
   limit: 100
   weight: 0.453
   slot: "Chest"
+  type: "Sleeveless"
   examine: "A mostly clean apron."
 white_apron_noted: 1006
 cape_red:
@@ -9706,6 +9707,7 @@ brown_apron:
   limit: 100
   weight: 0.453
   slot: "Chest"
+  type: "Sleeveless"
   examine: "A mostly clean apron."
 brown_apron_noted: 1758
 ball_of_wool:

--- a/data/definitions/npcs.yml
+++ b/data/definitions/npcs.yml
@@ -105,7 +105,7 @@ cow_calf:
   slayxp: 6.0
   style: "crush"
   examine: "Young, but still beefy."
-  category: "calf"
+  category: "cow"
   height: 15
 goblin_mohawk_blue:
   id: 4262

--- a/data/spawns/drops.yml
+++ b/data/spawns/drops.yml
@@ -441,7 +441,8 @@ mega_rare_drop_table:
 cow_drop_table:
   type: all
   drops:
-    - drops:
+    - type: all
+      drops:
         - name: cowhide
         - name: raw_beef
         - name: bones
@@ -452,7 +453,8 @@ cow_drop_table:
 chicken_drop_table:
   type: all
   drops:
-    - drops:
+    - type: all
+      drops:
         - name: raw_chicken
         - name: bones
     - roll: 128

--- a/data/spawns/drops.yml
+++ b/data/spawns/drops.yml
@@ -23,7 +23,6 @@ allotment_seed_drop_table:
     - name: snape_grass_seed
       chance: 1
 general_seeds:
-  # TODO npc combatLevel * 10
   roll: 0
   drops:
     - name: allotment_seed_subtable

--- a/data/spawns/drops.yml
+++ b/data/spawns/drops.yml
@@ -1,683 +1,540 @@
 allotment_seed_drop_table:
+  roll: 128
   drops:
     - name: potato_seed
-      quantity: 1-4
-      chance: 64/128
+      amount: 1-4
+      chance: 64
     - name: onion_seed
-      quantity: 1-3
-      chance: 32/128
+      amount: 1-3
+      chance: 32
     - name: cabbage_seed
-      quantity: 1-3
-      chance: 16/128
+      amount: 1-3
+      chance: 16
     - name: tomato_seed
-      quantity: 1-2
-      chance: 8/128
+      amount: 1-2
+      chance: 8
     - name: sweetcorn_seed
-      quantity: 1-2
-      chance: 4/128
+      amount: 1-2
+      chance: 4
     - name: strawberry_seed
-      amount: 1
-      chance: 2/128
+      chance: 2
     - name: watermelon_seed
-      amount: 1
-      chance: 1/128
+      chance: 1
     - name: snape_grass_seed
-      amount: 1
-      chance: 1/128
+      chance: 1
 general_seeds:
   # TODO npc combatLevel * 10
+  roll: 0
   drops:
-    - table: allotment_seed_subtable
-      chance: 485/0
-    - table: hops_seed_subtable
-      chance: 728/0
-    - table: flower_seed_subtable
-      chance: 850/0
-    - table: bush_seed_subtable
-      chance: 947/0
-    - table: herb_seed_subtable
-      chance: 995/0
-    - table: special_seed_subtable
-      chance: 1000/0
+    - name: allotment_seed_subtable
+      chance: 485
+    - name: hops_seed_subtable
+      chance: 728
+    - name: flower_seed_subtable
+      chance: 850
+    - name: bush_seed_subtable
+      chance: 947
+    - name: herb_seed_subtable
+      chance: 995
+    - name: special_seed_subtable
+      chance: 1000
 allotment_seed_subtable:
+  roll: 1008
   drops:
     - name: potato_seed
       amount: 4
-      chance: 368/1008
+      chance: 368
     - name: onion_seed
       amount: 4
-      chance: 276/1008
+      chance: 276
     - name: cabbage_seed
       amount: 4
-      chance: 184/1008
+      chance: 184
     - name: tomato_seed
       amount: 3
-      chance: 92/1008
+      chance: 92
     - name: sweetcorn_seed
       amount: 3
-      chance: 46/1008
+      chance: 46
     - name: strawberry_seed
       amount: 2
-      chance: 23/1008
+      chance: 23
     - name: watermelon_seed
       amount: 2
-      chance: 11/1008
+      chance: 11
     - name: snape_grass_seed
       amount: 2
-      chance: 8/1008
+      chance: 8
 hops_seed_subtable:
-  total: 1000
+  roll: 1000
   drops:
     - name: barley_seed
       amount: 4
-      chance: 229/1000
+      chance: 229
     - name: hammerstone_seed
       amount: 3
-      chance: 228/1000
+      chance: 228
     - name: asgarnian_seed
       amount: 3
-      chance: 172/1000
+      chance: 172
     - name: jute_seed
       amount: 2
-      chance: 171/1000
+      chance: 171
     - name: yanillian_seed
       amount: 2
-      chance: 114/1000
+      chance: 114
     - name: krandorian_seed
       amount: 2
-      chance: 57/1000
+      chance: 57
     - name: wildblood_seed
-      amount: 1
-      chance: 29/1000
+      chance: 29
 flower_seed_subtable:
+  roll: 1000
   drops:
     - name: marigold_seed
-      amount: 1
-      chance: 376/1000
+      chance: 376
     - name: nasturtium_seed
-      amount: 1
-      chance: 249/1000
+      chance: 249
     - name: rosemary_seed
-      amount: 1
-      chance: 161/1000
+      chance: 161
     - name: woad_seed
-      amount: 1
-      chance: 119/1000
+      chance: 119
     - name: limpwurt_seed
-      amount: 1
-      chance: 95/1000
+      chance: 95
 bush_seed_subtable:
+  roll: 1000
   drops:
     - name: redberry_seed
-      amount: 1
-      chance: 400/1000
+      chance: 400
     - name: cadavaberry_seed
-      amount: 1
-      chance: 280/1000
+      chance: 280
     - name: dwellberry_seed
-      amount: 1
-      chance: 200/1000
+      chance: 200
     - name: jangerberry_seed
-      amount: 1
-      chance: 80/1000
+      chance: 80
     - name: whiteberry_seed
-      amount: 1
-      chance: 29/1000
+      chance: 29
     - name: poison_ivy_seed
-      amount: 1
-      chance: 11/1000
+      chance: 11
 herb_seed_subtable:
+  roll: 1000
   drops:
     - name: guam_seed
-      amount: 1
-      chance: 320/1000
+      chance: 320
     - name: marrentill_seed
-      amount: 1
-      chance: 218/1000
+      chance: 218
     - name: tarromin_seed
-      amount: 1
-      chance: 149/1000
+      chance: 149
     - name: harralander_seed
-      amount: 1
-      chance: 101/1000
+      chance: 101
     - name: ranarr_seed
-      amount: 1
-      chance: 69/1000
+      chance: 69
     - name: toadflax_seed
-      amount: 1
-      chance: 47/1000
+      chance: 47
     - name: irit_seed
-      amount: 1
-      chance: 32/1000
+      chance: 32
     - name: avantoe_seed
-      amount: 1
-      chance: 22/1000
+      chance: 22
     - name: kwuarm_seed
-      amount: 1
-      chance: 15/1000
+      chance: 15
     - name: snapdragon_seed
-      amount: 1
-      chance: 10/1000
+      chance: 10
     - name: cadantine_seed
-      amount: 1
-      chance: 7/1000
+      chance: 7
     - name: lantadyme_seed
-      amount: 1
-      chance: 5/1000
+      chance: 5
     - name: dwarf_weed_seed
-      amount: 1
-      chance: 3/1000
+      chance: 3
     - name: torstol_seed
-      amount: 1
-      chance: 2/1000
+      chance: 2
 special_seed_subtable:
+  roll: 1100
   drops:
     - name: mushroom_spore
-      amount: 1
-      chance: 500/1100
+      chance: 500
     - name: belladonna_seed
-      amount: 1
-      chance: 300/1100
+      chance: 300
     - name: cactus_seed
-      amount: 1
-      chance: 200/1100
+      chance: 200
     - name: potato_cactus_seed
-      amount: 1
-      chance: 100/1100
+      chance: 100
 rare_seed_drop_table:
+  roll: 238
   drops:
     - name: toadflax_seed
-      amount: 1
-      chance: 47/238
+      chance: 47
     - name: irit_seed
-      amount: 1
-      chance: 32/238
+      chance: 32
     - name: belladonna_seed
-      amount: 1
-      chance: 31/238
+      chance: 31
     - name: avantoe_seed
-      amount: 1
-      chance: 22/238
+      chance: 22
     - name: poison_ivy_seed
-      amount: 1
-      chance: 22/238
+      chance: 22
     - name: cactus_seed
-      amount: 1
-      chance: 21/238
+      chance: 21
     - name: kwuarm_seed
-      amount: 1
-      chance: 15/238
+      chance: 15
     - name: potato_cactus_seed
-      amount: 1
-      chance: 15/238
+      chance: 15
     - name: snapdragon_seed
-      amount: 1
-      chance: 10/238
+      chance: 10
     - name: cadantine_seed
-      amount: 1
-      chance: 7/238
+      chance: 7
     - name: lantadyme_seed
-      amount: 1
-      chance: 5/238
+      chance: 5
     - name: snape_grass_seed
       amount: 3
-      chance: 4/238
+      chance: 4
     - name: dwarf_weed_seed
-      amount: 1
-      chance: 3/238
+      chance: 3
     - name: torstol_seed
-      amount: 1
-      chance: 2/238
+      chance: 2
 tree_herb_seed_drop_table:
+  roll: 250
   drops:
     - name: ranarr_seed
-      amount: 1
-      chance: 30/250
+      chance: 30
     - name: snapdragon_seed
-      amount: 1
-      chance: 28/250
+      chance: 28
     - name: torstol_seed
-      amount: 1
-      chance: 22/250
+      chance: 22
     - name: watermelon_seed
       amount: 15
-      chance: 21/250
+      chance: 21
     - name: willow_seed
-      amount: 1
-      chance: 20/250
+      chance: 20
     - name: mahogany_seed
-      amount: 1
-      chance: 18/250
+      chance: 18
     - name: maple_seed
-      amount: 1
-      chance: 18/250
+      chance: 18
     - name: teak_seed
-      amount: 1
-      chance: 18/250
+      chance: 18
     - name: yew_seed
-      amount: 1
-      chance: 18/250
+      chance: 18
     - name: papaya_tree_seed
-      amount: 1
-      chance: 14/250
+      chance: 14
     - name: magic_seed
-      amount: 1
-      chance: 11/250
+      chance: 11
     - name: palm_tree_seed
-      amount: 1
-      chance: 10/250
+      chance: 10
     - name: spirit_seed
-      amount: 1
-      chance: 4/250
+      chance: 4
     - name: dragonfruit_tree_seed
-      amount: 1
-      chance: 6/250
+      chance: 6
     - name: celastrus_seed
-      amount: 1
-      chance: 4/250
+      chance: 4
     - name: redwood_tree_seed
-      amount: 1
-      chance: 4/250
+      chance: 4
 uncommon_seed_drop_table:
+  roll: 1048
   drops:
     - name: limpwurt_seed
-      amount: 1
-      chance: 137/1048
+      chance: 137
     - name: strawberry_seed
-      amount: 1
-      chance: 131/1048
+      chance: 131
     - name: marrentill_seed
-      amount: 1
-      chance: 125/1048
+      chance: 125
     - name: jangerberry_seed
-      amount: 1
-      chance: 92/1048
+      chance: 92
     - name: tarromin_seed
-      amount: 1
-      chance: 85/1048
+      chance: 85
     - name: wildblood_seed
-      amount: 1
-      chance: 83/1048
+      chance: 83
     - name: watermelon_seed
-      amount: 1
-      chance: 63/1048
+      chance: 63
     - name: harralander_seed
-      amount: 1
-      chance: 56/1048
+      chance: 56
     - name: snape_grass_seed
-      amount: 1
-      chance: 40/1048
+      chance: 40
     - name: ranarr_seed
-      amount: 1
-      chance: 39/1048
+      chance: 39
     - name: whiteberry_seed
-      amount: 1
-      chance: 34/1048
+      chance: 34
     - name: mushroom_spore
-      amount: 1
-      chance: 29/1048
+      chance: 29
     - name: toadflax_seed
-      amount: 1
-      chance: 27/1048
+      chance: 27
     - name: belladonna_seed
-      amount: 1
-      chance: 18/1048
+      chance: 18
     - name: irit_seed
-      amount: 1
-      chance: 18/1048
+      chance: 18
     - name: poison_ivy_seed
-      amount: 1
-      chance: 13/1048
+      chance: 13
     - name: avantoe_seed
-      amount: 1
-      chance: 12/1048
+      chance: 12
     - name: cactus_seed
-      amount: 1
-      chance: 12/1048
+      chance: 12
     - name: kwuarm_seed
-      amount: 1
-      chance: 9/1048
+      chance: 9
     - name: potato_cactus_seed
-      amount: 1
-      chance: 8/1048
+      chance: 8
     - name: snapdragon_seed
-      amount: 1
-      chance: 5/1048
+      chance: 5
     - name: cadantine_seed
-      amount: 1
-      chance: 4/1048
+      chance: 4
     - name: lantadyme_seed
-      amount: 1
-      chance: 3/1048
+      chance: 3
     - name: dwarf_weed_seed
-      amount: 1
-      chance: 2/1048
+      chance: 2
     - name: torstol_seed
-      amount: 1
-      chance: 1/1048
+      chance: 1
 herb_drop_table:
+  roll: 128
   drops:
     - name: grimy_guam_leaf
-      amount: 1
-      chance: 32/128
+      chance: 32
     - name: grimy_marrentill
-      amount: 1
-      chance: 24/128
+      chance: 24
     - name: grimy_tarromin
-      amount: 1
-      chance: 18/128
+      chance: 18
     - name: grimy_harralander
-      amount: 1
-      chance: 14/128
+      chance: 14
     - name: grimy_ranarr_weed
-      amount: 1
-      chance: 11/128
+      chance: 11
     - name: grimy_irit_leaf
-      amount: 1
-      chance: 8/128
+      chance: 8
     - name: grimy_avantoe
-      amount: 1
-      chance: 6/128
+      chance: 6
     - name: grimy_kwuarm
-      amount: 1
-      chance: 5/128
+      chance: 5
     - name: grimy_cadantine
-      amount: 1
-      chance: 4/128
+      chance: 4
     - name: grimy_lantadyme
-      amount: 1
-      chance: 3/128
+      chance: 3
     - name: grimy_dwarf_weed
-      amount: 1
-      chance: 3/128
+      chance: 3
 useful_herb_drop_table:
+  roll: 16
   drops:
     - name: grimy_avantoe_noted
-      amount: 1
-      chance: 5/16
+      chance: 5
     - name: grimy_snapdragon_noted
-      amount: 1
-      chance: 4/16
+      chance: 4
     - name: grimy_ranarr_weed_noted
-      amount: 1
-      chance: 4/16
+      chance: 4
     - name: grimy_torstol_noted
-      amount: 1
-      chance: 3/16
+      chance: 3
 runes_and_ammunition:
+  roll: 128
   drops:
     - name: nature_rune
       amount: 67
-      chance: 3/128
+      chance: 3
     - name: adamant_javelin
       amount: 20
-      chance: 2/128
+      chance: 2
     - name: death_rune
       amount: 45
-      chance: 2/128
+      chance: 2
     - name: law_rune
       amount: 45
-      chance: 2/128
+      chance: 2
     - name: rune_arrow
       amount: 42
-      chance: 2/128
+      chance: 2
     - name: steel_arrow
       amount: 150
-      chance: 2/128
+      chance: 2
 weapons_and_armour:
+  roll: 128
   drops:
     - name: rune_2h_sword
-      amount: 1
-      chance: 3/128
+      chance: 3
     - name: rune_battleaxe
-      amount: 1
-      chance: 3/128
+      chance: 3
     - name: rune_sq_shield
-      amount: 1
-      chance: 2/128
+      chance: 2
     - name: dragon_med_helm
-      amount: 1
-      chance: 1/128
+      chance: 1
     - name: rune_kiteshield
-      amount: 1
-      chance: 1/128
+      chance: 1
 other:
+  roll: 128
   drops:
     - name: coins
       amount: 3000
-      chance: 21/128
+      chance: 21
     - name: loop_half_of_key
-      amount: 1
-      chance: 20/128
+      chance: 20
     - name: tooth_half_of_key
-      amount: 1
-      chance: 20/128
+      chance: 20
     - name: runite_bar
-      amount: 1
-      chance: 5/128
+      chance: 5
     - name: dragonstone
-      amount: 1
-      chance: 2/128
+      chance: 2
     - name: silver_ore_noted
       amount: 100
-      chance: 2/128
+      chance: 2
 subtables:
+  roll: 128
   drops:
     - name: gem_drop_table
-      amount: 1
-      chance: 20/128
-    - name: mega-rare_drop_table
-      amount: 1
-      chance: 15/128
+      chance: 20
+    - name: mega_rare_drop_table
+      chance: 15
 gem_drop_table:
+  roll: 128
   drops:
     - name: nothing
       amount: 0
-      chance: 63/128
+      chance: 63
     - name: uncut_sapphire
-      amount: 1
-      chance: 32/128
+      chance: 32
     - name: uncut_emerald
-      amount: 1
-      chance: 16/128
+      chance: 16
     - name: uncut_ruby
-      amount: 1
-      chance: 8/128
+      chance: 8
     - name: talisman
-      amount: 1
-      chance: 3/128
+      chance: 3
     - name: uncut_diamond
-      amount: 1
-      chance: 2/128
+      chance: 2
     - name: rune_javelin
       amount: 5
-      chance: 1/128
+      chance: 1
     - name: loop_half_of_key
-      amount: 1
-      chance: 1/128
+      chance: 1
     - name: tooth_half_of_key
-      amount: 1
-      chance: 1/128
-    - name: mega-rare_drop_table
-      amount: 1
-      chance: 1/128
+      chance: 1
+    - name: mega_rare_drop_table
+      chance: 1
 talisman_drop_table:
+  roll: 70
   drops:
     - name: air_talisman
-      amount: 1
-      chance: 10/70
+      chance: 10
     - name: body_talisman
-      amount: 1
-      chance: 10/70
+      chance: 10
     - name: earth_talisman
-      amount: 1
-      chance: 10/70
+      chance: 10
     - name: fire_talisman
-      amount: 1
-      chance: 10/70
+      chance: 10
     - name: mind_talisman
-      amount: 1
-      chance: 10/70
+      chance: 10
     - name: water_talisman
-      amount: 1
-      chance: 10/70
+      chance: 10
     - name: cosmic_talisman
-      amount: 1
-      chance: 4/70
+      chance: 4
     - name: chaos_talisman
-      amount: 1
-      chance: 3/70
+      chance: 3
     - name: nature_talisman
-      amount: 1
-      chance: 3/70
+      chance: 3
 superior_drop_table:
+  roll: 8
   drops:
     - name: dust_battlestaff
-      amount: 1
-      chance: 3/8
+      chance: 3
     - name: mist_battlestaff
-      amount: 1
-      chance: 3/8
-mega-rare_drop_table:
-  total: 128
+      chance: 3
+mega_rare_drop_table:
+  roll: 128
   drops:
     - name: nothing
       amount: 0
       chance: 113
     - name: rune_spear
-      amount: 1
       chance: 8
     - name: shield_left_half
-      amount: 1
       chance: 4
     - name: dragon_spear
-      amount: 1
       chance: 3
 cow_drop_table:
+  type: all
   drops:
-    - table:
-        chance: 1/1
-        drops:
-          - name: cowhide
-            amount: 1
-            chance: 1/1
-          - name: raw_beef
-            amount: 1
-            chance: 1/1
-          - name: bones
-            amount: 1
-            chance: 1/1
-    - table:
-        chance: 1/1
-        drops:
-          - name: easy_clue_scroll
-            amount: 1
-            chance: 1/128
+    - drops:
+        - name: cowhide
+        - name: raw_beef
+        - name: bones
+    - roll: 128
+      drops:
+        - name: easy_clue_scroll
+          chance: 1
 chicken_drop_table:
+  type: all
   drops:
-    - table:
-        chance: 1/1
-        drops:
-          - name: raw_chicken
-            amount: 1
-            chance: 1/1
-          - name: bones
-            amount: 1
-            chance: 1/1
-    - table:
-        chance: 1/1
-        drops:
-          - name: feather
-            amount: 5
-            chance: 64/128
-          - name: feather
-            amount: 15
-            chance: 32/128
-    - table:
-        chance: 1/1
-        drops:
-          - name: easy_clue_scroll
-            amount: 1
-            chance: 1/300
+    - drops:
+        - name: raw_chicken
+        - name: bones
+    - roll: 128
+      drops:
+        - name: feather
+          amount: 5
+          chance: 64
+        - name: feather
+          amount: 15
+          chance: 32
+    - roll: 300
+      drops:
+        - name: easy_clue_scroll
+          chance: 1
 rat_drop_table:
+  type: all
   drops:
-    - table:
-        chance: 1/1
-        drops:
-          - name: bones
-            amount: 1
-            chance: 1/1
-    - table:
-        chance: 1/1
-        drops:
-          - name: rat_bone
-            amount: 1
-            chance: 1/4
+    - drops:
+        - name: bones
+    - roll: 4
+      drops:
+        - name: rat_bone
+          chance: 1
 goblin_drop_table:
+  type: all
   drops:
-    - table:
-        chance: 1/1
-        drops:
-          - name: bones
-            amount: 1
-            chance: 1/1
-    - table:
-        chance: 1/1
-        drops:
-          - name: bronze_sq_shield
-            amount: 1
-            chance: 3/128
-          - name: bronze_spear
-            amount: 1
-            chance: 4/128
-          - name: body_rune
-            amount: 7
-            chance: 5/128
-          - name: water_rune
-            amount: 6
-            chance: 6/128
-          - name: earth_rune
-            amount: 4
-            chance: 3/128
-          - name: bronze_bolts
-            amount: 8
-            chance: 3/128
-          - name: coins
-            amount: 5
-            chance: 28/128
-          - name: coins
-            amount: 9
-            chance: 3/128
-          - name: coins
-            amount: 15
-            chance: 3/128
-          - name: coins
-            amount: 20
-            chance: 2/128
-          - name: coins
-            amount: 1
-            chance: 1/128
-          - name: nothing
-            amount: 0
-            chance: 38/128
-          - name: hammer
-            amount: 1
-            chance: 15/128
-          - name: goblin_book
-            amount: 1
-            chance: 2/128
-          - name: goblin_mail
-            amount: 1
-            chance: 5/128
-          - name: chefs_hat
-            amount: 1
-            chance: 3/128
-          - name: beer
-            amount: 1
-            chance: 2/128
-          - name: brass_necklace
-            amount: 1
-            chance: 1/128
-          - name: air_talisman
-            amount: 1
-            chance: 1/128
+    - drops:
+        - name: bones
+    - roll: 128
+      drops:
+        - name: bronze_sq_shield
+          chance: 3
+        - name: bronze_spear
+          chance: 4
+        - name: body_rune
+          amount: 7
+          chance: 5
+        - name: water_rune
+          amount: 6
+          chance: 6
+        - name: earth_rune
+          amount: 4
+          chance: 3
+        - name: bronze_bolts
+          amount: 8
+          chance: 3
+        - name: coins
+          amount: 5
+          chance: 28
+        - name: coins
+          amount: 9
+          chance: 3
+        - name: coins
+          amount: 15
+          chance: 3
+        - name: coins
+          amount: 20
+          chance: 2
+        - name: coins
+          amount: 1
+          chance: 1
+        - name: nothing
+          amount: 0
+          chance: 38
+        - name: hammer
+          amount: 1
+          chance: 15
+        - name: goblin_book
+          amount: 1
+          chance: 2
+        - name: goblin_mail
+          amount: 1
+          chance: 5
+        - name: chefs_hat
+          amount: 1
+          chance: 3
+        - name: beer
+          amount: 1
+          chance: 2
+        - name: brass_necklace
+          amount: 1
+          chance: 1
+        - name: air_talisman
+          amount: 1
+          chance: 1

--- a/engine/src/main/kotlin/world/gregs/voidps/engine/action/Suspension.kt
+++ b/engine/src/main/kotlin/world/gregs/voidps/engine/action/Suspension.kt
@@ -5,4 +5,5 @@ sealed class Suspension {
     object Movement : Suspension()
     object Tick : Suspension()
     object Infinite : Suspension()
+    object External : Suspension()
 }

--- a/engine/src/main/kotlin/world/gregs/voidps/engine/entity/character/contain/Container.kt
+++ b/engine/src/main/kotlin/world/gregs/voidps/engine/entity/character/contain/Container.kt
@@ -463,6 +463,13 @@ data class Container(
         return null
     }
 
+    fun sortedByDescending(block: (Item) -> Int) {
+        val all = this.items.sortedByDescending(block)
+        all.forEachIndexed { index, item ->
+            this.items[index] = item
+        }
+    }
+
     fun sort() {
         val all = LinkedList<Item>()
         for ((index, item) in this.items.withIndex().reversed()) {

--- a/engine/src/main/kotlin/world/gregs/voidps/engine/entity/character/contain/Container.kt
+++ b/engine/src/main/kotlin/world/gregs/voidps/engine/entity/character/contain/Container.kt
@@ -5,6 +5,7 @@ import com.github.michaelbull.logging.InlineLogger
 import world.gregs.voidps.engine.entity.definition.ItemDefinitions
 import world.gregs.voidps.engine.entity.item.Item
 import world.gregs.voidps.engine.event.Events
+import world.gregs.voidps.utility.get
 import java.util.*
 
 data class Container(
@@ -612,5 +613,30 @@ data class Container(
 
     companion object {
         private val logger = InlineLogger()
+
+        fun setup(
+            capacity: Int,
+            stackMode: StackMode = StackMode.Normal,
+            id: Int = 0,
+            name: String = "",
+            secondary: Boolean = false,
+            minimumAmount: Int = 0,
+            container: Container = Container(Array(capacity) { Item("", minimumAmount) }),
+            events: Events? = null
+        ) = container.apply {
+            if (!setup) {
+                minimumAmounts = IntArray(capacity) { minimumAmount }
+                this.id = id
+                this.name = name
+                this.capacity = capacity
+                this.stackMode = stackMode
+                definitions = get()
+                if (events != null) {
+                    this.events.add(events)
+                }
+                this.secondary = secondary
+                this.setup = true
+            }
+        }
     }
 }

--- a/engine/src/main/kotlin/world/gregs/voidps/engine/entity/character/contain/Containers.kt
+++ b/engine/src/main/kotlin/world/gregs/voidps/engine/entity/character/contain/Containers.kt
@@ -50,17 +50,16 @@ fun Player.container(name: String, def: ContainerDefinition, secondary: Boolean 
     return containers.getOrPut(if (secondary) "_$name" else name) {
         Container(items = Array(def.length) { Item("", if (shop) -1 else 0) })
     }.apply {
-        if (!setup) {
-            minimumAmounts = IntArray(capacity) { if (shop) -1 else 0 }
-            id = def.id
-            this.name = if (secondary) "_$name" else name
-            capacity = def.length
-            stackMode = if (shop) StackMode.Always else def["stack", StackMode.Normal]
-            definitions = get()
-            this.events.add(this@container.events)
-            this.secondary = secondary
-            this.setup = true
-        }
+        Container.setup(
+            container = this,
+            id = def.id,
+            capacity = def.length,
+            secondary = secondary,
+            name = if (secondary) "_$name" else name,
+            minimumAmount = if (shop) -1 else 0,
+            stackMode = if (shop) StackMode.Always else def["stack", StackMode.Normal],
+            events = this@container.events
+        )
     }
 }
 

--- a/engine/src/main/kotlin/world/gregs/voidps/engine/entity/item/drop/Drop.kt
+++ b/engine/src/main/kotlin/world/gregs/voidps/engine/entity/item/drop/Drop.kt
@@ -1,5 +1,3 @@
 package world.gregs.voidps.engine.entity.item.drop
 
-interface Drop {
-    val chance: Int
-}
+interface Drop

--- a/engine/src/main/kotlin/world/gregs/voidps/engine/entity/item/drop/Drop.kt
+++ b/engine/src/main/kotlin/world/gregs/voidps/engine/entity/item/drop/Drop.kt
@@ -1,0 +1,5 @@
+package world.gregs.voidps.engine.entity.item.drop
+
+interface Drop {
+    val chance: Int
+}

--- a/engine/src/main/kotlin/world/gregs/voidps/engine/entity/item/drop/DropTable.kt
+++ b/engine/src/main/kotlin/world/gregs/voidps/engine/entity/item/drop/DropTable.kt
@@ -2,29 +2,50 @@ package world.gregs.voidps.engine.entity.item.drop
 
 import kotlin.random.Random
 
+/**
+ * Distributes a collection of items to award for a monster kill.
+ * [ItemDrop]'s are selected based on a single [random] roll between 0 and [roll]
+ * Going down the [drops] list if the accumulated [ItemDrop.chance] exceeds the [roll] then that item is awarded.
+ *
+ * @param type The selection strategy; All - Every top-level drop is rolled, First - Only the first rewarded item is returned
+ * @param roll The maximum roll (exclusive)
+ * @param drops A list of [ItemDrop]'s and nested [DropTable]'s
+ */
 data class DropTable(
     val type: TableType,
     val roll: Int,
-    val drops: List<Drop>,
-    override val chance: Int
+    val drops: List<Drop>
 ) : Drop {
 
-    fun role(list: MutableList<ItemDrop> = mutableListOf(), value: Int = -1): List<ItemDrop> {
-        val roll = Random.nextInt(0, if (roll == 0 && value != -1) value else roll)
+    fun role(maximumRoll: Int = -1, list: MutableList<ItemDrop> = mutableListOf()): MutableList<ItemDrop> {
+        collect(list, maximumRoll, random(maximumRoll))
+        return list
+    }
+
+    fun random(maximum: Int): Int {
+        return Random.nextInt(0, if (roll <= 0 && maximum != -1) maximum else roll)
+    }
+
+    fun collect(list: MutableList<ItemDrop>, value: Int, roll: Int = random(value)): Boolean {
         var count = 0
         for (drop in drops) {
-            count += drop.chance
-            if (roll < count) {
-                when (drop) {
-                    is DropTable -> drop.role(list, value)
-                    is ItemDrop -> list.add(drop)
+            if (drop is DropTable) {
+                if (drop.collect(list, value) && type == TableType.First) {
+                    return true
                 }
-                if (type == TableType.First) {
-                    return list
+            } else if (drop is ItemDrop) {
+                if (type == TableType.All) {
+                    list.add(drop)
+                } else {
+                    count += drop.chance
+                    if (roll < count) {
+                        list.add(drop)
+                        return true
+                    }
                 }
             }
         }
-        return list
+        return type == TableType.All
     }
 
     class Builder {
@@ -54,9 +75,9 @@ data class DropTable(
         }
 
         fun build(): DropTable {
-            val total = drops.sumOf { it.chance }
+            val total = drops.sumOf { if (it is ItemDrop) it.chance else 0 }
             assert(total < roll) { "Chances $total cannot exceed roll $roll." }
-            return DropTable(type, roll, drops, chance)
+            return DropTable(type, roll, drops)
         }
     }
 }

--- a/engine/src/main/kotlin/world/gregs/voidps/engine/entity/item/drop/DropTable.kt
+++ b/engine/src/main/kotlin/world/gregs/voidps/engine/entity/item/drop/DropTable.kt
@@ -1,0 +1,62 @@
+package world.gregs.voidps.engine.entity.item.drop
+
+import kotlin.random.Random
+
+data class DropTable(
+    val type: TableType,
+    val roll: Int,
+    val drops: List<Drop>,
+    override val chance: Int
+) : Drop {
+
+    fun role(list: MutableList<ItemDrop> = mutableListOf(), value: Int = -1): List<ItemDrop> {
+        val roll = Random.nextInt(0, if (roll == 0 && value != -1) value else roll)
+        var count = 0
+        for (drop in drops) {
+            count += drop.chance
+            if (roll < count) {
+                when (drop) {
+                    is DropTable -> drop.role(list, value)
+                    is ItemDrop -> list.add(drop)
+                }
+                if (type == TableType.First) {
+                    return list
+                }
+            }
+        }
+        return list
+    }
+
+    class Builder {
+        private var type: TableType = TableType.First
+        private var roll = 1
+        private var chance: Int = 1
+        private val drops = mutableListOf<Drop>()
+
+        fun addDrop(drop: Drop): Builder {
+            this.drops.add(drop)
+            return this
+        }
+
+        fun withRoll(total: Int): Builder {
+            this.roll = total
+            return this
+        }
+
+        fun withType(type: TableType): Builder {
+            this.type = type
+            return this
+        }
+
+        fun withChance(chance: Int): Builder {
+            this.chance = chance
+            return this
+        }
+
+        fun build(): DropTable {
+            val total = drops.sumOf { it.chance }
+            assert(total < roll) { "Chances $total cannot exceed roll $roll." }
+            return DropTable(type, roll, drops, chance)
+        }
+    }
+}

--- a/engine/src/main/kotlin/world/gregs/voidps/engine/entity/item/drop/DropTables.kt
+++ b/engine/src/main/kotlin/world/gregs/voidps/engine/entity/item/drop/DropTables.kt
@@ -1,0 +1,80 @@
+package world.gregs.voidps.engine.entity.item.drop
+
+import org.koin.dsl.module
+import world.gregs.voidps.engine.data.file.FileLoader
+import world.gregs.voidps.engine.timedLoad
+import world.gregs.voidps.utility.getProperty
+
+val dropTableModule = module {
+    single(createdAtStart = true) { DropTables().load() }
+}
+
+@Suppress("UNCHECKED_CAST")
+class DropTables {
+
+    private lateinit var tables: Map<String, DropTable>
+
+    fun get(key: String) = tables[key]
+
+    fun getValue(key: String) = tables.getValue(key)
+
+    fun load(loader: FileLoader = world.gregs.voidps.utility.get(), path: String = getProperty("dropsPath")): DropTables {
+        timedLoad("drop table") {
+            load(loader.load<Map<String, Any>>(path))
+        }
+        return this
+    }
+
+    fun load(data: Map<String, Any>): Int {
+        tables = data.map { (key, value) -> key to loadTable(data, value as Map<String, Any>).build() }.toMap()
+        return tables.size
+    }
+
+    private fun loadTable(names: Map<String, Any>, map: Map<String, Any>): DropTable.Builder {
+        val table = DropTable.Builder()
+        if (map.containsKey("chance")) {
+            table.withChance(map.chance())
+        }
+        if (map.containsKey("roll")) {
+            table.withRoll(map.roll())
+        }
+        if (map.containsKey("type")) {
+            table.withType(TableType.byName(map["type"] as String))
+        }
+        if (map.containsKey("drops")) {
+            val drops = map["drops"] as List<Map<String, Any>>
+            for (drop in drops) {
+                if (drop.containsKey("drops") || drop.containsKey("name") && names.containsKey(drop.name())) {
+                    table.addDrop(loadTable(names, drop).build())
+                } else if(drop.containsKey("name")) {
+                    table.addDrop(ItemDrop(drop.name(), drop.amount(), drop.chance()))
+                }
+            }
+        } else if (map.containsKey("name")) {
+            val name = map.name()
+            check(names.contains(name)) { "Unable to find drop table link with name '$name'" }
+            table.addDrop(
+                loadTable(names, names[name] as Map<String, Any>)
+                    .withChance(map.chance())
+                    .build()
+            )
+        }
+        return table
+    }
+
+    private fun Map<String, Any>.name() = this["name"] as String
+    private fun Map<String, Any>.amount(): IntRange = if (containsKey("amount")) {
+        val amount = this["amount"]
+        if (amount is String && amount.contains("-")) {
+            amount.split("-").toIntRange()
+        } else {
+            amount as Int..amount
+        }
+    } else {
+        1..1
+    }
+
+    private fun Map<String, Any>.roll() = (this["roll"] as? Int) ?: 1
+    private fun Map<String, Any>.chance() = (this["chance"] as? Int) ?: 1
+    private fun List<String>.toIntRange() = first().toInt()..last().toInt()
+}

--- a/engine/src/main/kotlin/world/gregs/voidps/engine/entity/item/drop/ItemDrop.kt
+++ b/engine/src/main/kotlin/world/gregs/voidps/engine/entity/item/drop/ItemDrop.kt
@@ -1,0 +1,34 @@
+package world.gregs.voidps.engine.entity.item.drop
+
+import com.fasterxml.jackson.core.JsonGenerator
+import com.fasterxml.jackson.databind.JsonSerializer
+import com.fasterxml.jackson.databind.SerializerProvider
+import com.fasterxml.jackson.databind.annotation.JsonSerialize
+import world.gregs.voidps.engine.entity.item.Item
+
+data class ItemDrop(
+    val name: String,
+    @get:JsonSerialize(using = RangeSerializer::class)
+    val amount: IntRange,
+    override val chance: Int,
+) : Drop {
+
+    fun toItem(): Item {
+        if (name == "nothing" || name == "") {
+            return Item.EMPTY
+        }
+        return Item(name, amount.random())
+    }
+
+    companion object {
+        private class RangeSerializer : JsonSerializer<IntRange>() {
+            override fun serialize(value: IntRange, jsonGenerator: JsonGenerator, serializerProvider: SerializerProvider) {
+                if (value.first == value.last) {
+                    jsonGenerator.writeObject(value.first)
+                } else {
+                    jsonGenerator.writeObject("${value.first}-${value.last}")
+                }
+            }
+        }
+    }
+}

--- a/engine/src/main/kotlin/world/gregs/voidps/engine/entity/item/drop/ItemDrop.kt
+++ b/engine/src/main/kotlin/world/gregs/voidps/engine/entity/item/drop/ItemDrop.kt
@@ -10,11 +10,15 @@ data class ItemDrop(
     val name: String,
     @get:JsonSerialize(using = RangeSerializer::class)
     val amount: IntRange,
-    override val chance: Int,
+    val chance: Int = 1,
 ) : Drop {
 
+    init {
+        assert(chance > 0) { "Item must have a positive chance." }
+    }
+
     fun toItem(): Item {
-        if (name == "nothing" || name == "") {
+        if (name == "nothing" || name.isBlank()) {
             return Item.EMPTY
         }
         return Item(name, amount.random())

--- a/engine/src/main/kotlin/world/gregs/voidps/engine/entity/item/drop/TableType.kt
+++ b/engine/src/main/kotlin/world/gregs/voidps/engine/entity/item/drop/TableType.kt
@@ -1,7 +1,13 @@
 package world.gregs.voidps.engine.entity.item.drop
 
 enum class TableType {
+    /**
+     * Stop rolling after first item is awarded.
+     */
     First,
+    /**
+     * All drops in the table are called whether an item is awarded or not
+     */
     All;
 
     companion object {

--- a/engine/src/main/kotlin/world/gregs/voidps/engine/entity/item/drop/TableType.kt
+++ b/engine/src/main/kotlin/world/gregs/voidps/engine/entity/item/drop/TableType.kt
@@ -1,0 +1,10 @@
+package world.gregs.voidps.engine.entity.item.drop
+
+enum class TableType {
+    First,
+    All;
+
+    companion object {
+        fun byName(name: String) = values().first { it.name.toLowerCase() == name }
+    }
+}

--- a/engine/src/test/kotlin/world/gregs/voidps/engine/entity/item/drop/DropTableTest.kt
+++ b/engine/src/test/kotlin/world/gregs/voidps/engine/entity/item/drop/DropTableTest.kt
@@ -1,0 +1,78 @@
+package world.gregs.voidps.engine.entity.item.drop
+
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+internal class DropTableTest {
+
+    @Test
+    fun `Roll number from 0 until drop table roll value`() {
+        val drops = DropTable(TableType.First, 100, listOf())
+        val roll: Int = drops.random(maximum = Int.MAX_VALUE)
+        assertTrue(roll in 0 until 100)
+    }
+
+    @Test
+    fun `Roll number from 0 until value passed in`() {
+        val drops = DropTable(TableType.First, 0, listOf())
+        val roll: Int = drops.random(maximum = 100)
+        assertTrue(roll in 0 until 100)
+    }
+
+    @Test
+    fun `Roll every item in all type table`() {
+        val item1 = drop("1", 1)
+        val item2 = drop("2", 1)
+        val root = DropTable(TableType.All, -1, listOf(item1, item2))
+
+        val list = mutableListOf<ItemDrop>()
+        root.collect(list, -1, -1)
+
+        assertTrue(list.contains(item1))
+        assertTrue(list.contains(item2))
+    }
+
+    @Test
+    fun `Roll first item in table of tables`() {
+        val item1 = drop("1", 1)
+        val item2 = drop("2", 1)
+        val subTable1 = DropTable(TableType.All, 1, listOf(item1))
+        val subTable2 = DropTable(TableType.All, 1, listOf(item2))
+        val root = DropTable(TableType.First, -1, listOf(subTable1, subTable2))
+
+        val list = mutableListOf<ItemDrop>()
+        root.collect(list, -1, -1)
+
+        assertTrue(list.contains(item1))
+        assertFalse(list.contains(item2))
+    }
+
+    @Test
+    fun `Roll all tables of tables`() {
+        val item1 = drop("1", 1)
+        val item2 = drop("2", 1)
+        val subTable1 = DropTable(TableType.First, 1, listOf(item1))
+        val subTable2 = DropTable(TableType.First, 1, listOf(item2))
+        val root = DropTable(TableType.All, -1, listOf(subTable1, subTable2))
+
+        val list = mutableListOf<ItemDrop>()
+        root.collect(list, -1, -1)
+
+        assertTrue(list.contains(item1))
+        assertTrue(list.contains(item2))
+    }
+
+    @Test
+    fun `Don't collect drop with chance lower than roll`() {
+        val item1 = drop("1", 10)
+        val table = DropTable(TableType.First, -1, listOf(item1))
+
+        val list = mutableListOf<ItemDrop>()
+        table.collect(list, -1, 100)
+
+        assertFalse(list.contains(item1))
+    }
+
+    private fun drop(name: String, chance: Int): ItemDrop = ItemDrop(name, 1..1, chance)
+}

--- a/game/src/main/kotlin/world/gregs/voidps/GameModules.kt
+++ b/game/src/main/kotlin/world/gregs/voidps/GameModules.kt
@@ -10,6 +10,7 @@ import world.gregs.voidps.engine.data.file.jsonPlayerModule
 import world.gregs.voidps.engine.data.playerLoaderModule
 import world.gregs.voidps.engine.entity.character.player.login.loginQueueModule
 import world.gregs.voidps.engine.entity.definition.definitionsModule
+import world.gregs.voidps.engine.entity.item.drop.dropTableModule
 import world.gregs.voidps.engine.entity.list.entityListModule
 import world.gregs.voidps.engine.entity.obj.customObjectModule
 import world.gregs.voidps.engine.entity.obj.objectFactoryModule
@@ -48,6 +49,7 @@ fun getGameModules() = listOf(
     instanceModule,
     instancePoolModule,
     definitionsModule,
+    dropTableModule,
     objectFactoryModule,
     lineOfSightModule,
     navModule,

--- a/game/src/main/kotlin/world/gregs/voidps/world/interact/entity/npc/shop/ItemInformation.kts
+++ b/game/src/main/kotlin/world/gregs/voidps/world/interact/entity/npc/shop/ItemInformation.kts
@@ -10,7 +10,6 @@ import world.gregs.voidps.engine.entity.character.contain.ItemChanged
 import world.gregs.voidps.engine.entity.character.player.Player
 import world.gregs.voidps.engine.entity.character.player.skill.Level.has
 import world.gregs.voidps.engine.entity.clear
-import world.gregs.voidps.engine.entity.get
 import world.gregs.voidps.engine.entity.getOrNull
 import world.gregs.voidps.engine.entity.item.EquipSlot
 import world.gregs.voidps.engine.entity.item.Item
@@ -31,7 +30,7 @@ val requirementMessages = enums.get(1435).map!!
 val quests = enums.get(2252).map!!
 
 on<InterfaceOption>({ name == "shop" && option == "Info" }) { player: Player ->
-    val shop: String = player["shop"]
+    val shop: String = player.getOrNull("shop") ?: return@on
     val sample = component == "sample"
     val actualIndex = itemIndex / (if (sample) 4 else 6)
     val container = player.shopContainer(sample)

--- a/game/src/main/resources/game.properties
+++ b/game/src/main/resources/game.properties
@@ -21,6 +21,7 @@ soundDefinitionsPath=./data/definitions/sounds.yml
 midiDefinitionsPath=./data/definitions/midis.yml
 jingleDefinitionsPath=./data/definitions/jingles.yml
 variableDefinitionsPath=./data/definitions/variables.yml
+dropsPath=./data/spawns/drops.yml
 xteaPath=./data/xteas.dat
 revision=634
 loginLimit=5

--- a/tools/src/main/kotlin/world/gregs/voidps/tools/DropTableDefinitions.kt
+++ b/tools/src/main/kotlin/world/gregs/voidps/tools/DropTableDefinitions.kt
@@ -12,7 +12,7 @@ import world.gregs.voidps.engine.entity.definition.ItemDefinitions
 import world.gregs.voidps.engine.entity.item.drop.DropTables
 import world.gregs.voidps.engine.entity.item.drop.ItemDrop
 
-object DropTables {
+object DropTableDefinitions {
     @JvmStatic
     fun main(args: Array<String>) {
         val koin = startKoin {
@@ -26,7 +26,7 @@ object DropTables {
 
         val list = mutableListOf<ItemDrop>()
         repeat(1000000) {
-            table.role(list)
+            table.role(list = list)
         }
         val container = Container.setup(100, stackMode = StackMode.Always)
         list.forEach {

--- a/tools/src/main/kotlin/world/gregs/voidps/tools/DropTables.kt
+++ b/tools/src/main/kotlin/world/gregs/voidps/tools/DropTables.kt
@@ -1,0 +1,44 @@
+package world.gregs.voidps.tools
+
+import org.koin.core.context.startKoin
+import org.koin.dsl.module
+import world.gregs.voidps.cache.definition.decoder.ItemDecoder
+import world.gregs.voidps.engine.client.cacheDefinitionModule
+import world.gregs.voidps.engine.client.cacheModule
+import world.gregs.voidps.engine.data.file.FileLoader
+import world.gregs.voidps.engine.entity.character.contain.Container
+import world.gregs.voidps.engine.entity.character.contain.StackMode
+import world.gregs.voidps.engine.entity.definition.ItemDefinitions
+import world.gregs.voidps.engine.entity.item.drop.DropTables
+import world.gregs.voidps.engine.entity.item.drop.ItemDrop
+
+object DropTables {
+    @JvmStatic
+    fun main(args: Array<String>) {
+        val koin = startKoin {
+            fileProperties("/tool.properties")
+            modules(cacheModule, cacheDefinitionModule, module {
+                single { ItemDefinitions(ItemDecoder(get())).load(FileLoader()) }
+            })
+        }.koin
+        val decoder = DropTables().load(FileLoader())
+        val table = decoder.getValue("goblin_drop_table")
+
+        val list = mutableListOf<ItemDrop>()
+        repeat(1000000) {
+            table.role(list)
+        }
+        val container = Container.setup(100, stackMode = StackMode.Always)
+        list.forEach {
+            val item = it.toItem()
+            if (item.isNotEmpty()) {
+                container.add(item.name, item.amount)
+            }
+        }
+        for (item in container.getItems()) {
+            if (item.isNotEmpty()) {
+                println(item)
+            }
+        }
+    }
+}

--- a/tools/src/main/resources/tool.properties
+++ b/tools/src/main/resources/tool.properties
@@ -17,3 +17,4 @@ itemDefinitionsPath=./data/definitions/items.yml
 animationDefinitionsPath=./data/definitions/animations.yml
 graphicDefinitionsPath=./data/definitions/graphics.yml
 containerDefinitionsPath=./data/definitions/containers.yml
+dropsPath=./data/spawns/drops.yml

--- a/utility/src/main/kotlin/world/gregs/voidps/utility/func/TextFunc.kt
+++ b/utility/src/main/kotlin/world/gregs/voidps/utility/func/TextFunc.kt
@@ -1,6 +1,7 @@
 package world.gregs.voidps.utility.func
 
 import org.jetbrains.kotlin.util.suffixIfNot
+import java.text.DecimalFormat
 
 fun String.plural(count: Int, plural: String = "s") = plural(count.toLong(), plural)
 
@@ -19,6 +20,12 @@ fun Long.toSIPrefix(): String {
         this >= 0x3e8 -> "${this / 0x3e8}K"
         else -> toString()
     }
+}
+
+val dec = DecimalFormat("#,###")
+
+fun Long.toDigitGroupString(): String {
+    return dec.format(this)
 }
 
 fun Int.toSIPrefix() = toLong().toSIPrefix()


### PR DESCRIPTION
* Add chance based nestable drop tables
* Add existing npcs tables on npc death
* Make container setup easier for unit tests #173
* Fix some apron equip definitions
* Add external action suspending
* Add scheduler exception handling
* Add container descended sorting
* Add drop simulating command ::sim <table/npc string id> <kill-count>