### PR TITLE
Delays and other fixes

### DIFF
--- a/data/definitions/animations.yml
+++ b/data/definitions/animations.yml
@@ -738,18 +738,21 @@ emote_trample_snow:
 rest_legs_out:
   id: 2716
   ticks: 4
+  infinite: true
 stand_legs_out:
   id: 2921
   ticks: 2
 rest_arms_back:
   id: 5713
   ticks: 4
+  infinite: true
 stand_arms_back:
   id: 5748
   ticks: 2
 rest_arms_crossed:
   id: 11786
   ticks: 4
+  infinite: true
 stand_arms_crossed:
   id: 11788
   ticks: 2

--- a/data/definitions/items.yml
+++ b/data/definitions/items.yml
@@ -7299,6 +7299,7 @@ bronze_pickaxe:
   slash_def: 1.0
   slot: "Weapon"
   mining_delay: 8
+  aka: [ bronze_pick ]
   examine: "Used for mining."
   kept: "Wilderness"
 bronze_pickaxe_noted: 1266
@@ -7314,6 +7315,7 @@ iron_pickaxe:
   slash_def: 1.0
   slot: "Weapon"
   mining_delay: 7
+  aka: [ iron_pick ]
   examine: "Used for mining."
   kept: "Wilderness"
 iron_pickaxe_noted: 1268
@@ -7329,6 +7331,7 @@ steel_pickaxe:
   slash_def: 2.0
   slot: "Weapon"
   mining_delay: 6
+  aka: [ steel_pick ]
   examine: "Used for mining."
   kept: "Wilderness"
 steel_pickaxe_noted: 1270
@@ -7344,6 +7347,7 @@ adamant_pickaxe:
   slash_def: 1.0
   slot: "Weapon"
   mining_delay: 4
+  aka: [ adamant_pick, addy_pick, addy_pickaxe ]
   examine: "Used for mining."
 adamant_pickaxe_noted: 1272
 mithril_pickaxe:
@@ -7358,6 +7362,7 @@ mithril_pickaxe:
   slash_def: 1.0
   slot: "Weapon"
   mining_delay: 5
+  aka: [ mithril_pick, mith_pick, mith_pickaxe ]
   examine: "Used for mining."
 mithril_pickaxe_noted: 1274
 rune_pickaxe:
@@ -7372,6 +7377,7 @@ rune_pickaxe:
   slash_def: 1.0
   slot: "Weapon"
   mining_delay: 3
+  aka: [ rune_pick ]
   examine: "Used for mining."
 rune_pickaxe_noted: 1276
 bronze_sword:
@@ -73097,6 +73103,7 @@ volatile_clay_pickaxe:
   slot: "Weapon"
   mining_delay: 3
   mining_level: 50
+  aka: [ volatile_pickaxe, volatile_pick ]
   examine: "Your volatile tool wants to mine some rocks."
   weight: 2.0
 volatile_clay_hatchet:
@@ -73155,6 +73162,7 @@ sacred_clay_pickaxe:
   slot: "Weapon"
   mining_delay: 3
   mining_level: 50
+  aka: [ sacred_pickaxe, sacred_pick ]
   examine: "Your sacred clay tool has transformed into a pickaxe."
   weight: 2.0
 sacred_clay_hatchet:
@@ -79031,6 +79039,7 @@ dragon_pickaxe:
   slash_def: 1.0
   slot: "Weapon"
   mining_delay: 3
+  aka: [ dragon_pick ]
   examine: "Used for mining."
 dragon_pickaxe_noted: 15260
 dragon_pickaxe_lent: 15261
@@ -88734,6 +88743,7 @@ novite_pickaxe:
   slash_def: 1.0
   slot: "Weapon"
   mining_delay: 7
+  aka: [ novite_pick ]
   examine: "A pickaxe for mining."
   weight: 2.721
 novite_pickaxe_noted: 16296
@@ -88746,6 +88756,7 @@ bathus_pickaxe:
   slash_def: 1.0
   slot: "Weapon"
   mining_delay: 7
+  aka: [ bathus_pick ]
   examine: "A pickaxe for mining."
   weight: 2.721
 bathus_pickaxe_noted: 16298
@@ -88758,6 +88769,7 @@ marmaros_pickaxe:
   slash_def: 1.0
   slot: "Weapon"
   mining_delay: 6
+  aka: [ marmaros_pick ]
   examine: "A pickaxe for mining."
   weight: 2.721
 marmaros_pickaxe_noted: 16300
@@ -88770,6 +88782,7 @@ kratonite_pickaxe:
   slash_def: 1.0
   slot: "Weapon"
   mining_delay: 6
+  aka: [ kratonite_pick ]
   examine: "A pickaxe for mining."
   weight: 2.721
 kratonite_pickaxe_noted: 16302
@@ -88782,6 +88795,7 @@ fractite_pickaxe:
   slash_def: 1.0
   slot: "Weapon"
   mining_delay: 5
+  aka: [ fractite_pick ]
   examine: "A pickaxe for mining."
   weight: 2.721
 fractite_pickaxe_noted: 16304
@@ -88794,6 +88808,7 @@ zephyrium_pickaxe:
   slash_def: 1.0
   slot: "Weapon"
   mining_delay: 5
+  aka: [ zephyrium_pick, zeph_pickaxe, zeph_pick ]
   examine: "A pickaxe for mining."
   weight: 2.721
 zephyrium_pickaxe_noted: 16306
@@ -88806,6 +88821,7 @@ argonite_pickaxe:
   slash_def: 1.0
   slot: "Weapon"
   mining_delay: 4
+  aka: [ argonite_pick, argon_pick, argon_pickaxe ]
   examine: "A pickaxe for mining."
   weight: 2.721
 argonite_pickaxe_noted: 16308
@@ -88818,6 +88834,7 @@ katagon_pickaxe:
   slash_def: 1.0
   slot: "Weapon"
   mining_delay: 4
+  aka: [ katagon_pick, kata_pick, kata_pickaxe ]
   examine: "A pickaxe for mining."
   weight: 2.721
 katagon_pickaxe_noted: 16310
@@ -88830,6 +88847,7 @@ gorgonite_pickaxe:
   slash_def: 1.0
   slot: "Weapon"
   mining_delay: 3
+  aka: [ gorgonite_pick, gorgon_pick, gorgon_pickaxe ]
   examine: "A pickaxe for mining."
   weight: 2.721
 gorgonite_pickaxe_noted: 16312
@@ -88842,6 +88860,7 @@ promethium_pickaxe:
   slash_def: 1.0
   slot: "Weapon"
   mining_delay: 3
+  aka: [ promethium_pick, prom_pick, prom_pickaxe ]
   examine: "A pickaxe for mining."
   weight: 2.721
 promethium_pickaxe_noted: 16314
@@ -88854,6 +88873,7 @@ primal_pickaxe:
   slash_def: 1.0
   slot: "Weapon"
   mining_delay: 2
+  aka: [ primal_pick ]
   examine: "A pickaxe for mining."
   weight: 2.721
 primal_pickaxe_noted: 16316

--- a/engine/src/main/kotlin/world/gregs/voidps/engine/Modules.kt
+++ b/engine/src/main/kotlin/world/gregs/voidps/engine/Modules.kt
@@ -8,6 +8,7 @@ import world.gregs.voidps.engine.client.ConnectionQueue
 import world.gregs.voidps.engine.client.update.batch.ChunkBatches
 import world.gregs.voidps.engine.data.FileStorage
 import world.gregs.voidps.engine.data.PlayerFactory
+import world.gregs.voidps.engine.data.PlayerSave
 import world.gregs.voidps.engine.entity.character.npc.NPCs
 import world.gregs.voidps.engine.entity.character.player.Players
 import world.gregs.voidps.engine.entity.definition.*
@@ -53,6 +54,7 @@ val gameModule = module {
             getIntProperty("homeX", 0), getIntProperty("homeY", 0), getIntProperty("homePlane", 0)
         ))
     }
+    single { PlayerSave(get()) }
     // IO
     single { FileStorage() }
     single(named("jsonStorage")) { FileStorage(json = true) }

--- a/engine/src/main/kotlin/world/gregs/voidps/engine/action/Action.kt
+++ b/engine/src/main/kotlin/world/gregs/voidps/engine/action/Action.kt
@@ -7,7 +7,6 @@ import world.gregs.voidps.engine.entity.character.setAnimation
 import world.gregs.voidps.engine.event.Events
 import world.gregs.voidps.engine.tick.Scheduler
 import world.gregs.voidps.engine.utility.get
-import world.gregs.voidps.network.Instruction
 import kotlin.coroutines.CoroutineContext
 import kotlin.coroutines.resume
 
@@ -23,10 +22,8 @@ class Action(
 
     var continuation: CancellableContinuation<*>? = null
     var suspension: Suspension? = null
-    var instruction: Instruction? = null
     var wait: Job? = null
     var job: Job? = null
-    var completion: (() -> Unit)? = null
 
     val isActive: Boolean
         get() = continuation?.isActive ?: true
@@ -98,8 +95,6 @@ class Action(
                 if (this@Action.type == type) {
                     this@Action.type = ActionType.None
                 }
-                completion?.invoke()
-                completion = null
                 events.emit(ActionFinished(type))
             }
         }

--- a/engine/src/main/kotlin/world/gregs/voidps/engine/client/ConnectionGatekeeper.kt
+++ b/engine/src/main/kotlin/world/gregs/voidps/engine/client/ConnectionGatekeeper.kt
@@ -27,7 +27,7 @@ class ConnectionGatekeeper(
         return indices.obtain()
     }
 
-    override fun disconnect(name: String, address: String, index: Int?) {
+    override fun disconnect(name: String, address: String) {
         online.remove(name)
         val count = connections(address) - 1
         if (count <= 0) {
@@ -35,8 +35,9 @@ class ConnectionGatekeeper(
         } else {
             logins[address] = count
         }
-        if (index != null) {
-            indices.release(index)
-        }
+    }
+
+    override fun releaseIndex(index: Int) {
+        indices.release(index)
     }
 }

--- a/engine/src/main/kotlin/world/gregs/voidps/engine/client/PlayerAccountLoader.kt
+++ b/engine/src/main/kotlin/world/gregs/voidps/engine/client/PlayerAccountLoader.kt
@@ -6,6 +6,7 @@ import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.withContext
 import org.mindrot.jbcrypt.BCrypt
 import world.gregs.voidps.engine.data.PlayerFactory
+import world.gregs.voidps.engine.data.PlayerSave
 import world.gregs.voidps.engine.entity.character.player.Player
 import world.gregs.voidps.engine.entity.character.player.Players
 import world.gregs.voidps.engine.map.collision.Collisions
@@ -17,6 +18,7 @@ import world.gregs.voidps.network.*
 class PlayerAccountLoader(
     private val queue: NetworkQueue,
     private val factory: PlayerFactory,
+    private val saving: PlayerSave,
     private val gameContext: CoroutineDispatcher,
     private val collisions: Collisions,
     private val players: Players
@@ -28,12 +30,17 @@ class PlayerAccountLoader(
      */
     override suspend fun load(client: Client, username: String, password: String, index: Int, displayMode: Int): MutableSharedFlow<Instruction>? {
         try {
+            val saving = saving.saving(username)
+            if (saving) {
+                client.disconnect(Response.ACCOUNT_ONLINE)
+                return null
+            }
             val player = factory.getOrElse(username, index) { factory.create(username, password) }
             if (validPassword(player, password)) {
                 client.disconnect(Response.INVALID_CREDENTIALS)
                 return null
             }
-            
+
             logger.info { "Player $username loaded and queued for login." }
             withContext(gameContext) {
                 queue.await()

--- a/engine/src/main/kotlin/world/gregs/voidps/engine/client/instruction/handle/NPCOptionHandler.kt
+++ b/engine/src/main/kotlin/world/gregs/voidps/engine/client/instruction/handle/NPCOptionHandler.kt
@@ -42,7 +42,7 @@ class NPCOptionHandler(
             return
         }
         player.walkTo(npc, watch = npc, distance = npc.def["interact_distance", 1], cancelAction = true) { path ->
-            delay(1) {
+            player.delay(1) {
                 player.watch(null)
                 player.face(npc)
             }

--- a/engine/src/main/kotlin/world/gregs/voidps/engine/client/update/batch/ChunkBatches.kt
+++ b/engine/src/main/kotlin/world/gregs/voidps/engine/client/update/batch/ChunkBatches.kt
@@ -6,6 +6,7 @@ import world.gregs.voidps.engine.client.update.view.Viewport
 import world.gregs.voidps.engine.entity.MAX_PLAYERS
 import world.gregs.voidps.engine.entity.character.player.Player
 import world.gregs.voidps.engine.entity.character.player.name
+import world.gregs.voidps.engine.entity.get
 import world.gregs.voidps.engine.map.PooledIdMap
 import world.gregs.voidps.engine.map.Tile
 import world.gregs.voidps.engine.map.area.Cuboid
@@ -64,8 +65,9 @@ class ChunkBatches(
 
     fun run(player: Player) {
         val previous = toChunkCuboid(player.tile.minus(player.movement.delta).chunk, player.viewport!!.localRadius)
+        val loggedIn = player["logged_in", false]
         forEachChunk(player, player.tile) { chunk ->
-            if (previous.contains(chunk.x, chunk.y, chunk.plane)) {
+            if (!loggedIn && previous.contains(chunk.x, chunk.y, chunk.plane)) {
                 encode(player, chunk, batches[chunk] ?: return@forEachChunk)
             } else {
                 sendChunkClear(player, chunk)

--- a/engine/src/main/kotlin/world/gregs/voidps/engine/client/update/player/PlayerResetTask.kt
+++ b/engine/src/main/kotlin/world/gregs/voidps/engine/client/update/player/PlayerResetTask.kt
@@ -5,6 +5,7 @@ import world.gregs.voidps.engine.client.update.batch.ChunkBatches
 import world.gregs.voidps.engine.client.update.iterator.TaskIterator
 import world.gregs.voidps.engine.entity.character.player.Player
 import world.gregs.voidps.engine.entity.character.player.Players
+import world.gregs.voidps.engine.entity.clear
 
 /**
  * Resets non-persistent changes
@@ -25,6 +26,7 @@ class PlayerResetTask(
     override fun run(player: Player) {
         player.movement.reset()
         player.visuals.reset()
+        player.clear("logged_in")
     }
 
 }

--- a/engine/src/main/kotlin/world/gregs/voidps/engine/client/variable/Variables.kt
+++ b/engine/src/main/kotlin/world/gregs/voidps/engine/client/variable/Variables.kt
@@ -7,7 +7,7 @@ import world.gregs.voidps.engine.client.sendVarbit
 import world.gregs.voidps.engine.client.sendVarc
 import world.gregs.voidps.engine.client.sendVarcStr
 import world.gregs.voidps.engine.client.sendVarp
-import world.gregs.voidps.engine.data.MapSerializer
+import world.gregs.voidps.engine.data.serial.MapSerializer
 import world.gregs.voidps.engine.entity.character.player.Player
 import world.gregs.voidps.engine.entity.definition.VariableDefinitions
 import world.gregs.voidps.engine.entity.definition.config.VariableDefinition

--- a/engine/src/main/kotlin/world/gregs/voidps/engine/data/FileStorage.kt
+++ b/engine/src/main/kotlin/world/gregs/voidps/engine/data/FileStorage.kt
@@ -2,14 +2,15 @@ package world.gregs.voidps.engine.data
 
 import com.fasterxml.jackson.core.JsonGenerator
 import com.fasterxml.jackson.databind.ObjectMapper
-import com.fasterxml.jackson.databind.SerializerProvider
 import com.fasterxml.jackson.databind.exc.MismatchedInputException
 import com.fasterxml.jackson.databind.module.SimpleModule
-import com.fasterxml.jackson.databind.ser.std.StdSerializer
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory
 import com.fasterxml.jackson.dataformat.yaml.YAMLGenerator
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.github.michaelbull.logging.InlineLogger
+import world.gregs.voidps.engine.data.serial.DoubleArraySerializer
+import world.gregs.voidps.engine.data.serial.DoubleSerializer
+import world.gregs.voidps.engine.data.serial.TileSerializer
 import world.gregs.voidps.engine.map.Tile
 import java.io.File
 
@@ -66,20 +67,8 @@ class FileStorage private constructor(
         private fun jsonMapper() = jacksonObjectMapper().apply {
             enable(JsonGenerator.Feature.WRITE_BIGDECIMAL_AS_PLAIN)
             val module = SimpleModule()
-            module.addSerializer(DoubleArray::class.java, object : StdSerializer<DoubleArray>(DoubleArray::class.java) {
-                override fun serialize(value: DoubleArray, gen: JsonGenerator, provider: SerializerProvider) {
-                    gen.writeStartArray()
-                    for (double in value) {
-                        gen.writeNumber(double.toBigDecimal())
-                    }
-                    gen.writeEndArray()
-                }
-            })
-            module.addSerializer(Double::class.java, object : StdSerializer<Double>(Double::class.java) {
-                override fun serialize(value: Double, gen: JsonGenerator, provider: SerializerProvider) {
-                    gen.writeNumber(value.toBigDecimal())
-                }
-            })
+            module.addSerializer(DoubleArray::class.java, DoubleArraySerializer)
+            module.addSerializer(Double::class.java, DoubleSerializer)
             module.addSerializer(Tile::class.java, TileSerializer)
             registerModule(module)
         }

--- a/engine/src/main/kotlin/world/gregs/voidps/engine/data/PlayerSave.kt
+++ b/engine/src/main/kotlin/world/gregs/voidps/engine/data/PlayerSave.kt
@@ -1,0 +1,26 @@
+package world.gregs.voidps.engine.data
+
+import world.gregs.voidps.engine.entity.character.player.Player
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+
+class PlayerSave(
+    private val factory: PlayerFactory
+) {
+    private val executor = Executors.newSingleThreadExecutor()
+    private val queued = mutableSetOf<String>()
+
+    fun queue(player: Player) {
+        queued.add(player.accountName)
+        executor.submit {
+            factory.save(player.accountName, player)
+            queued.remove(player.accountName)
+        }
+    }
+
+    fun saving(name: String) = queued.contains(name)
+
+    fun shutdown() {
+        executor.awaitTermination(15, TimeUnit.SECONDS)
+    }
+}

--- a/engine/src/main/kotlin/world/gregs/voidps/engine/data/serial/DoubleArraySerializer.kt
+++ b/engine/src/main/kotlin/world/gregs/voidps/engine/data/serial/DoubleArraySerializer.kt
@@ -1,0 +1,15 @@
+package world.gregs.voidps.engine.data.serial
+
+import com.fasterxml.jackson.core.JsonGenerator
+import com.fasterxml.jackson.databind.SerializerProvider
+import com.fasterxml.jackson.databind.ser.std.StdSerializer
+
+object DoubleArraySerializer : StdSerializer<DoubleArray>(DoubleArray::class.java) {
+    override fun serialize(value: DoubleArray, gen: JsonGenerator, provider: SerializerProvider) {
+        gen.writeStartArray()
+        for (double in value) {
+            gen.writeNumber(DoubleSerializer.toBigDecimal(double))
+        }
+        gen.writeEndArray()
+    }
+}

--- a/engine/src/main/kotlin/world/gregs/voidps/engine/data/serial/DoubleSerializer.kt
+++ b/engine/src/main/kotlin/world/gregs/voidps/engine/data/serial/DoubleSerializer.kt
@@ -1,0 +1,20 @@
+package world.gregs.voidps.engine.data.serial
+
+import com.fasterxml.jackson.core.JsonGenerator
+import com.fasterxml.jackson.databind.SerializerProvider
+import com.fasterxml.jackson.databind.ser.std.StdSerializer
+import java.math.BigDecimal
+
+object DoubleSerializer : StdSerializer<Double>(Double::class.java) {
+    override fun serialize(value: Double, gen: JsonGenerator, provider: SerializerProvider) {
+        gen.writeNumber(toBigDecimal(value))
+    }
+
+    fun toBigDecimal(double: Double): BigDecimal {
+        var bigDecimal = double.toBigDecimal()
+        if (!bigDecimal.toPlainString().contains(".")) {
+            bigDecimal = bigDecimal.setScale(1)
+        }
+        return bigDecimal
+    }
+}

--- a/engine/src/main/kotlin/world/gregs/voidps/engine/data/serial/MapSerializer.kt
+++ b/engine/src/main/kotlin/world/gregs/voidps/engine/data/serial/MapSerializer.kt
@@ -1,4 +1,4 @@
-package world.gregs.voidps.engine.data
+package world.gregs.voidps.engine.data.serial
 
 import com.fasterxml.jackson.core.JsonGenerator
 import com.fasterxml.jackson.databind.SerializerProvider
@@ -9,7 +9,7 @@ object MapSerializer : StdSerializer<Map<String, Any>>(emptyMap<String, Any>()::
         gen.writeStartObject()
         for ((key, value) in map) {
             if (value is Double) {
-                gen.writeNumberField(key, value.toBigDecimal())
+                gen.writeNumberField(key, DoubleSerializer.toBigDecimal(value))
             } else {
                 gen.writePOJOField(key, value)
             }

--- a/engine/src/main/kotlin/world/gregs/voidps/engine/data/serial/TileSerializer.kt
+++ b/engine/src/main/kotlin/world/gregs/voidps/engine/data/serial/TileSerializer.kt
@@ -1,4 +1,4 @@
-package world.gregs.voidps.engine.data
+package world.gregs.voidps.engine.data.serial
 
 import com.fasterxml.jackson.core.JsonGenerator
 import com.fasterxml.jackson.databind.SerializerProvider

--- a/engine/src/main/kotlin/world/gregs/voidps/engine/entity/Values.kt
+++ b/engine/src/main/kotlin/world/gregs/voidps/engine/entity/Values.kt
@@ -3,7 +3,7 @@ package world.gregs.voidps.engine.entity
 import com.fasterxml.jackson.annotation.JsonIgnore
 import com.fasterxml.jackson.databind.annotation.JsonSerialize
 import it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap
-import world.gregs.voidps.engine.data.MapSerializer
+import world.gregs.voidps.engine.data.serial.MapSerializer
 
 /**
  * Map for storing a mix of temporary and general values

--- a/engine/src/main/kotlin/world/gregs/voidps/engine/entity/character/VisualExtensions.kt
+++ b/engine/src/main/kotlin/world/gregs/voidps/engine/entity/character/VisualExtensions.kt
@@ -54,6 +54,7 @@ fun Character.setAnimation(id: String, override: Boolean = false): Int {
     if (run) {
         anim.run = definition.id
     }
+    anim.infinite = definition["infinite", false]
     if (stand || force || walk || run) {
         anim.speed = definition["speed", 0]
         anim.priority = definition.priority

--- a/engine/src/main/kotlin/world/gregs/voidps/engine/entity/character/player/Player.kt
+++ b/engine/src/main/kotlin/world/gregs/voidps/engine/entity/character/player/Player.kt
@@ -160,6 +160,7 @@ class Player(
             }
             events.emit(RegionLogin)
         }
+        set("logged_in", true)
         collisions.add(this)
         players.add(this)
         setup()

--- a/engine/src/main/kotlin/world/gregs/voidps/engine/entity/character/player/Player.kt
+++ b/engine/src/main/kotlin/world/gregs/voidps/engine/entity/character/player/Player.kt
@@ -10,6 +10,7 @@ import kotlinx.coroutines.withContext
 import world.gregs.voidps.engine.action.Action
 import world.gregs.voidps.engine.action.ActionType
 import world.gregs.voidps.engine.action.Contexts
+import world.gregs.voidps.engine.client.ConnectionGatekeeper
 import world.gregs.voidps.engine.client.ui.GameFrame
 import world.gregs.voidps.engine.client.ui.InterfaceOptions
 import world.gregs.voidps.engine.client.ui.Interfaces
@@ -177,9 +178,11 @@ class Player(
                 val collisions: Collisions = get()
                 collisions.remove(this@Player)
                 val players: Players = get()
+                val gatekeeper: ConnectionGatekeeper = get()
                 players.remove(this@Player)
-                delay(1) {
+                World.delay(1) {
                     players.removeIndex(this@Player)
+                    gatekeeper.releaseIndex(index)
                 }
                 events.emit(Unregistered)
                 val save: PlayerSave = get()

--- a/engine/src/main/kotlin/world/gregs/voidps/engine/entity/character/player/Player.kt
+++ b/engine/src/main/kotlin/world/gregs/voidps/engine/entity/character/player/Player.kt
@@ -17,7 +17,7 @@ import world.gregs.voidps.engine.client.ui.dialogue.Dialogues
 import world.gregs.voidps.engine.client.update.view.Viewport
 import world.gregs.voidps.engine.client.variable.Variables
 import world.gregs.voidps.engine.data.PlayerBuilder
-import world.gregs.voidps.engine.data.PlayerFactory
+import world.gregs.voidps.engine.data.PlayerSave
 import world.gregs.voidps.engine.entity.*
 import world.gregs.voidps.engine.entity.character.Character
 import world.gregs.voidps.engine.entity.character.Levels
@@ -182,8 +182,8 @@ class Player(
                     players.removeIndex(this@Player)
                 }
                 events.emit(Unregistered)
-                val factory: PlayerFactory = get()
-                factory.save(accountName, this@Player)
+                val save: PlayerSave = get()
+                save.queue(this@Player)
             }
         }
     }

--- a/engine/src/main/kotlin/world/gregs/voidps/engine/entity/character/player/PlayerRights.kt
+++ b/engine/src/main/kotlin/world/gregs/voidps/engine/entity/character/player/PlayerRights.kt
@@ -2,7 +2,7 @@ package world.gregs.voidps.engine.entity.character.player
 
 import world.gregs.voidps.engine.entity.get
 import world.gregs.voidps.engine.entity.set
-import world.gregs.voidps.engine.utility.capitalise
+import world.gregs.voidps.engine.utility.toSentenceCase
 
 enum class PlayerRights {
     None,
@@ -11,7 +11,7 @@ enum class PlayerRights {
 }
 
 var Player.rights: PlayerRights
-    get() = PlayerRights.valueOf(get("rights", "none").capitalise())
+    get() = PlayerRights.valueOf(get("rights", "none").toSentenceCase())
     set(value) = set("rights", true, value.name.lowercase())
 
 fun Player.isAdmin() = hasRights(PlayerRights.Admin)

--- a/engine/src/main/kotlin/world/gregs/voidps/engine/entity/definition/config/GearDefinition.kt
+++ b/engine/src/main/kotlin/world/gregs/voidps/engine/entity/definition/config/GearDefinition.kt
@@ -2,8 +2,8 @@ package world.gregs.voidps.engine.entity.definition.config
 
 import world.gregs.voidps.cache.definition.Extra
 import world.gregs.voidps.engine.entity.item.Item
-import world.gregs.voidps.engine.utility.capitalise
 import world.gregs.voidps.engine.utility.toIntRange
+import world.gregs.voidps.engine.utility.toSentenceCase
 import world.gregs.voidps.network.visual.update.player.EquipSlot
 
 data class GearDefinition(
@@ -19,7 +19,7 @@ data class GearDefinition(
         operator fun invoke(type: String, map: Map<String, Any>): GearDefinition {
             val range = (map["levels"] as String).toIntRange()
             val equipment = (map["equipment"] as? Map<String, List<Map<String, Any>>>)
-                ?.map { (key, value) -> EquipSlot.valueOf(key.capitalise()) to value.map { Item(it["id"] as String, it["amount"] as? Int ?: 1) } }
+                ?.map { (key, value) -> EquipSlot.valueOf(key.toSentenceCase()) to value.map { Item(it["id"] as String, it["amount"] as? Int ?: 1) } }
                 ?.toMap() ?: emptyMap()
             val inventory = (map["inventory"] as? List<Map<String, Any>>)
                 ?.map { itemList(it) } ?: emptyList()

--- a/engine/src/main/kotlin/world/gregs/voidps/engine/entity/definition/data/Tree.kt
+++ b/engine/src/main/kotlin/world/gregs/voidps/engine/entity/definition/data/Tree.kt
@@ -30,7 +30,7 @@ data class Tree(
             log = (map["log"] as? String)?.let { Item(it, def = itemDefinitions.get(it)) } ?: EMPTY.log,
             level = map["level"] as? Int ?: EMPTY.level,
             xp = map["xp"] as? Double ?: EMPTY.xp,
-            depleteRate = map["chance"] as? Double ?: EMPTY.depleteRate,
+            depleteRate = map["deplete_rate"] as? Double ?: EMPTY.depleteRate,
             chance = (map["chance"] as? String)?.toIntRange() ?: EMPTY.chance,
             hatchetLowDifference = (map["hatchet_low_dif"] as? String)?.toIntRange() ?: EMPTY.hatchetLowDifference,
             hatchetHighDifference = (map["hatchet_high_dif"] as? String)?.toIntRange() ?: EMPTY.hatchetHighDifference,

--- a/engine/src/main/kotlin/world/gregs/voidps/engine/tick/Scheduler.kt
+++ b/engine/src/main/kotlin/world/gregs/voidps/engine/tick/Scheduler.kt
@@ -67,13 +67,6 @@ class Scheduler(
 }
 
 /**
- * Executes a task after [ticks]
- */
-fun delay(ticks: Int = 0, loop: Boolean = false, cancelExecution: Boolean = false, task: Job.(Long) -> Unit): Job {
-    return get<Scheduler>().add(ticks, loop, cancelExecution, task)
-}
-
-/**
  * Executes a task after [ticks], cancelling if player logs out
  */
 fun <T : Entity> T.delay(ticks: Int = 0, loop: Boolean = false, cancelExecution: Boolean = false, task: Job.(Long) -> Unit): Job {

--- a/engine/src/main/kotlin/world/gregs/voidps/engine/utility/TextFunc.kt
+++ b/engine/src/main/kotlin/world/gregs/voidps/engine/utility/TextFunc.kt
@@ -5,7 +5,6 @@ import net.pearx.kasechange.splitter.WordSplitter
 import net.pearx.kasechange.toCase
 import net.pearx.kasechange.universalWordSplitter
 import java.text.DecimalFormat
-import java.util.*
 
 fun String.toIntRange(inclusive: Boolean = false, separator: String = "-"): IntRange {
     val split = split(separator)
@@ -74,9 +73,6 @@ fun Int?.toBoolean() = this == 1
 fun Int.nearby(size: Int): IntRange {
     return this - size..this + size
 }
-
-@Deprecated("Use toSentenceCase", replaceWith = ReplaceWith("toSentenceCase()"))
-fun String.capitalise(locale: Locale = Locale.getDefault()): String = replaceFirstChar { if (it.isLowerCase()) it.titlecase(locale) else it.toString() }
 
 private val capitaliseFormat = CaseFormatterConfig(false, " ", wordCapitalize = false, firstWordCapitalize = true)
 

--- a/engine/src/test/kotlin/world/gregs/voidps/engine/client/ConnectionGatekeeperTest.kt
+++ b/engine/src/test/kotlin/world/gregs/voidps/engine/client/ConnectionGatekeeperTest.kt
@@ -49,8 +49,8 @@ internal class ConnectionGatekeeperTest : KoinMock() {
 
     @Test
     fun `Logout player not online`() {
-        val index = gatekeeper.connect("test", "123")
-        gatekeeper.disconnect("test", "123", index)
+        gatekeeper.connect("test", "123")
+        gatekeeper.disconnect("test", "123")
         assertEquals(0, gatekeeper.connections("123"))
         assertFalse(gatekeeper.connected("test"))
     }

--- a/game/src/main/kotlin/world/gregs/voidps/Main.kt
+++ b/game/src/main/kotlin/world/gregs/voidps/Main.kt
@@ -23,6 +23,7 @@ import world.gregs.voidps.engine.client.PlayerAccountLoader
 import world.gregs.voidps.engine.client.instruction.InterfaceHandler
 import world.gregs.voidps.engine.client.update.iterator.ParallelIterator
 import world.gregs.voidps.engine.data.PlayerFactory
+import world.gregs.voidps.engine.data.PlayerSave
 import world.gregs.voidps.engine.entity.World
 import world.gregs.voidps.engine.entity.character.npc.NPCs
 import world.gregs.voidps.engine.entity.character.player.Players
@@ -71,10 +72,11 @@ object Main {
         val huffman: Huffman = get()
         val players: Players = get()
         val factory: PlayerFactory = get()
+        val save: PlayerSave = get()
         val queue: ConnectionQueue = get()
         val gatekeeper: ConnectionGatekeeper = get()
 
-        val accountLoader = PlayerAccountLoader(queue, factory, Contexts.Game, collisions, players)
+        val accountLoader = PlayerAccountLoader(queue, factory, save, Contexts.Game, collisions, players)
         val protocol = protocol(huffman)
         val server = Network(revision, modulus, private, gatekeeper, accountLoader, limit, Contexts.Game, protocol)
 

--- a/game/src/main/kotlin/world/gregs/voidps/world/activity/skill/Stats.kts
+++ b/game/src/main/kotlin/world/gregs/voidps/world/activity/skill/Stats.kts
@@ -14,8 +14,8 @@ import world.gregs.voidps.engine.entity.definition.getComponentIntId
 import world.gregs.voidps.engine.entity.get
 import world.gregs.voidps.engine.entity.set
 import world.gregs.voidps.engine.event.on
-import world.gregs.voidps.engine.utility.capitalise
 import world.gregs.voidps.engine.utility.inject
+import world.gregs.voidps.engine.utility.toSentenceCase
 
 val definitions: InterfaceDefinitions by inject()
 
@@ -30,7 +30,7 @@ on<InterfaceOpened>({ id == "stats" }) { player: Player ->
 }
 
 on<InterfaceOption>({ id == "stats" && option == "View" }) { player: Player ->
-    val skill = valueOf(component.capitalise())
+    val skill = valueOf(component.toSentenceCase())
     val menuIndex = menu.indexOf(skill) + 1
 
     if (player.hasVar("skill_stat_flash", skill.name)) {

--- a/game/src/main/kotlin/world/gregs/voidps/world/activity/skill/cooking/Cooking.kts
+++ b/game/src/main/kotlin/world/gregs/voidps/world/activity/skill/cooking/Cooking.kts
@@ -50,7 +50,7 @@ on<InterfaceOnObject>({ obj.heatSource && item.def.has("cooking") }) { player: P
         try {
             var tick = 0
             while (isActive && tick < amount && player.awaitDialogues()) {
-                if (objects.get(obj.tile, obj.id) == null) {
+                if (objects[obj.tile, obj.id] == null) {
                     break
                 }
 

--- a/game/src/main/kotlin/world/gregs/voidps/world/activity/skill/cooking/Cooking.kts
+++ b/game/src/main/kotlin/world/gregs/voidps/world/activity/skill/cooking/Cooking.kts
@@ -22,8 +22,8 @@ import world.gregs.voidps.engine.entity.obj.GameObject
 import world.gregs.voidps.engine.entity.obj.Objects
 import world.gregs.voidps.engine.entity.set
 import world.gregs.voidps.engine.event.on
-import world.gregs.voidps.engine.utility.capitalise
 import world.gregs.voidps.engine.utility.inject
+import world.gregs.voidps.engine.utility.toSentenceCase
 import world.gregs.voidps.network.visual.update.player.EquipSlot
 import world.gregs.voidps.world.interact.dialogue.type.makeAmount
 
@@ -38,7 +38,7 @@ on<InterfaceOnObject>({ obj.heatSource && item.def.has("cooking") }) { player: P
         val cooking: Uncooked = definition.getOrNull("cooking") ?: return@action
         val (_, amount) = player.makeAmount(
             listOf(item.id),
-            type = cooking.type.capitalise(),
+            type = cooking.type.toSentenceCase(),
             maximum = player.inventory.getCount(item.id).toInt(),
             text = "How many would you like to ${cooking.type}?"
         )

--- a/game/src/main/kotlin/world/gregs/voidps/world/activity/skill/mining/Mining.kts
+++ b/game/src/main/kotlin/world/gregs/voidps/world/activity/skill/mining/Mining.kts
@@ -24,14 +24,14 @@ import world.gregs.voidps.engine.entity.hasEffect
 import world.gregs.voidps.engine.entity.item.Item
 import world.gregs.voidps.engine.entity.item.equipped
 import world.gregs.voidps.engine.entity.item.requiredEquipLevel
-import world.gregs.voidps.engine.entity.obj.GameObject
-import world.gregs.voidps.engine.entity.obj.ObjectClick
-import world.gregs.voidps.engine.entity.obj.ObjectOption
-import world.gregs.voidps.engine.entity.obj.replace
+import world.gregs.voidps.engine.entity.obj.*
 import world.gregs.voidps.engine.entity.start
 import world.gregs.voidps.engine.event.on
+import world.gregs.voidps.engine.utility.inject
 import world.gregs.voidps.network.visual.update.player.EquipSlot
 import kotlin.random.Random
+
+val objects: Objects by inject()
 
 on<ObjectClick>({ option == "Mine" }) { player: Player ->
     cancelled = player.hasEffect("skilling_delay")
@@ -46,6 +46,10 @@ on<ObjectOption>({ option == "Mine" }) { player: Player ->
         try {
             var first = true
             mining@ while (isActive && player.awaitDialogues()) {
+                if (objects[obj.tile, obj.id] == null) {
+                    break
+                }
+
                 if (player.inventory.isFull()) {
                     player.message("Your inventory is too full to hold any more ore.")
                     break

--- a/game/src/main/kotlin/world/gregs/voidps/world/activity/skill/mining/Mining.kts
+++ b/game/src/main/kotlin/world/gregs/voidps/world/activity/skill/mining/Mining.kts
@@ -7,6 +7,7 @@ import world.gregs.voidps.engine.action.ActionType
 import world.gregs.voidps.engine.action.action
 import world.gregs.voidps.engine.client.message
 import world.gregs.voidps.engine.client.ui.awaitDialogues
+import world.gregs.voidps.engine.entity.World
 import world.gregs.voidps.engine.entity.character.clearAnimation
 import world.gregs.voidps.engine.entity.character.contain.hasItem
 import world.gregs.voidps.engine.entity.character.contain.inventory
@@ -24,6 +25,7 @@ import world.gregs.voidps.engine.entity.hasEffect
 import world.gregs.voidps.engine.entity.item.Item
 import world.gregs.voidps.engine.entity.item.equipped
 import world.gregs.voidps.engine.entity.item.requiredEquipLevel
+import world.gregs.voidps.engine.entity.members
 import world.gregs.voidps.engine.entity.obj.*
 import world.gregs.voidps.engine.entity.start
 import world.gregs.voidps.engine.event.on
@@ -81,7 +83,12 @@ on<ObjectOption>({ option == "Mine" }) { player: Player ->
                         continue
                     }
                 }
-                for (item in rock.ores) {
+                var ores = rock.ores
+                if (obj.id == "rune_essence_rocks") {
+                    val name = if (World.members && player.has(Skill.Mining, 30)) "pure_essence" else "rune_essence"
+                    ores = rock.ores.filter { it.id == name }
+                }
+                for (item in ores) {
                     val ore = item.def["mining", Ore.EMPTY]
                     if (success(player.levels.get(Skill.Mining), ore.chance)) {
                         player.experience.add(Skill.Mining, ore.xp)

--- a/game/src/main/kotlin/world/gregs/voidps/world/activity/skill/woodcutting/Woodcutting.kts
+++ b/game/src/main/kotlin/world/gregs/voidps/world/activity/skill/woodcutting/Woodcutting.kts
@@ -20,10 +20,7 @@ import world.gregs.voidps.engine.entity.definition.data.Tree
 import world.gregs.voidps.engine.entity.hasEffect
 import world.gregs.voidps.engine.entity.item.Item
 import world.gregs.voidps.engine.entity.item.requiredUseLevel
-import world.gregs.voidps.engine.entity.obj.GameObject
-import world.gregs.voidps.engine.entity.obj.ObjectClick
-import world.gregs.voidps.engine.entity.obj.ObjectOption
-import world.gregs.voidps.engine.entity.obj.replace
+import world.gregs.voidps.engine.entity.obj.*
 import world.gregs.voidps.engine.entity.start
 import world.gregs.voidps.engine.event.on
 import world.gregs.voidps.engine.utility.Maths
@@ -33,6 +30,7 @@ import kotlin.random.Random
 
 val players: Players by inject()
 val definitions: ObjectDefinitions by inject()
+val objects: Objects by inject()
 
 val minPlayers = 0
 val maxPlayers = 2000
@@ -46,6 +44,10 @@ on<ObjectOption>({ def.has("woodcutting") && (option == "Chop down" || option ==
         try {
             var first = true
             while (isActive && player.awaitDialogues()) {
+                if (objects[obj.tile, obj.id] == null) {
+                    break
+                }
+
                 val tree: Tree? = def.getOrNull("woodcutting")
                 if (tree == null || !player.has(Skill.Woodcutting, tree.level, true)) {
                     break

--- a/game/src/main/kotlin/world/gregs/voidps/world/command/admin/AdminCommands.kts
+++ b/game/src/main/kotlin/world/gregs/voidps/world/command/admin/AdminCommands.kts
@@ -10,7 +10,7 @@ import world.gregs.voidps.engine.client.ui.event.Command
 import world.gregs.voidps.engine.client.variable.clearVar
 import world.gregs.voidps.engine.client.variable.removeVar
 import world.gregs.voidps.engine.client.variable.setVar
-import world.gregs.voidps.engine.data.PlayerFactory
+import world.gregs.voidps.engine.data.PlayerSave
 import world.gregs.voidps.engine.entity.*
 import world.gregs.voidps.engine.entity.character.contain.Container
 import world.gregs.voidps.engine.entity.character.contain.StackMode
@@ -116,12 +116,10 @@ on<Command>({ prefix == "npc" }) { player: Player ->
     npc?.start("frozen")
 }
 
-val playerFactory: PlayerFactory by inject()
+val playerSave: PlayerSave by inject()
 
 on<Command>({ prefix == "save" }) { _: Player ->
-    players.forEach {
-        playerFactory.save(it.accountName, it)
-    }
+    players.forEach(playerSave::queue)
 }
 
 val definitions: ItemDefinitions by inject()

--- a/game/src/main/kotlin/world/gregs/voidps/world/command/admin/AdminCommands.kts
+++ b/game/src/main/kotlin/world/gregs/voidps/world/command/admin/AdminCommands.kts
@@ -198,7 +198,7 @@ on<Command>({ prefix == "master" }) { player: Player ->
 
 on<Command>({ prefix == "setlevel" }) { player: Player ->
     val split = content.split(" ")
-    val skill = Skill.valueOf(split[0].capitalise())
+    val skill = Skill.valueOf(split[0].toSentenceCase())
     val level = split[1].toInt()
     val target = if (split.size > 2) {
         val name = content.removeSuffix("${split[0]} ${split[1]} ")

--- a/game/src/main/kotlin/world/gregs/voidps/world/community/assist/AssistDisplay.kts
+++ b/game/src/main/kotlin/world/gregs/voidps/world/community/assist/AssistDisplay.kts
@@ -7,7 +7,7 @@ import world.gregs.voidps.engine.entity.character.player.Player
 import world.gregs.voidps.engine.entity.character.player.skill.Skill
 import world.gregs.voidps.engine.entity.getOrNull
 import world.gregs.voidps.engine.event.on
-import world.gregs.voidps.engine.utility.capitalise
+import world.gregs.voidps.engine.utility.toSentenceCase
 import world.gregs.voidps.world.community.assist.Assistance.canAssist
 import world.gregs.voidps.world.community.assist.Assistance.redirectSkillExperience
 import world.gregs.voidps.world.community.assist.Assistance.stopRedirectingSkillExp
@@ -17,7 +17,7 @@ import world.gregs.voidps.world.community.assist.Assistance.stopRedirectingSkill
  */
 
 on<InterfaceOption>({ id == "assist_xp" && option == "Toggle Skill On / Off" }) { player: Player ->
-    val skill = Skill.valueOf(component.capitalise())
+    val skill = Skill.valueOf(component.toSentenceCase())
     val assisted: Player? = player.getOrNull("assisted")
     if (assisted == null) {
         player.action.cancel(ActionType.Assisting)

--- a/game/src/main/kotlin/world/gregs/voidps/world/interact/entity/combat/Combat.kt
+++ b/game/src/main/kotlin/world/gregs/voidps/world/interact/entity/combat/Combat.kt
@@ -223,7 +223,7 @@ fun hit(source: Character, target: Character?, type: String, weapon: Item?, spel
 
 fun removeAmmo(player: Player, target: Character, ammo: String, required: Int) {
     if (ammo == "bolt_rack") {
-        delay {
+        player.delay {
             player.equipment.remove(ammo, required)
         }
         return
@@ -241,7 +241,7 @@ private fun exceptions(ammo: String) = ammo == "silver_bolts" || ammo == "bone_b
 private fun remove(player: Player, target: Character, ammo: String, required: Int, recoverChance: Double, dropChance: Double) {
     val random = Random.nextDouble()
     if (random > recoverChance) {
-        delay {
+        player.delay {
             player.equipment.remove(ammo, required)
             if (!player.equipment.contains(ammo)) {
                 player.message("That was your last one!")

--- a/game/src/main/kotlin/world/gregs/voidps/world/interact/entity/item/FloorItemRespawn.kts
+++ b/game/src/main/kotlin/world/gregs/voidps/world/interact/entity/item/FloorItemRespawn.kts
@@ -1,9 +1,7 @@
+import world.gregs.voidps.engine.entity.*
 import world.gregs.voidps.engine.entity.Unregistered
-import world.gregs.voidps.engine.entity.contains
-import world.gregs.voidps.engine.entity.get
 import world.gregs.voidps.engine.entity.item.floor.FloorItem
 import world.gregs.voidps.engine.entity.item.floor.FloorItems
-import world.gregs.voidps.engine.entity.set
 import world.gregs.voidps.engine.event.on
 import world.gregs.voidps.engine.map.spawn.ItemSpawn
 import world.gregs.voidps.engine.tick.delay
@@ -13,7 +11,7 @@ val items: FloorItems by inject()
 
 on<Unregistered>({ it.contains("respawn") }) { floorItem: FloorItem ->
     val spawn: ItemSpawn = floorItem["respawn"]
-    floorItem.delay(spawn.delay) {
+    World.delay(spawn.delay) {
         val item = items.add(spawn.id, spawn.amount, spawn.tile, revealTicks = 0)
         item["respawn"] = spawn
     }

--- a/game/src/main/kotlin/world/gregs/voidps/world/interact/entity/item/FloorItemRespawn.kts
+++ b/game/src/main/kotlin/world/gregs/voidps/world/interact/entity/item/FloorItemRespawn.kts
@@ -13,7 +13,7 @@ val items: FloorItems by inject()
 
 on<Unregistered>({ it.contains("respawn") }) { floorItem: FloorItem ->
     val spawn: ItemSpawn = floorItem["respawn"]
-    delay(spawn.delay) {
+    floorItem.delay(spawn.delay) {
         val item = items.add(spawn.id, spawn.amount, spawn.tile, revealTicks = 0)
         item["respawn"] = spawn
     }

--- a/game/src/main/kotlin/world/gregs/voidps/world/interact/entity/npc/shop/Restock.kts
+++ b/game/src/main/kotlin/world/gregs/voidps/world/interact/entity/npc/shop/Restock.kts
@@ -49,8 +49,8 @@ on<Unregistered> { player: Player ->
     }
 }
 
-on<World, Registered> {
-    delay(restockTimeTicks, loop = true) {
+on<World, Registered> { world ->
+    world.delay(restockTimeTicks, loop = true) {
         for ((key, container) in GeneralStores.stores) {
             val def = containerDefs.get(key)
             restock(def, container)

--- a/game/src/main/kotlin/world/gregs/voidps/world/interact/entity/player/Poison.kts
+++ b/game/src/main/kotlin/world/gregs/voidps/world/interact/entity/player/Poison.kts
@@ -22,7 +22,7 @@ on<EffectStart>({ effect == "poison" }) { character: Character ->
         if (character is Player) {
             character.message(Colour.Green { "You have been poisoned." })
         }
-        delay(0) {
+        character.delay(0) {
             damage(character)
         }
     }

--- a/game/src/main/kotlin/world/gregs/voidps/world/interact/world/map/Introduction.kts
+++ b/game/src/main/kotlin/world/gregs/voidps/world/interact/world/map/Introduction.kts
@@ -51,7 +51,7 @@ fun setup(player: Player) {
     player.inventory.add("tinderbox")
     player.inventory.add("small_fishing_net")
     player.inventory.add("shrimp")
-    player.inventory.add("empty_bucket")
+    player.inventory.add("bucket")
     player.inventory.add("empty_pot")
     player.inventory.add("bread")
     player.inventory.add("bronze_pickaxe")

--- a/game/src/main/kotlin/world/gregs/voidps/world/map/falador/MakeoverMage.kts
+++ b/game/src/main/kotlin/world/gregs/voidps/world/map/falador/MakeoverMage.kts
@@ -310,7 +310,7 @@ on<Registered>({ it.id.startsWith("make_over_mage") }) { npc: NPC ->
         npc.transform(if (toFemale) "make_over_mage_female" else "make_over_mage_male")
         npc.setGraphic("curse_hit", delay = 15)
         npc.setAnimation("bind_staff")
-        delay(ticks = 1) {
+        npc.delay(ticks = 1) {
             npc.forceChat = if (toFemale) "Ooh!" else "Aha!"
         }
     }

--- a/network/src/main/kotlin/world/gregs/voidps/network/Network.kt
+++ b/network/src/main/kotlin/world/gregs/voidps/network/Network.kt
@@ -156,7 +156,7 @@ class Network(
     suspend fun login(read: ByteReadChannel, client: Client, username: String, password: String, displayMode: Int) {
         val index = gatekeeper.connect(username, client.address)
         client.on(disconnectContext, ClientState.Disconnected) {
-            gatekeeper.disconnect(username, client.address, index)
+            gatekeeper.disconnect(username, client.address)
         }
         if (index == null) {
             client.disconnect(Response.WORLD_FULL)

--- a/network/src/main/kotlin/world/gregs/voidps/network/NetworkGatekeeper.kt
+++ b/network/src/main/kotlin/world/gregs/voidps/network/NetworkGatekeeper.kt
@@ -7,5 +7,6 @@ interface NetworkGatekeeper {
     fun connected(name: String): Boolean
     fun connections(address: String): Int
     fun connect(name: String, address: String? = null): Int?
-    fun disconnect(name: String, address: String, index: Int?)
+    fun disconnect(name: String, address: String)
+    fun releaseIndex(index: Int)
 }

--- a/network/src/main/kotlin/world/gregs/voidps/network/visual/encode/player/PlayerAnimationEncoder.kt
+++ b/network/src/main/kotlin/world/gregs/voidps/network/visual/encode/player/PlayerAnimationEncoder.kt
@@ -5,7 +5,7 @@ import world.gregs.voidps.network.visual.PlayerVisuals
 import world.gregs.voidps.network.visual.VisualEncoder
 import world.gregs.voidps.network.visual.VisualMask.PLAYER_ANIMATION_MASK
 
-class PlayerAnimationEncoder : VisualEncoder<PlayerVisuals>(PLAYER_ANIMATION_MASK) {
+class PlayerAnimationEncoder : VisualEncoder<PlayerVisuals>(PLAYER_ANIMATION_MASK, initial = true) {
 
     override fun encode(writer: Writer, visuals: PlayerVisuals) {
         val (first, second, third, fourth, speed) = visuals.animation

--- a/network/src/main/kotlin/world/gregs/voidps/network/visual/update/Animation.kt
+++ b/network/src/main/kotlin/world/gregs/voidps/network/visual/update/Animation.kt
@@ -15,9 +15,13 @@ data class Animation(
     var run: Int = -1,
     var speed: Int = 0
 ) : Visual {
+    var infinite: Boolean = false
     var priority: Int = -1
 
     override fun needsReset(): Boolean {
+        if (infinite) {
+            return false
+        }
         return stand != -1 || force != -1 || walk != -1 || run != -1
     }
 
@@ -28,5 +32,6 @@ data class Animation(
         run = -1
         speed = 0
         priority = -1
+        infinite = false
     }
 }

--- a/tools/build.gradle.kts
+++ b/tools/build.gradle.kts
@@ -11,6 +11,7 @@ dependencies {
     implementation("org.sweble.wikitext:swc-engine:2.0.0")
     implementation("com.github.weisj:darklaf-core:2.7.3")
     implementation("javax.xml.bind:jaxb-api:2.3.1")
+    implementation("net.pearx.kasechange:kasechange:${findProperty("kaseChangeVersion")}")
 
     implementation("io.insert-koin:koin-core:${findProperty("koinVersion")}")
     implementation("com.displee:rs-cache-library:${findProperty("displeeCacheVersion")}")

--- a/tools/src/main/kotlin/world/gregs/voidps/tools/definition/item/pipe/extra/wiki/InfoBoxItem.kt
+++ b/tools/src/main/kotlin/world/gregs/voidps/tools/definition/item/pipe/extra/wiki/InfoBoxItem.kt
@@ -4,7 +4,7 @@ import world.gregs.voidps.engine.entity.definition.DefinitionsDecoder.Companion.
 import world.gregs.voidps.engine.entity.definition.DefinitionsDecoder.Companion.toIdentifier
 import world.gregs.voidps.engine.entity.item.ItemKept
 import world.gregs.voidps.engine.entity.item.ItemUse
-import world.gregs.voidps.engine.utility.capitalise
+import world.gregs.voidps.engine.utility.toSentenceCase
 import world.gregs.voidps.tools.Pipeline
 import world.gregs.voidps.tools.definition.item.Extras
 import world.gregs.voidps.tools.definition.item.pipe.page.PageCollector
@@ -83,7 +83,7 @@ class InfoBoxItem(val revision: LocalDate) : Pipeline.Modifier<Extras> {
                                 ItemUse.Surface
                             }
                         } else {
-                            ItemUse.valueOf(text.lowercase().capitalise())
+                            ItemUse.valueOf(text.lowercase().toSentenceCase())
                         }
                         extras.putIfAbsent("use", use)
                     }

--- a/tools/src/main/kotlin/world/gregs/voidps/tools/definition/npc/pipe/wiki/InfoBoxNPC.kt
+++ b/tools/src/main/kotlin/world/gregs/voidps/tools/definition/npc/pipe/wiki/InfoBoxNPC.kt
@@ -2,7 +2,7 @@ package world.gregs.voidps.tools.definition.npc.pipe.wiki
 
 import world.gregs.voidps.engine.entity.definition.DefinitionsDecoder.Companion.toIdentifier
 import world.gregs.voidps.engine.entity.item.ItemUse
-import world.gregs.voidps.engine.utility.capitalise
+import world.gregs.voidps.engine.utility.toSentenceCase
 import world.gregs.voidps.tools.Pipeline
 import world.gregs.voidps.tools.definition.item.Extras
 import world.gregs.voidps.tools.definition.item.pipe.extra.wiki.InfoBoxItem
@@ -46,7 +46,7 @@ class InfoBoxNPC(val revision: LocalDate, private val infoboxes: List<String>) :
                                 ItemUse.Surface
                             }
                         } else if (text.isNotBlank()) {
-                            ItemUse.valueOf(text.lowercase().capitalise())
+                            ItemUse.valueOf(text.lowercase().toSentenceCase())
                         } else {
                             null
                         }


### PR DESCRIPTION
* Fix wrong starting bucket
* Remove generic unlinked delay
* Fix initial chunk batches on login
* Don't reset infinite animations fixes #250
* Add player saving queue to remove delays from game thread
* Prevent logging in an account on the same tick as logging out
* Fix tree deplete rates typo #277
* Check fires, tree and rocks exist before acting on them with skills
* Update deprecated captialise() with toSentenceCase()
* Remove unused bits in Action.kt
* Fix double serialization (player saves)
* Add alternative pickaxe names
* Fix rune essence mining closes #277