### PR TITLE
Add npc pick-pocketing for thieving skill

### DIFF
--- a/data/definitions/animations.yml
+++ b/data/definitions/animations.yml
@@ -1542,7 +1542,7 @@ close_chest: 535
 open_chest: 536
 pick_pocket:
   id: 881
-  ticks: 2
+  ticks: 4
 cut_opal: 890
 cut_jade: 891
 cut_red_topaz: 892

--- a/data/definitions/animations.yml
+++ b/data/definitions/animations.yml
@@ -1540,7 +1540,9 @@ border_guard_draynor_raise: 23
 border_guard_draynor_lower: 22
 close_chest: 535
 open_chest: 536
-pick_pocket: 881
+pick_pocket:
+  id: 881
+  ticks: 2
 cut_opal: 890
 cut_jade: 891
 cut_red_topaz: 892

--- a/data/definitions/graphics.yml
+++ b/data/definitions/graphics.yml
@@ -1307,6 +1307,9 @@ stun:
 stun_hit:
   id: 348
   height: 60
+stun_long:
+  id: 245
+  height: 60
 teleport_block_cast: 1841
 teleport_block:
   id: 1842

--- a/data/definitions/npcs.yml
+++ b/data/definitions/npcs.yml
@@ -10,6 +10,11 @@ man:
   hitpoints: 70
   wander_radius: 4
   respawn_delay: 25
+  pickpocket:
+    stun_hit: 10
+    stun_ticks: 8
+    xp: 8.0
+    chance: 180-240
   style: crush
   race: human
   examine: "One of Gielinor's many citizens."
@@ -20,14 +25,8 @@ man_3:
   <<: *man
   id: 3
 woman:
+  <<: *man
   id: 4
-  max_hit_melee: 10
-  hitpoints: 70
-  wander_radius: 4
-  respawn_delay: 25
-  style: crush
-  race: human
-  examine: "One of Gielinor's many citizens."
 musician_lumbridge:
   id: 29
   song: 702

--- a/data/spawns/drops.yml
+++ b/data/spawns/drops.yml
@@ -1696,3 +1696,8 @@ monk_of_zamorak_drop_table:
       drops:
         - id: zamorak_robe_bottom
         - id: zamorak_robe_top
+human_pickpocket:
+  type: all
+  drops:
+    - id: coins
+      amount: 3

--- a/engine/src/main/kotlin/world/gregs/voidps/engine/client/instruction/handle/NPCOptionHandler.kt
+++ b/engine/src/main/kotlin/world/gregs/voidps/engine/client/instruction/handle/NPCOptionHandler.kt
@@ -11,6 +11,7 @@ import world.gregs.voidps.engine.entity.character.mode.interact.Interact
 import world.gregs.voidps.engine.entity.character.npc.NPCOption
 import world.gregs.voidps.engine.entity.character.npc.NPCs
 import world.gregs.voidps.engine.entity.character.player.Player
+import world.gregs.voidps.engine.entity.character.player.chat.ChatType
 import world.gregs.voidps.engine.entity.character.player.chat.noInterest
 import world.gregs.voidps.network.client.instruction.InteractNPC
 
@@ -42,6 +43,10 @@ class NPCOptionHandler(
         }
         if (selectedOption == "Listen-to" && player["movement", "walk"] == "music") {
             player.message("You are already resting.")
+            return
+        }
+        if (player.hasClock("stunned")) {
+            player.message("You're stunned!", ChatType.Filter)
             return
         }
         player.talkWith(npc, definition)

--- a/engine/src/main/kotlin/world/gregs/voidps/engine/data/definition/ItemDefinitions.kt
+++ b/engine/src/main/kotlin/world/gregs/voidps/engine/data/definition/ItemDefinitions.kt
@@ -132,33 +132,5 @@ class ItemDefinitions(
             }
             return value
         }
-
-        private fun YamlReader.readIntRange(): IntRange {
-            val start = reader.index
-            val number = number(start)
-            return if (reader.char == '-') {
-                val int = (number ?: reader.number(false, start, reader.index)) as Int
-                reader.skip()
-                val second = number(reader.index)
-                if (second != null) {
-                    int until second as Int
-                } else {
-                    int until int
-                }
-            } else if (reader.char == '.') {
-                val int = (number ?: reader.number(false, start, reader.index - 1)) as Int
-                reader.skip()
-                val second = number(reader.index)
-                if (second != null) {
-                    int..second as Int
-                } else {
-                    int..int
-                }
-            } else if (number != null) {
-                number as Int..number
-            } else {
-                throw IllegalArgumentException("Unexpected value ${reader.exception}")
-            }
-        }
     }
 }

--- a/engine/src/main/kotlin/world/gregs/voidps/engine/data/definition/NPCDefinitions.kt
+++ b/engine/src/main/kotlin/world/gregs/voidps/engine/data/definition/NPCDefinitions.kt
@@ -3,6 +3,7 @@ package world.gregs.voidps.engine.data.definition
 import it.unimi.dsi.fastutil.objects.Object2IntOpenHashMap
 import it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap
 import world.gregs.voidps.cache.definition.data.NPCDefinition
+import world.gregs.voidps.engine.data.definition.data.Pocket
 import world.gregs.voidps.engine.data.definition.data.Spot
 import world.gregs.voidps.engine.data.yaml.DefinitionConfig
 import world.gregs.voidps.engine.get
@@ -29,12 +30,17 @@ class NPCDefinitions(
                         map.putAll(value as Map<String, Any>)
                         return
                     }
-                    super.set(map, key,
-                        if (indent == 1 && key == "fishing") {
-                            Object2ObjectOpenHashMap((value as Map<String, Map<String, Any>>).mapValues { Spot(it.value) })
-                        } else {
-                            value
-                        }, indent, parentMap)
+                    if (indent == 1) {
+                        super.set(
+                            map, key, when (key) {
+                                "pickpocket" -> Pocket(value as Map<String, Any>)
+                                "fishing" -> Object2ObjectOpenHashMap((value as Map<String, Map<String, Any>>).mapValues { Spot(it.value) })
+                                else -> value
+                            }, indent, parentMap
+                        )
+                    } else {
+                        super.set(map, key, value, indent, parentMap)
+                    }
                 }
             }
             yaml.load<Any>(path, config)

--- a/engine/src/main/kotlin/world/gregs/voidps/engine/data/definition/NPCDefinitions.kt
+++ b/engine/src/main/kotlin/world/gregs/voidps/engine/data/definition/NPCDefinitions.kt
@@ -10,6 +10,7 @@ import world.gregs.voidps.engine.get
 import world.gregs.voidps.engine.getProperty
 import world.gregs.voidps.engine.timedLoad
 import world.gregs.yaml.Yaml
+import world.gregs.yaml.read.YamlReader
 
 class NPCDefinitions(
     override var definitions: Array<NPCDefinition>
@@ -25,6 +26,14 @@ class NPCDefinitions(
             val ids = Object2IntOpenHashMap<String>()
             this.ids = ids
             val config = object : DefinitionConfig<NPCDefinition>(ids, definitions) {
+                override fun setMapValue(reader: YamlReader, map: MutableMap<String, Any>, key: String, indent: Int, indentOffset: Int, withinMap: String?, parentMap: String?) {
+                    if (indent == 2 && key == "chance") {
+                        set(map, key, reader.readIntRange(), indent, parentMap)
+                    } else {
+                        super.setMapValue(reader, map, key, indent, indentOffset, withinMap, parentMap)
+                    }
+                }
+
                 override fun set(map: MutableMap<String, Any>, key: String, value: Any, indent: Int, parentMap: String?) {
                     if (key == "<<") {
                         map.putAll(value as Map<String, Any>)

--- a/engine/src/main/kotlin/world/gregs/voidps/engine/data/definition/data/Pocket.kt
+++ b/engine/src/main/kotlin/world/gregs/voidps/engine/data/definition/data/Pocket.kt
@@ -1,0 +1,32 @@
+package world.gregs.voidps.engine.data.definition.data
+
+/**
+ * @param level required to pickpocket
+ * @param xp experience per pickpocket
+ * @param stunHit the amount of damage when caught
+ * @param stunTicks the amount of ticks to stun for
+ * @param chance the chance of being successful
+ * @param caughtMessage npc message when caught
+ */
+data class Pocket(
+    val level: Int = 1,
+    val xp: Double = 0.0,
+    val stunHit: Int = 0,
+    val stunTicks: Int = 1,
+    val chance: IntRange = 1..1,
+    val caughtMessage: String = "What do you think you're doing?"
+) {
+    companion object {
+
+        operator fun invoke(map: Map<String, Any>) = Pocket(
+            level = map["level"] as? Int ?: EMPTY.level,
+            xp = map["xp"] as? Double ?: EMPTY.xp,
+            stunHit = map["stun_hit"] as? Int ?: EMPTY.stunHit,
+            stunTicks = map["stun_ticks"] as? Int ?: EMPTY.stunTicks,
+            chance = map["chance"] as? IntRange ?: EMPTY.chance,
+            caughtMessage = map["caught"] as? String ?: EMPTY.caughtMessage,
+        )
+
+        val EMPTY = Pocket()
+    }
+}

--- a/engine/src/main/kotlin/world/gregs/voidps/engine/data/yaml/DefinitionConfig.kt
+++ b/engine/src/main/kotlin/world/gregs/voidps/engine/data/yaml/DefinitionConfig.kt
@@ -1,6 +1,7 @@
 package world.gregs.voidps.engine.data.yaml
 
 import world.gregs.voidps.cache.definition.Extra
+import world.gregs.yaml.read.YamlReader
 
 open class DefinitionConfig<T : Extra>(
     val ids: MutableMap<String, Int>,
@@ -19,6 +20,34 @@ open class DefinitionConfig<T : Extra>(
             existing.putAll(extras)
         } else if (extras != null) {
             def.extras = extras
+        }
+    }
+
+    fun YamlReader.readIntRange(): IntRange {
+        val start = reader.index
+        val number = number(start)
+        return if (reader.char == '-') {
+            val int = (number ?: reader.number(false, start, reader.index)) as Int
+            reader.skip()
+            val second = number(reader.index)
+            if (second != null) {
+                int until second as Int
+            } else {
+                int until int
+            }
+        } else if (reader.char == '.') {
+            val int = (number ?: reader.number(false, start, reader.index - 1)) as Int
+            reader.skip()
+            val second = number(reader.index)
+            if (second != null) {
+                int..second as Int
+            } else {
+                int..int
+            }
+        } else if (number != null) {
+            number as Int..number
+        } else {
+            throw IllegalArgumentException("Unexpected value ${reader.exception}")
         }
     }
 }

--- a/engine/src/main/kotlin/world/gregs/voidps/engine/entity/item/drop/DropTable.kt
+++ b/engine/src/main/kotlin/world/gregs/voidps/engine/entity/item/drop/DropTable.kt
@@ -20,6 +20,13 @@ data class DropTable(
     override val chance: Int
 ) : Drop {
 
+    /**
+     * Roll a drop from the table
+     * @param maximumRoll overridable maximum roll for dynamic chances
+     * @param list optional list to add the drop to
+     * @param members whether members drops should be allowed or not
+     * @param player the player for [ItemDrop.predicate]'s
+     */
     fun role(maximumRoll: Int = -1, list: MutableList<ItemDrop> = mutableListOf(), members: Boolean = false, player: Player? = null): MutableList<ItemDrop> {
         collect(list, maximumRoll, members, player, random(maximumRoll))
         return list

--- a/game/src/main/kotlin/world/gregs/voidps/world/activity/skill/thieving/Pickpocketing.kts
+++ b/game/src/main/kotlin/world/gregs/voidps/world/activity/skill/thieving/Pickpocketing.kts
@@ -1,0 +1,80 @@
+package world.gregs.voidps.world.activity.skill.thieving
+
+import com.github.michaelbull.logging.InlineLogger
+import world.gregs.voidps.engine.client.message
+import world.gregs.voidps.engine.client.variable.hasClock
+import world.gregs.voidps.engine.client.variable.start
+import world.gregs.voidps.engine.data.definition.AnimationDefinitions
+import world.gregs.voidps.engine.data.definition.data.Pocket
+import world.gregs.voidps.engine.entity.World
+import world.gregs.voidps.engine.entity.character.face
+import world.gregs.voidps.engine.entity.character.forceChat
+import world.gregs.voidps.engine.entity.character.npc.npcOperate
+import world.gregs.voidps.engine.entity.character.player.chat.ChatType
+import world.gregs.voidps.engine.entity.character.player.chat.inventoryFull
+import world.gregs.voidps.engine.entity.character.player.skill.Skill
+import world.gregs.voidps.engine.entity.character.player.skill.exp.exp
+import world.gregs.voidps.engine.entity.character.player.skill.level.Level.has
+import world.gregs.voidps.engine.entity.character.player.skill.level.Level.success
+import world.gregs.voidps.engine.entity.character.setAnimation
+import world.gregs.voidps.engine.entity.item.drop.DropTables
+import world.gregs.voidps.engine.inject
+import world.gregs.voidps.engine.inv.inventory
+import world.gregs.voidps.engine.inv.transact.TransactionError
+import world.gregs.voidps.engine.inv.transact.operation.AddItem.add
+import world.gregs.voidps.engine.queue.softQueue
+import world.gregs.voidps.world.activity.skill.slayer.race
+import world.gregs.voidps.world.interact.entity.effect.stun
+import world.gregs.voidps.world.interact.entity.npc.combat.NPCAttack
+
+val animationDefinitions: AnimationDefinitions by inject()
+val dropTables: DropTables by inject()
+val logger = InlineLogger()
+
+npcOperate("Pickpocket") {
+    if (player.inventory.isFull()) {
+        player.inventoryFull()
+        return@npcOperate
+    }
+    if (player.hasClock("food_delay") || player.hasClock("action_delay")) { // Should action_delay and food_delay be the same??
+        return@npcOperate
+    }
+    val pocket: Pocket = target.def.getOrNull("pickpocket") ?: return@npcOperate
+    if (!player.has(Skill.Thieving, pocket.level)) {
+        return@npcOperate
+    }
+    player.setAnimation("pick_pocket", override = true)
+    player.start("action_delay", 2)
+    val name = target.def.name
+    player.message("You attempt to pick the ${name}'s pocket.", ChatType.Filter)
+    player.softQueue("pick-pocket", 2) {
+        if (success(player.levels.get(Skill.Thieving), pocket.chance)) {
+            player.message("You pick the ${name}'s pocket.", ChatType.Filter)
+            player.exp(Skill.Thieving, pocket.xp)
+            var table = dropTables.get("${target.id}_pickpocket")
+            if (table == null) {
+                table = dropTables.get("${target.race}_pickpocket")
+            }
+            if (table != null) {
+                val loot = table.role(members = World.members)
+                player.inventory.transaction {
+                    for (drop in loot) {
+                        val item = drop.toItem()
+                        add(item.id, item.amount)
+                    }
+                }
+                when (player.inventory.transaction.error) {
+                    is TransactionError.Full -> player.inventoryFull()
+                    TransactionError.None -> {}
+                    else -> logger.warn { "Unable to add pickpocket loot $player $loot" }
+                }
+            }
+        } else {
+            target.face(player)
+            target.forceChat = pocket.caughtMessage
+            target.setAnimation(NPCAttack.animation(target, animationDefinitions))
+            player.message("You fail to pick the ${name}'s pocket.", ChatType.Filter)
+            target.stun(player, pocket.stunTicks, pocket.stunHit)
+        }
+    }
+}

--- a/game/src/main/kotlin/world/gregs/voidps/world/activity/skill/thieving/Pickpocketing.kts
+++ b/game/src/main/kotlin/world/gregs/voidps/world/activity/skill/thieving/Pickpocketing.kts
@@ -19,10 +19,11 @@ import world.gregs.voidps.engine.entity.character.player.skill.exp.exp
 import world.gregs.voidps.engine.entity.character.player.skill.level.Level.has
 import world.gregs.voidps.engine.entity.character.player.skill.level.Level.success
 import world.gregs.voidps.engine.entity.character.setAnimation
-import world.gregs.voidps.engine.entity.item.drop.DropTable
 import world.gregs.voidps.engine.entity.item.drop.DropTables
+import world.gregs.voidps.engine.entity.item.drop.ItemDrop
 import world.gregs.voidps.engine.inject
 import world.gregs.voidps.engine.inv.inventory
+import world.gregs.voidps.engine.inv.transact.Transaction
 import world.gregs.voidps.engine.inv.transact.TransactionError
 import world.gregs.voidps.engine.inv.transact.operation.AddItem.add
 import world.gregs.voidps.engine.queue.softQueue
@@ -35,15 +36,16 @@ val dropTables: DropTables by inject()
 val logger = InlineLogger()
 
 npcOperate("Pickpocket") {
-    if (player.inventory.isFull()) {
-        player.inventoryFull()
-        return@npcOperate
-    }
     if (player.hasClock("food_delay") || player.hasClock("action_delay")) { // Should action_delay and food_delay be the same??
         return@npcOperate
     }
     val pocket: Pocket = target.def.getOrNull("pickpocket") ?: return@npcOperate
     if (!player.has(Skill.Thieving, pocket.level)) {
+        return@npcOperate
+    }
+    val success = success(player.levels.get(Skill.Thieving), pocket.chance)
+    val drops = getLoot(target) ?: emptyList()
+    if (success && !canLoot(player, drops)) {
         return@npcOperate
     }
     player.start("delay", 3)
@@ -52,11 +54,13 @@ npcOperate("Pickpocket") {
     player.message("You attempt to pick the ${name}'s pocket.", ChatType.Filter)
     target.start("movement_delay", 1)
     player.softQueue("pick-pocket", 2) {
-        if (success(player.levels.get(Skill.Thieving), pocket.chance)) {
+        if (success) {
+            player.inventory.transaction {
+                addLoot(drops)
+            }
             player.setAnimation("pick_pocket")
             player.message("You pick the ${name}'s pocket.", ChatType.Filter)
             player.exp(Skill.Thieving, pocket.xp)
-            giveLoot(player, target)
         } else {
             target.face(player)
             target.forceChat = pocket.caughtMessage
@@ -67,24 +71,30 @@ npcOperate("Pickpocket") {
     }
 }
 
-fun giveLoot(player: Player, target: NPC) {
-    var table: DropTable? = dropTables.get("${target.id}_pickpocket")
-    if (table == null) {
-        table = dropTables.get("${target.race}_pickpocket")
-    }
-    if (table == null) {
-        return
-    }
-    val loot = table.role(members = World.members)
-    player.inventory.transaction {
-        for (drop in loot) {
-            val item = drop.toItem()
-            add(item.id, item.amount)
-        }
-    }
-    when (player.inventory.transaction.error) {
+fun getLoot(target: NPC): List<ItemDrop>? {
+    val table = dropTables.get("${target.id}_pickpocket") ?: dropTables.get("${target.race}_pickpocket")
+    return table?.role(members = World.members)
+}
+
+fun canLoot(player: Player, drops: List<ItemDrop>): Boolean {
+    val transaction = player.inventory.transaction
+    transaction.start()
+    transaction.addLoot(drops)
+    transaction.revert()
+    when (transaction.error) {
         is TransactionError.Full -> player.inventoryFull()
-        TransactionError.None -> {}
-        else -> logger.warn { "Unable to add pickpocket loot $player $loot" }
+        TransactionError.None -> return true
+        else -> logger.warn { "Unable to add pickpocket loot $player $drops" }
+    }
+    return false
+}
+
+fun Transaction.addLoot(drops: List<ItemDrop>) {
+    for (drop in drops) {
+        val item = drop.toItem()
+        if (item.isEmpty()) {
+            continue
+        }
+        add(item.id, item.amount)
     }
 }

--- a/game/src/main/kotlin/world/gregs/voidps/world/activity/skill/thieving/Pickpocketing.kts
+++ b/game/src/main/kotlin/world/gregs/voidps/world/activity/skill/thieving/Pickpocketing.kts
@@ -9,7 +9,9 @@ import world.gregs.voidps.engine.data.definition.data.Pocket
 import world.gregs.voidps.engine.entity.World
 import world.gregs.voidps.engine.entity.character.face
 import world.gregs.voidps.engine.entity.character.forceChat
+import world.gregs.voidps.engine.entity.character.npc.NPC
 import world.gregs.voidps.engine.entity.character.npc.npcOperate
+import world.gregs.voidps.engine.entity.character.player.Player
 import world.gregs.voidps.engine.entity.character.player.chat.ChatType
 import world.gregs.voidps.engine.entity.character.player.chat.inventoryFull
 import world.gregs.voidps.engine.entity.character.player.skill.Skill
@@ -17,6 +19,7 @@ import world.gregs.voidps.engine.entity.character.player.skill.exp.exp
 import world.gregs.voidps.engine.entity.character.player.skill.level.Level.has
 import world.gregs.voidps.engine.entity.character.player.skill.level.Level.success
 import world.gregs.voidps.engine.entity.character.setAnimation
+import world.gregs.voidps.engine.entity.item.drop.DropTable
 import world.gregs.voidps.engine.entity.item.drop.DropTables
 import world.gregs.voidps.engine.inject
 import world.gregs.voidps.engine.inv.inventory
@@ -43,32 +46,17 @@ npcOperate("Pickpocket") {
     if (!player.has(Skill.Thieving, pocket.level)) {
         return@npcOperate
     }
-    player.setAnimation("pick_pocket", override = true)
-    player.start("action_delay", 2)
+    player.start("delay", 3)
+    player.start("movement_delay", 3)
     val name = target.def.name
     player.message("You attempt to pick the ${name}'s pocket.", ChatType.Filter)
+    target.start("movement_delay", 1)
     player.softQueue("pick-pocket", 2) {
         if (success(player.levels.get(Skill.Thieving), pocket.chance)) {
+            player.setAnimation("pick_pocket")
             player.message("You pick the ${name}'s pocket.", ChatType.Filter)
             player.exp(Skill.Thieving, pocket.xp)
-            var table = dropTables.get("${target.id}_pickpocket")
-            if (table == null) {
-                table = dropTables.get("${target.race}_pickpocket")
-            }
-            if (table != null) {
-                val loot = table.role(members = World.members)
-                player.inventory.transaction {
-                    for (drop in loot) {
-                        val item = drop.toItem()
-                        add(item.id, item.amount)
-                    }
-                }
-                when (player.inventory.transaction.error) {
-                    is TransactionError.Full -> player.inventoryFull()
-                    TransactionError.None -> {}
-                    else -> logger.warn { "Unable to add pickpocket loot $player $loot" }
-                }
-            }
+            giveLoot(player, target)
         } else {
             target.face(player)
             target.forceChat = pocket.caughtMessage
@@ -76,5 +64,27 @@ npcOperate("Pickpocket") {
             player.message("You fail to pick the ${name}'s pocket.", ChatType.Filter)
             target.stun(player, pocket.stunTicks, pocket.stunHit)
         }
+    }
+}
+
+fun giveLoot(player: Player, target: NPC) {
+    var table: DropTable? = dropTables.get("${target.id}_pickpocket")
+    if (table == null) {
+        table = dropTables.get("${target.race}_pickpocket")
+    }
+    if (table == null) {
+        return
+    }
+    val loot = table.role(members = World.members)
+    player.inventory.transaction {
+        for (drop in loot) {
+            val item = drop.toItem()
+            add(item.id, item.amount)
+        }
+    }
+    when (player.inventory.transaction.error) {
+        is TransactionError.Full -> player.inventoryFull()
+        TransactionError.None -> {}
+        else -> logger.warn { "Unable to add pickpocket loot $player $loot" }
     }
 }

--- a/game/src/main/kotlin/world/gregs/voidps/world/interact/entity/effect/Stun.kt
+++ b/game/src/main/kotlin/world/gregs/voidps/world/interact/entity/effect/Stun.kt
@@ -6,6 +6,7 @@ import world.gregs.voidps.engine.client.variable.start
 import world.gregs.voidps.engine.entity.character.Character
 import world.gregs.voidps.engine.entity.character.hit
 import world.gregs.voidps.engine.entity.character.player.Player
+import world.gregs.voidps.engine.entity.character.setGraphic
 import world.gregs.voidps.network.login.protocol.visual.update.Hitsplat
 
 val Character.stunned: Boolean get() = hasClock("stunned")
@@ -14,17 +15,19 @@ val Character.stunImmune: Boolean get() = this["immune_stun", false]
 
 fun Character.stun(target: Character, ticks: Int, hit: Int = -1): Boolean {
     if (target.stunned) {
-        (this as? Player)?.message("Your target is already stunned.") // TODO
+        (this as? Player)?.message("This target is already stunned.") // TODO
         return false
     } else if (target.stunImmune) {
-        (this as? Player)?.message("The target is currently immune to being stunned.") // TODO
+        (this as? Player)?.message("The target is immune to being stunned.") // TODO
         return false
     }
     if (hit != -1) {
         target.hit(this, hit, Hitsplat.Mark.Regular)
     }
-    (target as? Player)?.message("You've' been stunned!")
-    start("stunned", ticks)
-    start("movement_delay", ticks)
+    target.setGraphic("stun_long")
+    target.message("You've been stunned!")
+    target.start("delay", ticks)
+    target.start("stunned", ticks)
+    target.start("movement_delay", ticks)
     return true
 }

--- a/game/src/main/kotlin/world/gregs/voidps/world/interact/entity/effect/Stun.kt
+++ b/game/src/main/kotlin/world/gregs/voidps/world/interact/entity/effect/Stun.kt
@@ -1,0 +1,30 @@
+package world.gregs.voidps.world.interact.entity.effect
+
+import world.gregs.voidps.engine.client.message
+import world.gregs.voidps.engine.client.variable.hasClock
+import world.gregs.voidps.engine.client.variable.start
+import world.gregs.voidps.engine.entity.character.Character
+import world.gregs.voidps.engine.entity.character.hit
+import world.gregs.voidps.engine.entity.character.player.Player
+import world.gregs.voidps.network.login.protocol.visual.update.Hitsplat
+
+val Character.stunned: Boolean get() = hasClock("stunned")
+
+val Character.stunImmune: Boolean get() = this["immune_stun", false]
+
+fun Character.stun(target: Character, ticks: Int, hit: Int = -1): Boolean {
+    if (target.stunned) {
+        (this as? Player)?.message("Your target is already stunned.") // TODO
+        return false
+    } else if (target.stunImmune) {
+        (this as? Player)?.message("The target is currently immune to being stunned.") // TODO
+        return false
+    }
+    if (hit != -1) {
+        target.hit(this, hit, Hitsplat.Mark.Regular)
+    }
+    (target as? Player)?.message("You've' been stunned!")
+    start("stunned", ticks)
+    start("movement_delay", ticks)
+    return true
+}

--- a/game/src/main/kotlin/world/gregs/voidps/world/interact/entity/npc/combat/Attack.kts
+++ b/game/src/main/kotlin/world/gregs/voidps/world/interact/entity/npc/combat/Attack.kts
@@ -30,7 +30,6 @@ npcCombatSwing { npc ->
 }
 
 fun attackAnimation(npc: NPC): String {
-    var animation: String
     if (npc.def.contains("weapon_style")) {
         val id = npc.def["weapon_style", "unarmed"]
         val styleDefinition = definitions.get(id)
@@ -40,28 +39,12 @@ fun attackAnimation(npc: NPC): String {
             style = 0
         }
 
-        animation = "${styleDefinition.stringId}_${styleDefinition.attackTypes[style]}"
+        val animation = "${styleDefinition.stringId}_${styleDefinition.attackTypes[style]}"
         if (animationDefinitions.contains(animation)) {
             return animation
         }
     }
-    animation = "${npc.id}_attack"
-    if (animationDefinitions.contains(animation)) {
-        return animation
-    }
-    if (npc.def.contains("attack_anim")) {
-        animation = npc.def["attack_anim", ""]
-        if (animationDefinitions.contains(animation)) {
-            return animation
-        }
-    }
-    if (npc.race.isNotEmpty()) {
-        animation = "${npc.race}_attack"
-        if (animationDefinitions.contains(animation)) {
-            return animation
-        }
-    }
-    return ""
+    return NPCAttack.animation(npc, animationDefinitions)
 }
 
 fun attackSound(npc: NPC): String {

--- a/game/src/main/kotlin/world/gregs/voidps/world/interact/entity/npc/combat/NPCAttack.kt
+++ b/game/src/main/kotlin/world/gregs/voidps/world/interact/entity/npc/combat/NPCAttack.kt
@@ -1,0 +1,27 @@
+package world.gregs.voidps.world.interact.entity.npc.combat
+
+import world.gregs.voidps.engine.data.definition.AnimationDefinitions
+import world.gregs.voidps.engine.entity.character.npc.NPC
+import world.gregs.voidps.world.activity.skill.slayer.race
+
+object NPCAttack {
+    fun animation(npc: NPC, animationDefinitions: AnimationDefinitions): String {
+        var animation = "${npc.id}_attack"
+        if (animationDefinitions.contains(animation)) {
+            return animation
+        }
+        if (npc.def.contains("attack_anim")) {
+            animation = npc.def["attack_anim", ""]
+            if (animationDefinitions.contains(animation)) {
+                return animation
+            }
+        }
+        if (npc.race.isNotEmpty()) {
+            animation = "${npc.race}_attack"
+            if (animationDefinitions.contains(animation)) {
+                return animation
+            }
+        }
+        return ""
+    }
+}

--- a/game/src/test/kotlin/world/gregs/voidps/world/activity/skill/thieving/PickpocketTest.kt
+++ b/game/src/test/kotlin/world/gregs/voidps/world/activity/skill/thieving/PickpocketTest.kt
@@ -48,4 +48,18 @@ internal class PickpocketTest : WorldTest() {
         assertTrue(player.stunned)
     }
 
+    @Test
+    fun `Can't pickpocket with full inventory`() {
+        val player = createPlayer("thief", emptyTile)
+        player.inventory.add("cheese", 28)
+        val man = createNPC("man", emptyTile.addY(1))
+
+        player.npcOption(man, "Pickpocket")
+        tick(4)
+
+        assertEquals(player.inventory.count("coins"), 0)
+        assertEquals(player.experience.get(Skill.Thieving), 0.0)
+        assertFalse(player.stunned)
+    }
+
 }

--- a/game/src/test/kotlin/world/gregs/voidps/world/activity/skill/thieving/PickpocketTest.kt
+++ b/game/src/test/kotlin/world/gregs/voidps/world/activity/skill/thieving/PickpocketTest.kt
@@ -1,0 +1,51 @@
+package world.gregs.voidps.world.activity.skill.thieving
+
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import world.gregs.voidps.FakeRandom
+import world.gregs.voidps.engine.entity.character.player.skill.Skill
+import world.gregs.voidps.engine.inv.add
+import world.gregs.voidps.engine.inv.inventory
+import world.gregs.voidps.type.setRandom
+import world.gregs.voidps.world.interact.entity.effect.stunned
+import world.gregs.voidps.world.script.WorldTest
+import world.gregs.voidps.world.script.npcOption
+import kotlin.random.Random
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+
+internal class PickpocketTest : WorldTest() {
+
+    @Test
+    fun `Successfully pickpocket`() {
+        setRandom(object : FakeRandom() {
+            override fun nextInt(until: Int) = 0
+        })
+        val player = createPlayer("thief", emptyTile)
+        val man = createNPC("man", emptyTile.addY(1))
+
+        player.npcOption(man, "Pickpocket")
+        tick(4)
+
+        assertEquals(player.inventory.count("coins"), 3)
+        assertEquals(player.experience.get(Skill.Thieving), 8.0)
+        assertFalse(player.stunned)
+    }
+
+    @Test
+    fun `Fail to pickpocket`() {
+        setRandom(object : FakeRandom() {
+            override fun nextInt(until: Int) = until
+        })
+        val player = createPlayer("thief", emptyTile)
+        val man = createNPC("man", emptyTile.addY(1))
+
+        player.npcOption(man, "Pickpocket")
+        tick(4)
+
+        assertEquals(player.inventory.count("coins"), 0)
+        assertEquals(player.experience.get(Skill.Thieving), 0.0)
+        assertTrue(player.stunned)
+    }
+
+}


### PR DESCRIPTION
#485
* Added stun mechanic
* Added npc pick-pocketing
* Add pickpocket loot to drops.yaml
* Add man/woman/human pick-pocketing

Doesn't include success boosts like gloves of silence or ardy diary

Making an npc pick-pocket-able by adding data in npcs.yaml

```yaml
pickpocket:
    stun_hit: 10
    stun_ticks: 8
    xp: 14.5
    chance: 150-240
    caught: "Cor blimey mate, what are ye doing in me pockets?"
```

Add drops by specifying a [drop table](https://github.com/GregHib/void/wiki/drop-tables) with the npc id or race followed by `_pickpocket`. e.g. `woman_4_pickpocket`, `farmer_pickpocket`