### PR TITLE
Add light source crafting, lighting, extinguishing plus Giant Mole addition

### DIFF
--- a/data/definitions/item-on-item.yml
+++ b/data/definitions/item-on-item.yml
@@ -6207,6 +6207,95 @@ rune_crossbow_finished:
     - item: rune_crossbow
   message: "You add a string to the stock."
   animation: fletching_string_rune_crossbow
+# light source making
+white_lantern_make:
+  skill: firemaking
+  level: 1
+  xp: 0.0
+  ticks: 1
+  remove:
+    - item: white_candle
+    - item: candle_lantern_empty
+  add:
+    - item: candle_lantern_white
+  message: "You add the candle to the empty lantern frame."
+black_lantern_make:
+  skill: firemaking
+  level: 1
+  xp: 0.0
+  ticks: 1
+  remove:
+    - item: black_candle
+    - item: candle_lantern_empty
+  add:
+    - item: candle_lantern_black
+  message: "You add the candle to the empty lantern frame."
+default_bullseye_lantern_make:
+  skill: crafting
+  level: 49
+  xp: 0.0
+  ticks: 1
+  remove:
+    - item: bullseye_lantern_frame
+    - item: lantern_lens
+  add:
+    - item: bullseye_lantern_empty
+  message: "You add the lens to the bullseye lantern frame."
+emerald_bullseye_lantern_make:
+  skill: crafting
+  level: 1
+  xp: 0.0
+  ticks: 1
+  remove:
+    - item: bullseye_lantern_frame
+    - item: emerald_lens
+  add:
+    - item: emerald_lantern
+  message: "You add the lens to the bullseye lantern frame."
+sapphire_bullseye_lantern_make:
+  skill: crafting
+  level: 1
+  xp: 0.0
+  ticks: 1
+  remove:
+    - item: bullseye_lantern_frame
+    - item: sapphire_lens
+  add:
+    - item: sapphire_lantern
+  message: "You add the lens to the bullseye lantern frame."
+default_bullseye_lantern_oiled_make:
+  skill: crafting
+  level: 1
+  xp: 0.0
+  ticks: 2
+  remove:
+    - item: swamp_tar
+    - item: bullseye_lantern_empty
+  add:
+    - item: bullseye_lantern_oil
+  message: "You add the swamp tar to the empty lantern."
+oil_lamp_fill:
+  skill: firemaking
+  level: 12
+  xp: 0.0
+  ticks: 2
+  remove:
+    - item: swamp_tar
+    - item: oil_lamp_empty
+  add:
+    - item: oil_lamp_oil
+  message: "You add the swamp tar to the empty lantern."
+oil_lantern_fill:
+  skill: firemaking
+  level: 26
+  xp: 0.0
+  ticks: 2
+  remove:
+    - item: swamp_tar
+    - item: oil_lantern_empty
+  add:
+    - item: oil_lantern_oil
+  message: "You add the swamp tar to the empty lantern."
 # Vegetable Sacks
 potatoes_1:
   remove:

--- a/data/definitions/items.yml
+++ b/data/definitions/items.yml
@@ -185,12 +185,16 @@ black_candle_lit:
   id: 32
   tradeable: false
   weight: 0.028
+  light_source:
+    once_extinguish: "black_candle"
   examine: "A lit spooky candle."
   kept: "Reclaim"
 white_candle_lit:
   id: 33
   tradeable: false
   weight: 0.028
+  light_source:
+    once_extinguish: "white_candle"
   examine: "A lit candle."
   kept: "Reclaim"
 lit_candle:
@@ -211,12 +215,19 @@ white_candle:
   price: 270
   limit: 100
   weight: 0.028
+  light_source:
+    once_lit: "white_candle_lit"
+    level: 1
+    level: 1
   examine: "A candle."
 candle_noted: 37
 black_candle:
   id: 38
   tradeable: false
   weight: 0.028
+  light_source:
+    once_lit: "black_candle_lit"
+    level: 1
   examine: "A spooky candle."
   kept: "Reclaim"
 bronze_arrowtips:
@@ -3014,6 +3025,8 @@ lit_torch:
   id: 594
   tradeable: false
   weight: 0.5
+  light_source:
+    once_extinguish: "unlit_torch"
   examine: "A lit home-made torch."
   kept: "Wilderness"
 torch: 595
@@ -3022,6 +3035,9 @@ unlit_torch:
   price: 1
   limit: 100
   weight: 0.5
+  light_source:
+    once_lit: "lit_torch"
+    level: 1
   examine: "An unlit home-made torch."
 unlit_torch_noted: 597
 bronze_fire_arrows_unlit:
@@ -20368,6 +20384,9 @@ oil_lamp_oil:
   price: 1241
   limit: 100
   weight: 0.453
+  light_source:
+    once_lit: "oil_lamp"
+    level: 12
   examine: "Not the genie sort."
   kept: "Wilderness"
 oil_lamp_noted: 4523
@@ -20375,6 +20394,8 @@ oil_lamp:
   id: 4524
   tradeable: false
   weight: 0.453
+  light_source:
+    once_extinguish: "oil_lamp_oil"
   examine: "Not the genie sort."
   kept: "Wilderness"
 oil_lamp_empty:
@@ -20398,6 +20419,9 @@ candle_lantern_white:
   price: 621
   limit: 100
   weight: 0.907
+  light_source:
+    once_lit: "candle_lantern_lit_white"
+    level: 4
   examine: "A candle in a glass cage."
   kept: "Wilderness"
 candle_lantern_noted_2: 4530
@@ -20406,17 +20430,24 @@ candle_lantern_lit_white:
   id: 4531
   tradeable: false
   weight: 0.907
+  light_source:
+    once_extinguish: "candle_lantern_white"
   examine: "A flickering candle in a glass cage."
   kept: "Wilderness"
 candle_lantern_black:
   id: 4532
   weight: 0.907
+  light_source:
+    once_lit: "candle_lantern_lit_black"
+    level: 4
   examine: "A candle in a glass cage."
   kept: "Wilderness"
 candle_lantern_noted_3: 4533
 candle_lantern_lit_black:
   <<: *candle_lantern_lit_white
   id: 4534
+  light_source:
+    once_extinguish: "candle_lantern_black"
 oil_lantern_empty:
   id: 4535
   price: 18
@@ -20430,6 +20461,9 @@ oil_lantern_oil:
   price: 549
   limit: 100
   weight: 0.907
+  light_source:
+    once_lit: "oil_lantern"
+    level: 26
   examine: "An unlit oil lantern."
   kept: "Wilderness"
 oil_lantern_noted_2: 4538
@@ -20437,6 +20471,8 @@ oil_lantern:
   id: 4539
   tradeable: false
   weight: 0.907
+  light_source:
+    once_extinguish: "oil_lantern_oil"
   examine: "It lights your way through the dark places of the earth."
   kept: "Wilderness"
 oil_lantern_frame:
@@ -20476,6 +20512,9 @@ bullseye_lantern_oil:
   price: 1568
   limit: 100
   weight: 1.36
+  light_source:
+    once_lit: "bullseye_lantern_lit"
+    level: 49
   examine: "A sturdy steel lantern."
   kept: "Wilderness"
 bullseye_lantern_noted_3: 4549
@@ -20483,6 +20522,8 @@ bullseye_lantern_lit:
   id: 4550
   tradeable: false
   weight: 1.36
+  light_source:
+    once_extinguish: "bullseye_lantern_oil"
   examine: "A sturdy steel lantern casting a bright beam."
   kept: "Wilderness"
 spiny_helmet:
@@ -21239,12 +21280,17 @@ sapphire_lantern_oil:
   id: 4701
   tradeable: false
   weight: 1.36
+  light_source:
+    once_lit: "sapphire_lantern_lit"
+    level: 49
   examine: "A bullseye lantern with a sapphire for a lens."
   kept: "Reclaim"
 sapphire_lantern_lit:
   id: 4702
   tradeable: false
   weight: 1.36
+  light_source:
+    once_extinguish: "sapphire_lantern_oil"
   examine: "A lantern casting a bright blue beam."
   kept: "Reclaim"
 magic_stone_tears_of_guthix:
@@ -22763,6 +22809,8 @@ mining_helmet_lit:
   weight: 0.907
   slot: "Hat"
   type: "Hair"
+  light_source:
+    once_extinguish: "mining_helmet"
   examine: "A helmet with a lamp on it."
   kept: "Reclaim"
 mining_helmet:
@@ -22772,6 +22820,9 @@ mining_helmet:
   weight: 0.907
   slot: "Hat"
   type: "Hair"
+  light_source:
+    once_lit: "mining_helmet_lit"
+    level: 65
   examine: "A helmet with an unlit lamp on it."
 mining_helmet_noted: 5015
 bone_spear:
@@ -38758,6 +38809,9 @@ emerald_lantern:
   id: 9064
   tradeable: false
   weight: 1.36
+  light_source:
+    once_lit: "emerald_lantern_lit"
+    level: 49
   examine: "A mystical lantern."
   use: "Quest"
   kept: "Wilderness"
@@ -38766,6 +38820,8 @@ emerald_lantern_lit:
   tradeable: false
   weight: 1.36
   slot: "Shield"
+  light_source:
+    once_extinguish: "emerald_lantern"
   examine: "A mystical lantern casting a green beam."
   use: "Quest"
   kept: "Wilderness"

--- a/data/definitions/items.yml
+++ b/data/definitions/items.yml
@@ -218,7 +218,6 @@ white_candle:
   light_source:
     once_lit: "white_candle_lit"
     level: 1
-    level: 1
   examine: "A candle."
 candle_noted: 37
 black_candle:

--- a/engine/src/main/kotlin/world/gregs/voidps/engine/data/definition/ItemDefinitions.kt
+++ b/engine/src/main/kotlin/world/gregs/voidps/engine/data/definition/ItemDefinitions.kt
@@ -116,6 +116,7 @@ class ItemDefinitions(
                     "fletch_dart" -> FletchDarts(value as Map<String, Any>)
                     "fletch_bolts" -> FletchBolts(value as Map<String, Any>)
                     "fletching_unf" -> Fletching(value as Map<String, Any>)
+                    "light_source" -> LightSources(value as Map<String, Any>)
                     "skill_req" -> (value as MutableMap<String, Any>).mapKeys { Skill.valueOf(it.key.toSentenceCase()) }
                     else -> value
                 }, indent, parentMap)

--- a/engine/src/main/kotlin/world/gregs/voidps/engine/data/definition/data/LightSources.kt
+++ b/engine/src/main/kotlin/world/gregs/voidps/engine/data/definition/data/LightSources.kt
@@ -1,0 +1,23 @@
+package world.gregs.voidps.engine.data.definition.data
+
+/**
+ * @param onceLit the item that is given once the player lights a light source
+ * @param onceExtinguish the item that is given once the player extinguishes the light source
+ * @param level the firemaking level required to light the light source
+ */
+data class LightSources(
+    val onceLit: String = "",
+    val onceExtinguish: String = "",
+    val level: Int = -1
+) {
+    companion object {
+
+        operator fun invoke(map: Map<String, Any>) = LightSources(
+            onceLit = map["once_lit"] as? String ?: EMPTY.onceLit,
+            onceExtinguish = map["once_extinguish"] as? String ?: EMPTY.onceExtinguish,
+            level = map["level"] as? Int ?: EMPTY.level,
+        )
+
+        val EMPTY = LightSources()
+    }
+}

--- a/game/src/main/kotlin/world/gregs/voidps/world/activity/skill/firemaking/LightSource.kts
+++ b/game/src/main/kotlin/world/gregs/voidps/world/activity/skill/firemaking/LightSource.kts
@@ -1,0 +1,45 @@
+package world.gregs.voidps.world.activity.skill.firemaking
+
+import world.gregs.voidps.engine.client.message
+import world.gregs.voidps.engine.client.ui.interact.itemOnItem
+import world.gregs.voidps.engine.data.definition.data.LightSources
+import world.gregs.voidps.engine.entity.character.player.chat.ChatType
+import world.gregs.voidps.engine.entity.character.player.skill.Skill
+import world.gregs.voidps.engine.entity.character.player.skill.level.Level.has
+import world.gregs.voidps.engine.inv.inventory
+import world.gregs.voidps.engine.inv.transact.operation.ReplaceItem.replace
+import world.gregs.voidps.world.interact.entity.player.equip.inventoryItem
+
+
+itemOnItem("tinderbox*") {
+    val needsFlame: LightSources = toItem.def.getOrNull("light_source") ?: return@itemOnItem
+
+    if (!it.has(Skill.Firemaking, needsFlame.level, true)) {
+        return@itemOnItem
+    }
+
+    it.inventory.transaction {
+        replace(toItem.id, needsFlame.onceLit)
+    }
+
+    val litItem = determineLightSource(needsFlame.onceLit)
+    it.message("You light the $litItem", ChatType.Game)
+
+}
+
+inventoryItem("Extinguish") {
+    val toExtinguish: LightSources = item.def.getOrNull("light_source") ?: return@inventoryItem
+    player.inventory.transaction {
+        replace(item.id, toExtinguish.onceExtinguish)
+    }
+
+    player.message("You extinguish the flame.", ChatType.Game)
+}
+
+fun determineLightSource(itemName: String): String {
+    return when {
+        itemName.contains("lantern", ignoreCase = true) -> "lantern."
+        itemName.contains("candle", ignoreCase = true) -> "candle."
+        else -> "null"
+    }
+}

--- a/game/src/main/kotlin/world/gregs/voidps/world/activity/skill/firemaking/LightSource.kts
+++ b/game/src/main/kotlin/world/gregs/voidps/world/activity/skill/firemaking/LightSource.kts
@@ -1,7 +1,7 @@
 package world.gregs.voidps.world.activity.skill.firemaking
 
 import world.gregs.voidps.engine.client.message
-import world.gregs.voidps.engine.client.ui.interact.itemOnItem
+import world.gregs.voidps.engine.client.ui.interact.itemOnItems
 import world.gregs.voidps.engine.data.definition.data.LightSources
 import world.gregs.voidps.engine.entity.character.player.chat.ChatType
 import world.gregs.voidps.engine.entity.character.player.skill.Skill
@@ -10,12 +10,25 @@ import world.gregs.voidps.engine.inv.inventory
 import world.gregs.voidps.engine.inv.transact.operation.ReplaceItem.replace
 import world.gregs.voidps.world.interact.entity.player.equip.inventoryItem
 
+val acceptedUnlitSource = arrayOf(
+    "oil_lamp_oil",
+    "candle_lantern_white",
+    "candle_lantern_black",
+    "oil_lantern_oil",
+    "bullseye_lantern_oil",
+    "sapphire_lantern_oil",
+    "mining_helmet",
+    "emerald_lantern",
+    "white_candle",
+    "black_candle",
+    "unlit_torch"
+)
 
-itemOnItem("tinderbox*") {
-    val needsFlame: LightSources = toItem.def.getOrNull("light_source") ?: return@itemOnItem
+itemOnItems(arrayOf("tinderbox*"), acceptedUnlitSource) {
+    val needsFlame: LightSources = toItem.def.getOrNull("light_source") ?: return@itemOnItems
 
     if (!it.has(Skill.Firemaking, needsFlame.level, true)) {
-        return@itemOnItem
+        return@itemOnItems
     }
 
     it.inventory.transaction {
@@ -29,6 +42,7 @@ itemOnItem("tinderbox*") {
 
 inventoryItem("Extinguish") {
     val toExtinguish: LightSources = item.def.getOrNull("light_source") ?: return@inventoryItem
+
     player.inventory.transaction {
         replace(item.id, toExtinguish.onceExtinguish)
     }

--- a/game/src/main/kotlin/world/gregs/voidps/world/interact/entity/npc/combat/type/GiantMole.kts
+++ b/game/src/main/kotlin/world/gregs/voidps/world/interact/entity/npc/combat/type/GiantMole.kts
@@ -23,6 +23,7 @@ import world.gregs.voidps.engine.entity.character.setAnimation
 import world.gregs.voidps.engine.entity.obj.objectOperate
 import world.gregs.voidps.engine.entity.playerSpawn
 import world.gregs.voidps.engine.inject
+import world.gregs.voidps.engine.inv.equipment
 import world.gregs.voidps.engine.inv.inventory
 import world.gregs.voidps.engine.inv.itemChange
 import world.gregs.voidps.engine.inv.transact.operation.ReplaceItem.replace
@@ -201,11 +202,19 @@ itemChange("inventory") { player: Player ->
 
 fun hasLightSource(player: Player): Boolean {
     val playerItems = player.inventory.items
+    val playerEquipment = player.equipment.items
 
     for (item in playerItems) {
-        if (item.id.endsWith("lantern_lit") || item.id.endsWith("candle_lit")) {
+        if (item.id.endsWith("lantern_lit") || item.id.endsWith("candle_lit") || item.id == "firemaking_cape_t" || item.id == "firemaking_cape") {
             return true
         }
     }
+
+    for (equipmentItem in playerEquipment) {
+        if (equipmentItem.id == "firemaking_cape" || equipmentItem.id == "firemaking_cape_t") {
+            return true
+        }
+    }
+
     return false
 }


### PR DESCRIPTION
* Add the ability to make lanterns and lamps to `item-on-item.yml`
* Add `LightSources` data class to handle when `lighting` and `extinguish` light sources
* Add `LightSource.kts` to handle the logic when `lighting` and `extinguish` light sources
* Add `Firemaking cape` and `Firemaking cape t` as accepted light sources for `Giant Mole`, including if the players are wearing these capes.