### PR TITLE
Convert pauses and queues with interaction delays

### DIFF
--- a/engine/src/main/kotlin/world/gregs/voidps/engine/client/instruction/handle/FloorItemOptionHandler.kt
+++ b/engine/src/main/kotlin/world/gregs/voidps/engine/client/instruction/handle/FloorItemOptionHandler.kt
@@ -18,7 +18,7 @@ class FloorItemOptionHandler(
     private val logger = InlineLogger()
 
     override fun validate(player: Player, instruction: InteractFloorItem) {
-        if (player.contains("delay") || player.hasClock("input_delay")) {
+        if (player.contains("delay")) {
             return
         }
         val (id, x, y, optionIndex) = instruction

--- a/engine/src/main/kotlin/world/gregs/voidps/engine/client/instruction/handle/NPCOptionHandler.kt
+++ b/engine/src/main/kotlin/world/gregs/voidps/engine/client/instruction/handle/NPCOptionHandler.kt
@@ -23,7 +23,7 @@ class NPCOptionHandler(
     private val logger = InlineLogger()
 
     override fun validate(player: Player, instruction: InteractNPC) {
-        if (player.contains("delay") || player.hasClock("input_delay")) {
+        if (player.contains("delay")) {
             return
         }
         val npc = npcs.indexed(instruction.npcIndex) ?: return

--- a/engine/src/main/kotlin/world/gregs/voidps/engine/client/instruction/handle/ObjectOptionHandler.kt
+++ b/engine/src/main/kotlin/world/gregs/voidps/engine/client/instruction/handle/ObjectOptionHandler.kt
@@ -24,7 +24,7 @@ class ObjectOptionHandler(
     private val logger = InlineLogger()
 
     override fun validate(player: Player, instruction: InteractObject) {
-        if (player.contains("delay") || player.hasClock("input_delay")) {
+        if (player.contains("delay")) {
             return
         }
         val (objectId, x, y, option) = instruction

--- a/engine/src/main/kotlin/world/gregs/voidps/engine/client/instruction/handle/PlayerOptionHandler.kt
+++ b/engine/src/main/kotlin/world/gregs/voidps/engine/client/instruction/handle/PlayerOptionHandler.kt
@@ -18,7 +18,7 @@ class PlayerOptionHandler(
     private val logger = InlineLogger()
 
     override fun validate(player: Player, instruction: InteractPlayer) {
-        if (player.contains("delay") || player.hasClock("input_delay")) {
+        if (player.contains("delay")) {
             return
         }
         val target = players.indexed(instruction.playerIndex) ?: return

--- a/engine/src/main/kotlin/world/gregs/voidps/engine/client/instruction/handle/WalkHandler.kt
+++ b/engine/src/main/kotlin/world/gregs/voidps/engine/client/instruction/handle/WalkHandler.kt
@@ -11,7 +11,7 @@ import world.gregs.voidps.network.client.instruction.Walk
 class WalkHandler : InstructionHandler<Walk>() {
 
     override fun validate(player: Player, instruction: Walk) {
-        if (player.contains("delay") || player.hasClock("input_delay")) {
+        if (player.contains("delay")) {
             return
         }
         player.closeInterfaces()

--- a/engine/src/main/kotlin/world/gregs/voidps/engine/entity/character/mode/interact/Interaction.kt
+++ b/engine/src/main/kotlin/world/gregs/voidps/engine/entity/character/mode/interact/Interaction.kt
@@ -1,7 +1,9 @@
 package world.gregs.voidps.engine.entity.character.mode.interact
 
+import world.gregs.voidps.cache.definition.data.ObjectDefinition
 import world.gregs.voidps.engine.client.variable.remaining
 import world.gregs.voidps.engine.entity.character.Character
+import world.gregs.voidps.engine.entity.obj.GameObject
 import world.gregs.voidps.engine.event.CancellableEvent
 import world.gregs.voidps.engine.event.SuspendableEvent
 import world.gregs.voidps.engine.suspend.SuspendableContext

--- a/engine/src/main/kotlin/world/gregs/voidps/engine/entity/character/mode/interact/Interaction.kt
+++ b/engine/src/main/kotlin/world/gregs/voidps/engine/entity/character/mode/interact/Interaction.kt
@@ -1,9 +1,7 @@
 package world.gregs.voidps.engine.entity.character.mode.interact
 
-import world.gregs.voidps.cache.definition.data.ObjectDefinition
 import world.gregs.voidps.engine.client.variable.remaining
 import world.gregs.voidps.engine.entity.character.Character
-import world.gregs.voidps.engine.entity.obj.GameObject
 import world.gregs.voidps.engine.event.CancellableEvent
 import world.gregs.voidps.engine.event.SuspendableEvent
 import world.gregs.voidps.engine.suspend.SuspendableContext
@@ -13,7 +11,6 @@ abstract class Interaction<C : Character> : CancellableEvent(), SuspendableEvent
     var approach = false
     val operate: Boolean
         get() = !approach
-    override var onCancel: (() -> Unit)? = null
     var launched = false
 
     abstract fun copy(approach: Boolean): Interaction<C>

--- a/engine/src/main/kotlin/world/gregs/voidps/engine/entity/character/mode/move/AreaEntered.kt
+++ b/engine/src/main/kotlin/world/gregs/voidps/engine/entity/character/mode/move/AreaEntered.kt
@@ -17,8 +17,6 @@ data class AreaEntered<C : Character>(
     val area: Area
 ) : SuspendableEvent, SuspendableContext<C> {
 
-    override var onCancel: (() -> Unit)? = null
-
     override val size = 5
 
     override suspend fun pause(ticks: Int) {

--- a/engine/src/main/kotlin/world/gregs/voidps/engine/entity/character/mode/move/AreaExited.kt
+++ b/engine/src/main/kotlin/world/gregs/voidps/engine/entity/character/mode/move/AreaExited.kt
@@ -16,7 +16,6 @@ data class AreaExited<C : Character>(
     val tags: Set<String>,
     val area: Area
 ) : SuspendableEvent, SuspendableContext<C> {
-    override var onCancel: (() -> Unit)? = null
 
     override val size = 5
 

--- a/engine/src/main/kotlin/world/gregs/voidps/engine/entity/character/mode/move/Moved.kt
+++ b/engine/src/main/kotlin/world/gregs/voidps/engine/entity/character/mode/move/Moved.kt
@@ -19,7 +19,6 @@ data class Moved<C : Character>(
     val from: Tile,
     val to: Tile
 ) : CancellableEvent(), SuspendableContext<C>, SuspendableEvent {
-    override var onCancel: (() -> Unit)? = null
 
     override val size = 4
 

--- a/engine/src/main/kotlin/world/gregs/voidps/engine/event/Context.kt
+++ b/engine/src/main/kotlin/world/gregs/voidps/engine/event/Context.kt
@@ -9,7 +9,6 @@ import world.gregs.voidps.engine.entity.character.player.Player
  */
 interface Context<C : Character> {
     val character: C
-    var onCancel: (() -> Unit)?
     val Context<Player>.player: Player
         get() = character
     val Context<NPC>.npc: NPC

--- a/engine/src/main/kotlin/world/gregs/voidps/engine/queue/Action.kt
+++ b/engine/src/main/kotlin/world/gregs/voidps/engine/queue/Action.kt
@@ -13,7 +13,7 @@ class Action<C : Character>(
     val priority: ActionPriority,
     delay: Int = 0,
     val behaviour: LogoutBehaviour = LogoutBehaviour.Discard,
-    override var onCancel: (() -> Unit)? = { character.clearAnimation() },
+    var onCancel: (() -> Unit)? = { character.clearAnimation() },
     var action: suspend Action<*>.() -> Unit = {}
 ) : SuspendableContext<C> {
     var suspension: CancellableContinuation<Unit>? = null

--- a/engine/src/main/kotlin/world/gregs/voidps/engine/queue/Action.kt
+++ b/engine/src/main/kotlin/world/gregs/voidps/engine/queue/Action.kt
@@ -52,6 +52,30 @@ class Action<C : Character>(
         }
     }
 
+    /**
+     * Queue calls shouldn't be nested and should be replaced with suspensions
+     */
+
+    @Suppress("UNUSED_PARAMETER", "UnusedReceiverParameter")
+    @Deprecated("Replace nested queues with pause", ReplaceWith("pause(initialDelay)"))
+    fun Character.queue(name: String, initialDelay: Int = 0, behaviour: LogoutBehaviour = LogoutBehaviour.Discard, onCancel: (() -> Unit)? = null, block: (suspend Action<C>.() -> Unit)?) {
+    }
+
+    @Suppress("UNUSED_PARAMETER", "UnusedReceiverParameter")
+    @Deprecated("Replace nested queues with pause", ReplaceWith("pause(initialDelay)"))
+    fun Character.softQueue(name: String, initialDelay: Int = 0, behaviour: LogoutBehaviour = LogoutBehaviour.Discard, onCancel: (() -> Unit)? = null, block: (suspend Action<C>.() -> Unit)?) {
+    }
+
+    @Suppress("UNUSED_PARAMETER", "UnusedReceiverParameter")
+    @Deprecated("Replace nested queues with pause", ReplaceWith("pause(initialDelay)"))
+    fun Character.weakQueue(name: String, initialDelay: Int = 0, behaviour: LogoutBehaviour = LogoutBehaviour.Discard, onCancel: (() -> Unit)? = null, block: (suspend Action<C>.() -> Unit)?) {
+    }
+
+    @Suppress("UNUSED_PARAMETER", "UnusedReceiverParameter")
+    @Deprecated("Replace nested queues with pause", ReplaceWith("pause(initialDelay)"))
+    fun Character.strongQueue(name: String, initialDelay: Int = 0, behaviour: LogoutBehaviour = LogoutBehaviour.Discard, onCancel: (() -> Unit)? = null, block: (suspend Action<C>.() -> Unit)?) {
+    }
+
     override fun toString(): String {
         return "${name}_${count}_${priority.name.toSnakeCase()}_${behaviour.name.toSnakeCase()}"
     }

--- a/engine/src/main/kotlin/world/gregs/voidps/engine/suspend/SuspendableContext.kt
+++ b/engine/src/main/kotlin/world/gregs/voidps/engine/suspend/SuspendableContext.kt
@@ -2,6 +2,7 @@ package world.gregs.voidps.engine.suspend
 
 import kotlinx.coroutines.suspendCancellableCoroutine
 import world.gregs.voidps.engine.entity.character.Character
+import world.gregs.voidps.engine.entity.character.mode.interact.Interaction
 import world.gregs.voidps.engine.event.Context
 
 interface SuspendableContext<C : Character> : Context<C> {

--- a/engine/src/test/kotlin/world/gregs/voidps/engine/queue/ActionQueueTest.kt
+++ b/engine/src/test/kotlin/world/gregs/voidps/engine/queue/ActionQueueTest.kt
@@ -94,7 +94,7 @@ internal class ActionQueueTest {
     }
 
     @Test
-    fun `Queues can be suspended and resume`() {
+    fun `Queues can be suspended and resumed`() {
         var resumed = false
         val action = action {
             pause(4)

--- a/game/src/main/kotlin/world/gregs/voidps/world/activity/dnd/shootingstar/ShootingStar.kts
+++ b/game/src/main/kotlin/world/gregs/voidps/world/activity/dnd/shootingstar/ShootingStar.kts
@@ -6,7 +6,6 @@ import world.gregs.voidps.engine.client.ui.chat.Colours
 import world.gregs.voidps.engine.client.ui.chat.plural
 import world.gregs.voidps.engine.client.ui.chat.toTag
 import world.gregs.voidps.engine.client.ui.event.adminCommand
-import world.gregs.voidps.engine.client.variable.start
 import world.gregs.voidps.engine.data.Settings
 import world.gregs.voidps.engine.data.definition.data.Rock
 import world.gregs.voidps.engine.data.settingsReload

--- a/game/src/main/kotlin/world/gregs/voidps/world/activity/dnd/shootingstar/ShootingStar.kts
+++ b/game/src/main/kotlin/world/gregs/voidps/world/activity/dnd/shootingstar/ShootingStar.kts
@@ -31,7 +31,6 @@ import world.gregs.voidps.engine.inv.add
 import world.gregs.voidps.engine.inv.inventory
 import world.gregs.voidps.engine.inv.remove
 import world.gregs.voidps.engine.map.collision.blocked
-import world.gregs.voidps.engine.queue.softQueue
 import world.gregs.voidps.engine.timer.timerStart
 import world.gregs.voidps.engine.timer.timerStop
 import world.gregs.voidps.engine.timer.timerTick
@@ -224,15 +223,13 @@ objectApproach("Prospect", "crashed_star_tier_#") {
     arriveDelay()
     val starPayout = target.def["collect_for_next_layer", -1]
     player.message("You examine the crashed star...")
-    player.start("movement_delay", 4)
-    player.softQueue("prospect", 4) {
-        val star = def.getOrNull<Rock>("mining")?.ores?.firstOrNull()
-        if (star == null) {
-            player.message("Star has been mined...")
-        } else if (starPayout != -1) {
-            val percentageCollected = getLayerPercentage(totalCollected, starPayout)
-            player.message("There is $percentageCollected% left of this layer.")
-        }
+    delay(4)
+    val star = def.getOrNull<Rock>("mining")?.ores?.firstOrNull()
+    if (star == null) {
+        player.message("Star has been mined...")
+    } else if (starPayout != -1) {
+        val percentageCollected = getLayerPercentage(totalCollected, starPayout)
+        player.message("There is $percentageCollected% left of this layer.")
     }
 }
 

--- a/game/src/main/kotlin/world/gregs/voidps/world/activity/quest/mini/AlfredGrimhandsBarCrawl.kt
+++ b/game/src/main/kotlin/world/gregs/voidps/world/activity/quest/mini/AlfredGrimhandsBarCrawl.kt
@@ -1,6 +1,7 @@
 package world.gregs.voidps.world.activity.quest.mini
 
 import world.gregs.voidps.engine.client.message
+import world.gregs.voidps.engine.entity.character.mode.interact.TargetInteraction
 import world.gregs.voidps.engine.event.TargetContext
 import world.gregs.voidps.engine.entity.character.npc.NPC
 import world.gregs.voidps.engine.entity.character.player.Player
@@ -14,10 +15,10 @@ import world.gregs.voidps.world.interact.dialogue.Talk
 import world.gregs.voidps.world.interact.dialogue.type.npc
 import world.gregs.voidps.world.interact.dialogue.type.player
 
-suspend fun <T> T.barCrawlDrink(
+suspend fun <T : TargetInteraction<Player, NPC>> T.barCrawlDrink(
     start: (suspend T.() -> Unit)? = null,
     effects: suspend T.() -> Unit = {},
-) where T : TargetContext<Player, NPC>, T : SuspendableContext<Player> {
+) {
     player<Talk>("I'm doing Alfred Grimhand's Barcrawl.")
     val info: Map<String, Any> = target.def.getOrNull("bar_crawl") ?: return
     start?.invoke(this) ?: npc<Talk>(info["start"] as String)
@@ -27,15 +28,14 @@ suspend fun <T> T.barCrawlDrink(
         return
     }
     player.message(info["give"] as String)
-    player.queue("barcrawl_$id", 4) {
-        player.message(info["drink"] as String)
-        pause(4)
-        player.message(info["effect"] as String)
-        pause(4)
-        (info["sign"] as? String)?.let { player.message(it) }
-        player.addVarbit("barcrawl_signatures", id)
-        effects()
-    }
+    delay(4)
+    player.message(info["drink"] as String)
+    delay(4)
+    player.message(info["effect"] as String)
+    delay(4)
+    (info["sign"] as? String)?.let { player.message(it) }
+    player.addVarbit("barcrawl_signatures", id)
+    effects()
 }
 
 val barCrawlFilter: TargetContext<Player, NPC>.() -> Boolean = filter@{

--- a/game/src/main/kotlin/world/gregs/voidps/world/activity/quest/mini/AlfredGrimhandsBarCrawl.kt
+++ b/game/src/main/kotlin/world/gregs/voidps/world/activity/quest/mini/AlfredGrimhandsBarCrawl.kt
@@ -7,8 +7,6 @@ import world.gregs.voidps.engine.entity.character.npc.NPC
 import world.gregs.voidps.engine.entity.character.player.Player
 import world.gregs.voidps.engine.inv.inventory
 import world.gregs.voidps.engine.inv.remove
-import world.gregs.voidps.engine.queue.queue
-import world.gregs.voidps.engine.suspend.SuspendableContext
 import world.gregs.voidps.world.activity.quest.quest
 import world.gregs.voidps.world.interact.dialogue.Sad
 import world.gregs.voidps.world.interact.dialogue.Talk

--- a/game/src/main/kotlin/world/gregs/voidps/world/activity/skill/agility/course/BarbarianAdvanced.kts
+++ b/game/src/main/kotlin/world/gregs/voidps/world/activity/skill/agility/course/BarbarianAdvanced.kts
@@ -12,6 +12,8 @@ import world.gregs.voidps.engine.entity.character.player.skill.exp.exp
 import world.gregs.voidps.engine.entity.character.player.skill.level.Level.has
 import world.gregs.voidps.engine.entity.character.setAnimation
 import world.gregs.voidps.engine.entity.obj.objectOperate
+import world.gregs.voidps.engine.queue.LogoutBehaviour
+import world.gregs.voidps.engine.queue.queue
 import world.gregs.voidps.engine.queue.strongQueue
 import world.gregs.voidps.type.Direction
 import world.gregs.voidps.type.Tile
@@ -22,17 +24,15 @@ objectOperate("Run-up", "barbarian_outpost_run_wall") {
         return@objectOperate
     }
     player.clear("face_entity")
-    pause()
+    delay()
     player.face(Direction.NORTH)
     player.setAnimation("barbarian_wall_jump_climb")
-    player.start("input_delay", 10)
-    player.strongQueue("agility_wall", 7) {
-        player.exactMove(Tile(2538, 3545, 2), 30, Direction.NORTH)
-        player.setAnimation("barbarian_wall_jump")
-        pause(2)
-        player.exp(Skill.Agility, 15.0)
-        player.agilityStage(3)
-    }
+    delay(7)
+    player.exactMove(Tile(2538, 3545, 2), 30, Direction.NORTH)
+    player.setAnimation("barbarian_wall_jump")
+    delay(2)
+    player.exp(Skill.Agility, 15.0)
+    player.agilityStage(3)
 }
 
 objectOperate("Climb-up", "barbarian_outpost_climb_wall") {
@@ -41,93 +41,80 @@ objectOperate("Climb-up", "barbarian_outpost_climb_wall") {
     if (move) {
         player.walkTo(Tile(2537, 3546, 2))
     }
-    player.start("input_delay", if (move) 5 else 4)
-    player.strongQueue("agility_wall", if (move) 2 else 1) {
-        player.face(Direction.WEST)
-        pause()
-        player.setAnimation("barbarian_wall_climb")
-        pause()
-        player.tele(2536, 3546, 3)
-        player.setAnimation("barbarian_wall_stand_up")
-        pause()
-        player.exp(Skill.Agility, 15.0)
-        player.agilityStage(4)
-    }
+    delay(if (move) 2 else 1)
+    player.face(Direction.WEST)
+    delay()
+    player.setAnimation("barbarian_wall_climb")
+    delay()
+    player.tele(2536, 3546, 3)
+    player.setAnimation("barbarian_wall_stand_up")
+    delay()
+    player.exp(Skill.Agility, 15.0)
+    player.agilityStage(4)
 }
 
 objectOperate("Fire", "barbarian_outpost_spring") {
     player.clear("face_entity")
     player.face(Direction.NORTH)
-    player.start("input_delay", 6)
-    player.strongQueue("agility_spring", 1) {
-        target.animate("barbarian_spring_fire")
-        pause(1)
-        player.tele(2533, 3547, 3)
-        player.exactMove(Tile(2532, 3553, 3), 60, Direction.NORTH)
-        player.setAnimation("barbarian_spring_shoot")
-        pause(1)
-        target.animate("barbarian_spring_reset")
-        pause(3)
-        player.exp(Skill.Agility, 15.0)
-        player.agilityStage(5)
-    }
+    delay(1)
+    target.animate("barbarian_spring_fire")
+    delay(1)
+    player.tele(2533, 3547, 3)
+    player.exactMove(Tile(2532, 3553, 3), 60, Direction.NORTH)
+    player.setAnimation("barbarian_spring_shoot")
+    delay(1)
+    target.animate("barbarian_spring_reset")
+    delay(3)
+    player.exp(Skill.Agility, 15.0)
+    player.agilityStage(5)
 }
 
 objectOperate("Cross", "barbarian_outpost_balance_beam") {
     player.face(Direction.EAST)
-    player.start("input_delay", 6)
-    player.strongQueue("agility_beam", 1) {
-        onCancel = {
-            player.tele(2533, 3553, 3)
-            player.clearRenderEmote()
-        }
-        player.setAnimation("circus_cartwheel")
-        pause()
-        player.exactMove(Tile(2536, 3553, 3), 45, Direction.EAST)
-        pause()
-        player.renderEmote = "beam_balance"
-        pause()
-        player.exp(Skill.Agility, 15.0)
-        player.agilityStage(6)
+    delay()
+    player.setAnimation("circus_cartwheel")
+    delay()
+    player.exactMove(Tile(2536, 3553, 3), 45, Direction.EAST)
+    delay()
+    player.strongQueue("agility_beam", behaviour = LogoutBehaviour.Accelerate) {
+        delay(Int.MAX_VALUE)
+        player.tele(2533, 3553, 3)
+        player.clearRenderEmote()
     }
+    player.renderEmote = "beam_balance"
+    delay()
+    player.exp(Skill.Agility, 15.0)
+    player.agilityStage(6)
 }
 
 objectOperate("Jump-over", "barbarian_outpost_gap") {
     player.clearRenderEmote()
     player.setAnimation("barbarian_gap_jump")
-    player.start("input_delay", 2)
-    player.strongQueue("agility_gap", 1) {
-        player.tele(2539, 3553, 2)
-        player.setAnimation("barbarian_jump_land")
-        pause()
-        player.exp(Skill.Agility, 15.0)
-        player.agilityStage(7)
-    }
+    delay()
+    player.tele(2539, 3553, 2)
+    player.setAnimation("barbarian_jump_land")
+    delay()
+    player.exp(Skill.Agility, 15.0)
+    player.agilityStage(7)
 }
 
 objectOperate("Slide-down", "barbarian_outpost_roof") {
-    player.start("input_delay", 5)
-    player.strongQueue("agility_gap") {
-        onCancel = {
-            player.tele(2538, 3553, 2)
-        }
-        player.exactMove(player.tile.copy(x = 2540), 30, Direction.EAST)
-        player.setAnimation("barbarian_slide_start")
-        pause()
-        player.setAnimation("barbarian_slide")
-        player.exactMove(player.tile.copy(x = 2543, level = 1), 90, Direction.EAST)
-        pause()
-        player.setAnimation("barbarian_slide")
-        pause()
-        player.setAnimation("barbarian_slide_jump")
-        pause()
-        player.tele(2544, player.tile.y, 0)
-        player.setAnimation("barbarian_jump_land")
-        player.exp(Skill.Agility, 15.0)
-        if (player.agilityStage == 7) {
-            player.agilityStage = 0
-            player.inc("barbarian_course_advanced_laps")
-            player.exp(Skill.Agility, 615.0)
-        }
+    player.exactMove(player.tile.copy(x = 2540), 30, Direction.EAST)
+    player.setAnimation("barbarian_slide_start")
+    delay()
+    player.setAnimation("barbarian_slide")
+    player.exactMove(player.tile.copy(x = 2543, level = 1), 90, Direction.EAST)
+    delay()
+    player.setAnimation("barbarian_slide")
+    delay()
+    player.setAnimation("barbarian_slide_jump")
+    delay()
+    player.tele(2544, player.tile.y, 0)
+    player.setAnimation("barbarian_jump_land")
+    player.exp(Skill.Agility, 15.0)
+    if (player.agilityStage == 7) {
+        player.agilityStage = 0
+        player.inc("barbarian_course_advanced_laps")
+        player.exp(Skill.Agility, 615.0)
     }
 }

--- a/game/src/main/kotlin/world/gregs/voidps/world/activity/skill/agility/course/BarbarianAdvanced.kts
+++ b/game/src/main/kotlin/world/gregs/voidps/world/activity/skill/agility/course/BarbarianAdvanced.kts
@@ -1,6 +1,5 @@
 package world.gregs.voidps.world.activity.skill.agility.course
 
-import world.gregs.voidps.engine.client.variable.start
 import world.gregs.voidps.engine.entity.character.exactMove
 import world.gregs.voidps.engine.entity.character.face
 import world.gregs.voidps.engine.entity.character.move.tele
@@ -12,9 +11,6 @@ import world.gregs.voidps.engine.entity.character.player.skill.exp.exp
 import world.gregs.voidps.engine.entity.character.player.skill.level.Level.has
 import world.gregs.voidps.engine.entity.character.setAnimation
 import world.gregs.voidps.engine.entity.obj.objectOperate
-import world.gregs.voidps.engine.queue.LogoutBehaviour
-import world.gregs.voidps.engine.queue.queue
-import world.gregs.voidps.engine.queue.strongQueue
 import world.gregs.voidps.type.Direction
 import world.gregs.voidps.type.Tile
 import world.gregs.voidps.type.equals
@@ -76,11 +72,6 @@ objectOperate("Cross", "barbarian_outpost_balance_beam") {
     delay()
     player.exactMove(Tile(2536, 3553, 3), 45, Direction.EAST)
     delay()
-    player.strongQueue("agility_beam", behaviour = LogoutBehaviour.Accelerate) {
-        delay(Int.MAX_VALUE)
-        player.tele(2533, 3553, 3)
-        player.clearRenderEmote()
-    }
     player.renderEmote = "beam_balance"
     delay()
     player.exp(Skill.Agility, 15.0)
@@ -111,6 +102,7 @@ objectOperate("Slide-down", "barbarian_outpost_roof") {
     delay()
     player.tele(2544, player.tile.y, 0)
     player.setAnimation("barbarian_jump_land")
+    delay()
     player.exp(Skill.Agility, 15.0)
     if (player.agilityStage == 7) {
         player.agilityStage = 0

--- a/game/src/main/kotlin/world/gregs/voidps/world/activity/skill/agility/course/BarbarianOutpost.kts
+++ b/game/src/main/kotlin/world/gregs/voidps/world/activity/skill/agility/course/BarbarianOutpost.kts
@@ -115,7 +115,6 @@ objectOperate("Climb-over", "barbarian_outpost_obstacle_net") {
 }
 
 objectOperate("Walk-across", "barbarian_outpost_balancing_ledge") {
-    player.start("input_delay", 6)
     player.setAnimation("ledge_stand_right")
     val disable = Settings["agility.disableCourseFailure", false]
     val success = disable || Level.success(player.levels.get(Skill.Agility), 93) // 62.1% success rate

--- a/game/src/main/kotlin/world/gregs/voidps/world/activity/skill/agility/course/BarbarianOutpost.kts
+++ b/game/src/main/kotlin/world/gregs/voidps/world/activity/skill/agility/course/BarbarianOutpost.kts
@@ -29,19 +29,16 @@ objectOperate("Squeeze-through", "barbarian_outpost_entrance") {
     }
     player.agilityCourse("barbarian")
     val start = if (player.tile.y >= 3560) Tile(2552, 3561) else Tile(2552, 3558)
-    player.strongQueue("agility_pipe") {
-        if (player.tile != start) {
-            player.start("input_delay", 2)
-            player.walkTo(start)
-            pause()
-            player.face(target)
-            pause()
-        }
-        player.start("input_delay", 2)
-        player.setAnimation("climb_through_pipe")
-        val end = if (player.tile.y >= 3560) 3558 else 3561
-        player.exactMove(Tile(2552, end), 60)
+    if (player.tile != start) {
+        player.walkTo(start)
+        delay()
+        player.face(target)
+        delay()
     }
+    player.setAnimation("climb_through_pipe")
+    val end = if (player.tile.y >= 3560) 3558 else 3561
+    player.exactMove(Tile(2552, end), 60)
+    delay(2)
 }
 
 objectOperate("Swing-on", "barbarian_outpost_rope_swing") {
@@ -51,81 +48,71 @@ objectOperate("Swing-on", "barbarian_outpost_rope_swing") {
     val disable = Settings["agility.disableCourseFailure", false]
     val success = disable || Level.success(player.levels.get(Skill.Agility), 70) // 50% success at 35
 //  player.message("The rope swing is being used at the moment.", ChatType.Filter)
-    player.start("input_delay", if (success) 5 else 8)
-    player.strongQueue("agility_rope_swing", 2) {
-        player.setAnimation("rope_swing")
-        target.animate("swing_rope")
-        pause()
-        if (success) {
-            player.exactMove(player.tile.copy(y = 3549), 60, Direction.SOUTH)
-            pause()
-            player.exp(Skill.Agility, 22.0)
-            player.message("You skillfully swing across.", ChatType.Filter)
-        } else {
-            player.exactMove(player.tile.copy(y = 3550), 50, Direction.SOUTH)
-            pause(2)
-            player.tele(player.tile.copy(y = 9950))
-            player.damage(50)
-            pause(3)
-            player.walkTo(player.tile.copy(y = 9949), noCollision = true, noRun = true)
-            player.message("You slip and fall to the pit below.", ChatType.Filter)
-        }
-        if (success || Settings["agility.disableFailLapSkip", false]) {
-            player.agilityStage(1)
-        }
+    delay(2)
+    player.setAnimation("rope_swing")
+    target.animate("swing_rope")
+    delay()
+    if (success) {
+        player.exactMove(player.tile.copy(y = 3549), 60, Direction.SOUTH)
+        delay()
+        player.exp(Skill.Agility, 22.0)
+        player.message("You skillfully swing across.", ChatType.Filter)
+    } else {
+        player.exactMove(player.tile.copy(y = 3550), 50, Direction.SOUTH)
+        delay(2)
+        player.tele(player.tile.copy(y = 9950))
+        player.damage(50)
+        delay(3)
+        player.walkTo(player.tile.copy(y = 9949), noCollision = true, noRun = true)
+        player.message("You slip and fall to the pit below.", ChatType.Filter)
+    }
+    if (success || Settings["agility.disableFailLapSkip", false]) {
+        player.agilityStage(1)
     }
 }
 
 objectOperate("Walk-across", "barbarian_outpost_log_balance") {
-    player.start("input_delay", 12)
     val disable = Settings["agility.disableCourseFailure", false]
     val success = disable || Level.success(player.levels.get(Skill.Agility), 93) // 62.1% success rate at 35
-    player.strongQueue("agility_log_balance") {
-        onCancel = {
-            player.tele(2551, 3546)
-        }
-        player.message("You walk carefully across the slippery log...", ChatType.Filter)
-        player.renderEmote = "rope_balance"
-        player.walkTo(Tile(2550, 3546), noCollision = true, noRun = true)
-        pause(1)
-        if (success) {
-            player.walkTo(Tile(2541, 3546), noCollision = true, noRun = true)
-            pause(9)
-            player.clearRenderEmote()
-            player.exp(Skill.Agility, 13.7)
-            player.message("... and make it safely to the other side.", ChatType.Filter)
-        } else {
-            player.clear("face_entity")
-            player.face(Direction.WEST)
-            player.walkTo(Tile(2545, 3546), noCollision = true, noRun = true)
-            pause(7)
-            player.setAnimation("fall_off_log_left")
-            pause(1)
-            player.message("... but you lose your footing and fall into the water.", ChatType.Filter)
-            player.tele(2545, 3545)
-            player.renderEmote = "tread_water"
-            pause(1)
-            player.walkTo(Tile(2545, 3543), noCollision = true, noRun = true)
-            pause(2)
-            player.message("Something in the water bites you.", ChatType.Filter)
-            player.clearRenderEmote()
-            player.damage(random.nextInt(30, 52))
-        }
-        if (success || Settings["agility.disableFailLapSkip", false]) {
-            player.agilityStage(2)
-        }
+    player.message("You walk carefully across the slippery log...", ChatType.Filter)
+    player.renderEmote = "rope_balance"
+    player.walkTo(Tile(2550, 3546), noCollision = true, noRun = true)
+    delay()
+    if (success) {
+        player.walkTo(Tile(2541, 3546), noCollision = true, noRun = true)
+        delay(9)
+        player.clearRenderEmote()
+        player.exp(Skill.Agility, 13.7)
+        player.message("... and make it safely to the other side.", ChatType.Filter)
+    } else {
+        player.clear("face_entity")
+        player.face(Direction.WEST)
+        player.walkTo(Tile(2545, 3546), noCollision = true, noRun = true)
+        delay(7)
+        player.setAnimation("fall_off_log_left")
+        delay()
+        player.message("... but you lose your footing and fall into the water.", ChatType.Filter)
+        player.tele(2545, 3545)
+        player.renderEmote = "tread_water"
+        delay()
+        player.walkTo(Tile(2545, 3543), noCollision = true, noRun = true)
+        delay(2)
+        player.message("Something in the water bites you.", ChatType.Filter)
+        player.clearRenderEmote()
+        player.damage(random.nextInt(30, 52))
+    }
+    if (success || Settings["agility.disableFailLapSkip", false]) {
+        player.agilityStage(2)
     }
 }
 
 objectOperate("Climb-over", "barbarian_outpost_obstacle_net") {
     player.message("You climb the netting...", ChatType.Filter)
     player.setAnimation("climb_up")
-    player.start("input_delay", 2)
-    player.strongQueue("agility_netting", 2) {
-        player.agilityStage(3)
-        player.tele(2537, player.tile.y.coerceIn(3545, 3546), 1)
-        player.exp(Skill.Agility, 8.2)
-    }
+    delay(2)
+    player.agilityStage(3)
+    player.tele(2537, player.tile.y.coerceIn(3545, 3546), 1)
+    player.exp(Skill.Agility, 8.2)
 }
 
 objectOperate("Walk-across", "barbarian_outpost_balancing_ledge") {
@@ -133,42 +120,38 @@ objectOperate("Walk-across", "barbarian_outpost_balancing_ledge") {
     player.setAnimation("ledge_stand_right")
     val disable = Settings["agility.disableCourseFailure", false]
     val success = disable || Level.success(player.levels.get(Skill.Agility), 93) // 62.1% success rate
-    player.strongQueue("agility_ledge_balance", 1) {
-        onCancel = {
-            player.tele(2536, 3547, 1)
-        }
-        player.renderEmote = "ledge_balance"
-        player.message("You put your foot on the ledge and try to edge across...", ChatType.Filter)
-        if (success) {
-            player.walkTo(Tile(2532, 3547, 1), noCollision = true, noRun = true)
-            pause(5)
-            player.face(Direction.WEST)
-            player.setAnimation("ledge_stand_away_right")
-            player.clearRenderEmote()
-            player.exp(Skill.Agility, 22.0)
-            player.message("You skillfully edge across the gap.", ChatType.Filter)
-        } else {
-            // https://youtu.be/bPFbuMnCx18?si=KJIVXuBftlZ9_Wth&t=47
-            player.walkTo(Tile(2534, 3547, 1), noCollision = true, noRun = true)
-            pause(2)
-            player.face(Direction.WEST)
-            player.setAnimation("fall_off_log_left")
-            pause()
-            player.tele(2534, 3546, 1)
-            player.face(Direction.SOUTH)
-            player.renderEmote = "falling"
-            pause()
-            player.tele(2534, 3546, 0)
-            player.clearRenderEmote()
-            player.damage(50)
-            pause()
-            player.walkTo(Tile(2534, 3545), noCollision = true, noRun = true)
-    //            player.message("", ChatType.Filter) // TODO
-            // Skip stage so lap doesn't count at end
-        }
-        if (success || Settings["agility.disableFailLapSkip", false]) {
-            player.agilityStage(4)
-        }
+    delay()
+    player.renderEmote = "ledge_balance"
+    player.message("You put your foot on the ledge and try to edge across...", ChatType.Filter)
+    if (success) {
+        player.walkTo(Tile(2532, 3547, 1), noCollision = true, noRun = true)
+        delay(5)
+        player.face(Direction.WEST)
+        player.setAnimation("ledge_stand_away_right")
+        player.clearRenderEmote()
+        player.exp(Skill.Agility, 22.0)
+        player.message("You skillfully edge across the gap.", ChatType.Filter)
+    } else {
+        // https://youtu.be/bPFbuMnCx18?si=KJIVXuBftlZ9_Wth&t=47
+        player.walkTo(Tile(2534, 3547, 1), noCollision = true, noRun = true)
+        delay(2)
+        player.face(Direction.WEST)
+        player.setAnimation("fall_off_log_left")
+        delay()
+        player.tele(2534, 3546, 1)
+        player.face(Direction.SOUTH)
+        player.renderEmote = "falling"
+        delay()
+        player.tele(2534, 3546, 0)
+        player.clearRenderEmote()
+        player.damage(50)
+        delay()
+        player.walkTo(Tile(2534, 3545), noCollision = true, noRun = true)
+        //player.message("", ChatType.Filter) // TODO
+    }
+    // Skip stage so lap doesn't count at end
+    if (success || Settings["agility.disableFailLapSkip", false]) {
+        player.agilityStage(4)
     }
 }
 
@@ -177,25 +160,23 @@ objectOperate("Climb-over", "barbarian_outpost_crumbling_wall") {
         player.message("You cannot climb that from this side.")
         return@objectOperate
     }
-    player.strongQueue("agility_wall_climb") {
-        if (player.tile.x == target.tile.x) {
-            player.walkTo(target.tile.addX(-1))
-            pause(2)
-        }
-        player.start("input_delay", 2)
-        player.message("You climb the low wall...", ChatType.Filter)
-        player.setAnimation("climb_over_wall")
-        player.exactMove(target.tile.addX(1), 60, Direction.EAST)
-        pause(1)
-        if (target.tile.equals(2542, 3553)) {
-            if (player.agilityStage == 5) {
-                player.agilityStage = 0
-                player.exp(Skill.Agility, 46.3)
-                player.inc("barbarian_course_laps")
-            }
-        } else {
-            player.agilityStage(5)
-        }
-        player.exp(Skill.Agility, 13.7)
+    if (player.tile.x == target.tile.x) {
+        player.walkTo(target.tile.addX(-1))
+        delay(2)
     }
+    player.message("You climb the low wall...", ChatType.Filter)
+    player.setAnimation("climb_over_wall")
+    player.exactMove(target.tile.addX(1), 60, Direction.EAST)
+    delay()
+    if (target.tile.equals(2542, 3553)) {
+        if (player.agilityStage == 5) {
+            player.agilityStage = 0
+            player.exp(Skill.Agility, 46.3)
+            player.inc("barbarian_course_laps")
+        }
+    } else {
+        player.agilityStage(5)
+    }
+    player.exp(Skill.Agility, 13.7)
+    delay()
 }

--- a/game/src/main/kotlin/world/gregs/voidps/world/activity/skill/agility/course/BarbarianOutpost.kts
+++ b/game/src/main/kotlin/world/gregs/voidps/world/activity/skill/agility/course/BarbarianOutpost.kts
@@ -16,7 +16,6 @@ import world.gregs.voidps.engine.entity.character.player.skill.level.Level
 import world.gregs.voidps.engine.entity.character.player.skill.level.Level.has
 import world.gregs.voidps.engine.entity.character.setAnimation
 import world.gregs.voidps.engine.entity.obj.objectOperate
-import world.gregs.voidps.engine.queue.strongQueue
 import world.gregs.voidps.type.Direction
 import world.gregs.voidps.type.Tile
 import world.gregs.voidps.type.equals
@@ -37,7 +36,7 @@ objectOperate("Squeeze-through", "barbarian_outpost_entrance") {
     }
     player.setAnimation("climb_through_pipe")
     val end = if (player.tile.y >= 3560) 3558 else 3561
-    player.exactMove(Tile(2552, end), 60)
+    player.exactMove(Tile(2552, end), 60, direction = if (player.tile.y >= 3560) Direction.SOUTH else Direction.NORTH)
     delay(2)
 }
 

--- a/game/src/main/kotlin/world/gregs/voidps/world/activity/skill/agility/course/BarbarianOutpost.kts
+++ b/game/src/main/kotlin/world/gregs/voidps/world/activity/skill/agility/course/BarbarianOutpost.kts
@@ -1,7 +1,6 @@
 package world.gregs.voidps.world.activity.skill.agility.course
 
 import world.gregs.voidps.engine.client.message
-import world.gregs.voidps.engine.client.variable.start
 import world.gregs.voidps.engine.data.Settings
 import world.gregs.voidps.engine.entity.character.exactMove
 import world.gregs.voidps.engine.entity.character.face

--- a/game/src/main/kotlin/world/gregs/voidps/world/activity/skill/agility/course/GnomeAdvanced.kts
+++ b/game/src/main/kotlin/world/gregs/voidps/world/activity/skill/agility/course/GnomeAdvanced.kts
@@ -17,7 +17,6 @@ import world.gregs.voidps.engine.entity.character.setAnimation
 import world.gregs.voidps.engine.entity.obj.objectApproach
 import world.gregs.voidps.engine.entity.obj.objectOperate
 import world.gregs.voidps.engine.inject
-import world.gregs.voidps.engine.queue.strongQueue
 import world.gregs.voidps.type.Direction
 import world.gregs.voidps.type.Tile
 import world.gregs.voidps.type.Zone

--- a/game/src/main/kotlin/world/gregs/voidps/world/activity/skill/agility/course/GnomeAdvanced.kts
+++ b/game/src/main/kotlin/world/gregs/voidps/world/activity/skill/agility/course/GnomeAdvanced.kts
@@ -50,31 +50,29 @@ objectApproach("Run-across", "gnome_sign_post_advanced") {
     val success = disable || Level.success(player.levels.get(Skill.Agility), -8..286) // failure rate 4.68-1.17% from 85-88
     player.face(Direction.EAST)
     player.setAnimation("gnome_wall_${if (success) "run" else "fail"}")
-    player.start("input_delay", if (success) 4 else 20)
-    player.strongQueue("agility_wall_run", 1) {
-        if (!success) {
-            onCancel = {
-                player.tele(2484, 3418, 3)
-            }
-            player.exactMove(Tile(2480, 3418, 3), 30, Direction.EAST)
-            pause(6)
+    delay(1)
+    if (!success) {
+        onCancel = {
+            player.tele(2484, 3418, 3)
         }
-        player.exactMove(Tile(2484, 3418, 3), if (success) 60 else 210, Direction.EAST)
-        if (success) {
-            pause(2)
-            player.exp(Skill.Agility, 25.0)
-        } else {
-            pause(10)
-            player.setAnimation("gnome_wall_stand")
-            pause(1)
-            player.damage((player.levels.get(Skill.Constitution) - 10).coerceAtMost(65))
-        }
-        // Skip stage so lap doesn't count at end
-        if (success || Settings["agility.disableFailLapSkip", false]) {
-            player.agilityStage(5)
-        }
-        player.clearAnimation()
+        player.exactMove(Tile(2480, 3418, 3), 30, Direction.EAST)
+        delay(6)
     }
+    player.exactMove(Tile(2484, 3418, 3), if (success) 60 else 210, Direction.EAST)
+    if (success) {
+        delay(2)
+        player.exp(Skill.Agility, 25.0)
+    } else {
+        delay(10)
+        player.setAnimation("gnome_wall_stand")
+        delay()
+        player.damage((player.levels.get(Skill.Constitution) - 10).coerceAtMost(65))
+    }
+    // Skip stage so lap doesn't count at end
+    if (success || Settings["agility.disableFailLapSkip", false]) {
+        player.agilityStage(5)
+    }
+    player.clearAnimation()
 }
 
 objectApproach("Swing-to", "gnome_pole_advanced") {
@@ -84,41 +82,34 @@ objectApproach("Swing-to", "gnome_pole_advanced") {
     }
     player.steps.clear()
     player.face(Direction.NORTH)
-    player.start("input_delay", 14)
-    player.strongQueue("agility_run_up", 1) {
-        onCancel = {
-            player.tele(Tile(2486, 3418, 3))
-        }
-        player.setAnimation("gnome_run_up")
-        player.exactMove(tile.copy(y = 3421), 60, Direction.NORTH)
-        pause(2)
-        player.setAnimation("gnome_jump")
-        player.exactMove(tile.copy(y = 3425), 30, Direction.NORTH)
-        pause(1)
-        player.setAnimation("gnome_swing")
-        pause(4)
-        player.exactMove(tile.copy(y = 3429), 30, Direction.NORTH)
-        pause(5)
-        player.exactMove(tile.copy(y = 3432), 30, Direction.NORTH)
-        delay(2)
-        player.agilityStage(6)
-        player.exp(Skill.Agility, 25.0)
-    }
+    delay()
+    player.setAnimation("gnome_run_up")
+    player.exactMove(tile.copy(y = 3421), 60, Direction.NORTH)
+    delay(2)
+    player.setAnimation("gnome_jump")
+    player.exactMove(tile.copy(y = 3425), 30, Direction.NORTH)
+    delay(1)
+    player.setAnimation("gnome_swing")
+    delay(4)
+    player.exactMove(tile.copy(y = 3429), 30, Direction.NORTH)
+    delay(5)
+    player.exactMove(tile.copy(y = 3432), 30, Direction.NORTH)
+    delay(2)
+    player.agilityStage(6)
+    player.exp(Skill.Agility, 25.0)
 }
 
 objectOperate("Jump-over", "gnome_barrier_advanced") {
     player.setAnimation("gnome_jump_barrier")
-    player.start("input_delay", 4)
-    player.strongQueue("agility_branch", 1) {
-        player.exactMove(Tile(2485, 3434, 3), 30, Direction.NORTH)
-        pause(2)
-        player.tele(2485, 3436, 0)
-        player.setAnimation("gnome_pipe_land")
-        if (player.agilityStage == 6) {
-            player.agilityStage = 0
-            player.inc("gnome_course_advanced_laps")
-            player.exp(Skill.Agility, 605.0)
-        }
-        player.exp(Skill.Agility, 25.0)
+    delay()
+    player.exactMove(Tile(2485, 3434, 3), 30, Direction.NORTH)
+    delay(2)
+    player.tele(2485, 3436, 0)
+    player.setAnimation("gnome_pipe_land")
+    if (player.agilityStage == 6) {
+        player.agilityStage = 0
+        player.inc("gnome_course_advanced_laps")
+        player.exp(Skill.Agility, 605.0)
     }
+    player.exp(Skill.Agility, 25.0)
 }

--- a/game/src/main/kotlin/world/gregs/voidps/world/activity/skill/agility/course/GnomeAdvanced.kts
+++ b/game/src/main/kotlin/world/gregs/voidps/world/activity/skill/agility/course/GnomeAdvanced.kts
@@ -1,7 +1,6 @@
 package world.gregs.voidps.world.activity.skill.agility.course
 
 import world.gregs.voidps.engine.client.message
-import world.gregs.voidps.engine.client.variable.start
 import world.gregs.voidps.engine.data.Settings
 import world.gregs.voidps.engine.entity.character.clearAnimation
 import world.gregs.voidps.engine.entity.character.exactMove

--- a/game/src/main/kotlin/world/gregs/voidps/world/activity/skill/agility/course/GnomeAdvanced.kts
+++ b/game/src/main/kotlin/world/gregs/voidps/world/activity/skill/agility/course/GnomeAdvanced.kts
@@ -50,9 +50,6 @@ objectApproach("Run-across", "gnome_sign_post_advanced") {
     player.setAnimation("gnome_wall_${if (success) "run" else "fail"}")
     delay(1)
     if (!success) {
-        onCancel = {
-            player.tele(2484, 3418, 3)
-        }
         player.exactMove(Tile(2480, 3418, 3), 30, Direction.EAST)
         delay(6)
     }

--- a/game/src/main/kotlin/world/gregs/voidps/world/activity/skill/agility/course/GnomeStronghold.kts
+++ b/game/src/main/kotlin/world/gregs/voidps/world/activity/skill/agility/course/GnomeStronghold.kts
@@ -36,6 +36,7 @@ objectOperate("Walk-across", "gnome_log_balance") {
 }
 
 objectOperate("Climb-over", "gnome_obstacle_net") {
+    arriveDelay()
     player.agilityCourse("gnome")
     npcs.gnomeTrainer("Move it, move it, move it!", listOf(Zone(8768252), Zone(876853)))
     player.message("You climb the netting...", ChatType.Filter)
@@ -62,36 +63,30 @@ objectOperate("Climb", "gnome_tree_branch_up") {
 objectOperate("Walk-on", "gnome_balancing_rope") {
     npcs.gnomeTrainer("Come on scaredy cat, get across that rope!", Zone(9263413))
     player.walkTo(Tile(2483, 3420, 2), noCollision = true, noRun = true)
-    player.start("input_delay", 7)
     player.renderEmote = "rope_balance"
-    player.strongQueue("agility_rope_balance", 7) {
-        player.agilityStage(4)
-        player.clearRenderEmote()
-        player.exp(Skill.Agility, 7.5)
-        player.message("You passed the obstacle successfully.", ChatType.Filter)
-    }
+    delay(7)
+    player.agilityStage(4)
+    player.clearRenderEmote()
+    player.exp(Skill.Agility, 7.5)
+    player.message("You passed the obstacle successfully.", ChatType.Filter)
 }
 
 objectOperate("Walk-on", "gnome_balancing_rope_end") {
     player.walkTo(Tile(2477, 3420, 2), noCollision = true, noRun = true)
-    player.start("input_delay", 7)
     player.renderEmote = "rope_balance"
-    player.strongQueue("agility_rope_balance", 7) {
-        player.clearRenderEmote()
-        player.exp(Skill.Agility, 7.5)
-        player.message("You passed the obstacle successfully.", ChatType.Filter)
-    }
+    delay(7)
+    player.clearRenderEmote()
+    player.exp(Skill.Agility, 7.5)
+    player.message("You passed the obstacle successfully.", ChatType.Filter)
 }
 
 objectOperate("Climb-down", "gnome_tree_branch_down") {
     player.message("You climb the tree...", ChatType.Filter)
     player.setAnimation("climb_down")
-    player.start("input_delay", 2)
-    player.strongQueue("branch", 2) {
-        player.agilityStage(5)
-        player.tele(2486, 3420, 0)
-        player.exp(Skill.Agility, 5.0)
-    }
+    delay(2)
+    player.agilityStage(5)
+    player.tele(2486, 3420, 0)
+    player.exp(Skill.Agility, 5.0)
 }
 
 objectOperate("Climb-over", "gnome_obstacle_net_free_standing") {
@@ -99,13 +94,11 @@ objectOperate("Climb-over", "gnome_obstacle_net_free_standing") {
     npcs.gnomeTrainer("My Granny can move faster than you.", Zone(876854))
     player.message("You climb the netting.", ChatType.Filter)
     player.setAnimation("climb_up")
-    player.start("input_delay", 2)
-    player.strongQueue("agility_netting", 2) {
-        player.agilityStage(6)
-        val direction = target.tile.delta(player.tile).toDirection().vertical()
-        player.tele(player.tile.add(direction.delta).add(direction.delta))
-        player.exp(Skill.Agility, 7.5)
-    }
+    delay(2)
+    player.agilityStage(6)
+    val direction = target.tile.delta(player.tile).toDirection().vertical()
+    player.tele(player.tile.add(direction.delta).add(direction.delta))
+    player.exp(Skill.Agility, 7.5)
 }
 
 objectOperate("Squeeze-through", "gnome_obstacle_pipe_*") {

--- a/game/src/main/kotlin/world/gregs/voidps/world/activity/skill/agility/course/GnomeStronghold.kts
+++ b/game/src/main/kotlin/world/gregs/voidps/world/activity/skill/agility/course/GnomeStronghold.kts
@@ -15,7 +15,6 @@ import world.gregs.voidps.engine.entity.character.player.skill.exp.exp
 import world.gregs.voidps.engine.entity.character.setAnimation
 import world.gregs.voidps.engine.entity.obj.objectOperate
 import world.gregs.voidps.engine.inject
-import world.gregs.voidps.engine.queue.strongQueue
 import world.gregs.voidps.type.Direction
 import world.gregs.voidps.type.Tile
 import world.gregs.voidps.type.Zone

--- a/game/src/main/kotlin/world/gregs/voidps/world/activity/skill/agility/course/GnomeStronghold.kts
+++ b/game/src/main/kotlin/world/gregs/voidps/world/activity/skill/agility/course/GnomeStronghold.kts
@@ -51,13 +51,11 @@ objectOperate("Climb", "gnome_tree_branch_up") {
     npcs.gnomeTrainer("That's it - straight up", listOf(Zone(5069109), Zone(5071157)))
     player.message("You climb the tree...", ChatType.Filter)
     player.setAnimation("climb_up")
-    player.start("input_delay", 2)
-    player.strongQueue("agility_branch", 2) {
-        player.message("... to the platform above.", ChatType.Filter)
-        player.agilityStage(3)
-        player.tele(2473, 3420, 2)
-        player.exp(Skill.Agility, 5.0)
-    }
+    delay(2)
+    player.message("... to the platform above.", ChatType.Filter)
+    player.agilityStage(3)
+    player.tele(2473, 3420, 2)
+    player.exp(Skill.Agility, 5.0)
 }
 
 objectOperate("Walk-on", "gnome_balancing_rope") {

--- a/game/src/main/kotlin/world/gregs/voidps/world/activity/skill/agility/course/GnomeStronghold.kts
+++ b/game/src/main/kotlin/world/gregs/voidps/world/activity/skill/agility/course/GnomeStronghold.kts
@@ -1,7 +1,6 @@
 package world.gregs.voidps.world.activity.skill.agility.course
 
 import world.gregs.voidps.engine.client.message
-import world.gregs.voidps.engine.client.variable.start
 import world.gregs.voidps.engine.entity.character.exactMove
 import world.gregs.voidps.engine.entity.character.face
 import world.gregs.voidps.engine.entity.character.move.tele

--- a/game/src/main/kotlin/world/gregs/voidps/world/activity/skill/agility/course/GnomeStronghold.kts
+++ b/game/src/main/kotlin/world/gregs/voidps/world/activity/skill/agility/course/GnomeStronghold.kts
@@ -24,21 +24,15 @@ val npcs: NPCs by inject()
 
 objectOperate("Walk-across", "gnome_log_balance") {
     player.agilityCourse("gnome")
-    player.start("input_delay", 8)
-    player.strongQueue("agility_log_balance") {
-        onCancel = {
-            player.tele(2474, 3436)
-        }
-        npcs.gnomeTrainer("Okay get over that log, quick quick!", listOf(Zone(878901), Zone(878900), Zone(876852)))
-        player.renderEmote = "rope_balance"
-        player.walkTo(Tile(2474, 3429), noCollision = true, noRun = true)
-        player.message("You walk carefully across the slippery log...", ChatType.Filter)
-        pause(8)
-        player.clearRenderEmote()
-        player.agilityStage(1)
-        player.exp(Skill.Agility, 7.5)
-        player.message("... and make it safely to the other side.", ChatType.Filter)
-    }
+    npcs.gnomeTrainer("Okay get over that log, quick quick!", listOf(Zone(878901), Zone(878900), Zone(876852)))
+    player.renderEmote = "rope_balance"
+    player.walkTo(Tile(2474, 3429), noCollision = true, noRun = true)
+    player.message("You walk carefully across the slippery log...", ChatType.Filter)
+    delay(8)
+    player.clearRenderEmote()
+    player.agilityStage(1)
+    player.exp(Skill.Agility, 7.5)
+    player.message("... and make it safely to the other side.", ChatType.Filter)
 }
 
 objectOperate("Climb-over", "gnome_obstacle_net") {
@@ -46,12 +40,10 @@ objectOperate("Climb-over", "gnome_obstacle_net") {
     npcs.gnomeTrainer("Move it, move it, move it!", listOf(Zone(8768252), Zone(876853)))
     player.message("You climb the netting...", ChatType.Filter)
     player.setAnimation("climb_up")
-    player.start("input_delay", 2)
-    player.strongQueue("agility_netting", 2) {
-        player.agilityStage(2)
-        player.tele(player.tile.x.coerceIn(2471, 2476), 3424, 1)
-        player.exp(Skill.Agility, 7.5)
-    }
+    delay(2)
+    player.agilityStage(2)
+    player.tele(player.tile.x.coerceIn(2471, 2476), 3424, 1)
+    player.exp(Skill.Agility, 7.5)
 }
 
 objectOperate("Climb", "gnome_tree_branch_up") {
@@ -118,27 +110,22 @@ objectOperate("Climb-over", "gnome_obstacle_net_free_standing") {
 
 objectOperate("Squeeze-through", "gnome_obstacle_pipe_*") {
     player.agilityCourse("gnome")
-    player.strongQueue("agility_obstacle_pipe", 1) {
-        onCancel = {
-            player.tele(target.tile.addY(-1))
-        }
-        player.start("input_delay", 8)
-        player.face(Direction.NORTH)
-        player.message("You pull yourself through the pipes..", ChatType.Filter)
-        pause()
-        player.setAnimation("climb_through_pipe")
-        player.exactMove(target.tile.addY(2))
-        pause(4)
-        player.face(Direction.NORTH)
-        player.tele(target.tile.addY(3))
-        player.setAnimation("climb_through_pipe", delay = 1)
-        player.exactMove(target.tile.addY(6))
-        pause(2)
-        if (player.agilityStage == 6) {
-            player.agilityStage = 0
-            player.inc("gnome_course_laps")
-            player.exp(Skill.Agility, 39.0)
-        }
-        player.exp(Skill.Agility, 7.5)
+    delay()
+    player.face(Direction.NORTH)
+    player.message("You pull yourself through the pipes..", ChatType.Filter)
+    delay()
+    player.setAnimation("climb_through_pipe")
+    player.exactMove(target.tile.addY(2))
+    delay(4)
+    player.face(Direction.NORTH)
+    player.tele(target.tile.addY(3))
+    player.setAnimation("climb_through_pipe", delay = 1)
+    player.exactMove(target.tile.addY(6))
+    delay(2)
+    if (player.agilityStage == 6) {
+        player.agilityStage = 0
+        player.inc("gnome_course_laps")
+        player.exp(Skill.Agility, 39.0)
     }
+    player.exp(Skill.Agility, 7.5)
 }

--- a/game/src/main/kotlin/world/gregs/voidps/world/activity/skill/agility/course/WildernessCourse.kts
+++ b/game/src/main/kotlin/world/gregs/voidps/world/activity/skill/agility/course/WildernessCourse.kts
@@ -80,41 +80,35 @@ objectOperate("Open", "wilderness_agility_gate_east_closed", "wilderness_agility
     }
     val disable = Settings["agility.disableCourseFailure", false]
     val success = disable || Level.success(player.levels.get(Skill.Agility), 200..250)
-    player.strongQueue("course_exit") {
-        onCancel = {
-            player.tele(target.tile.addY(1))
-        }
-        player.start("input_delay", if (success) 16 else 10)
-        player.message("You go through the gate and try to edge over the ridge...", ChatType.Filter)
-        Door.enter(player, target)
-        pause(if (target.id.endsWith("west_closed")) 2 else 1)
-        player.renderEmote = "beam_balance"
-        if (!success) {
-            fallIntoPit()
-            return@strongQueue
-        }
-        player.walkTo(Tile(2998, 3917), noCollision = true, noRun = true)
-        pause(13)
-        player.clearRenderEmote()
-        val door = objects[Tile(2998, 3917), "wilderness_agility_door_closed"]
-        if (door != null) {
-            Door.enter(player, door)
-        } else {
-            player.walkTo(Tile(2998, 3916), noCollision = true, noRun = true)
-        }
-        player.message("You skillfully balance across the ridge...", ChatType.Filter)
-        player.exp(Skill.Agility, 15.0)
+    player.message("You go through the gate and try to edge over the ridge...", ChatType.Filter)
+    Door.enter(player, target)
+    delay(if (target.id.endsWith("west_closed")) 2 else 1)
+    player.renderEmote = "beam_balance"
+    if (!success) {
+        fallIntoPit()
+        return@objectOperate
     }
+    player.walkTo(Tile(2998, 3917), noCollision = true, noRun = true)
+    delay(13)
+    player.clearRenderEmote()
+    val door = objects[Tile(2998, 3917), "wilderness_agility_door_closed"]
+    if (door != null) {
+        Door.enter(player, door)
+    } else {
+        player.walkTo(Tile(2998, 3916), noCollision = true, noRun = true)
+    }
+    player.message("You skillfully balance across the ridge...", ChatType.Filter)
+    player.exp(Skill.Agility, 15.0)
 }
 
 suspend fun SuspendableContext<Player>.fallIntoPit() {
     player.walkTo(Tile(2998, 3924), noCollision = true, noRun = true)
-    pause(7)
+    delay(7)
     player.clearRenderEmote()
     player.face(Direction.NORTH)
     player.setAnimation("rope_walk_fall_down")
     player.message("You lose your footing and fall into the wolf pit.", ChatType.Filter)
-    pause()
+    delay()
     player.exactMove(Tile(3001, 3923), 25, Direction.SOUTH)
 }
 
@@ -123,27 +117,21 @@ objectOperate("Squeeze-through", "wilderness_obstacle_pipe") {
         player.message("You can't enter the pipe from this side.")
         return@objectOperate
     }
-    player.strongQueue("wilderness_pipe") {
-        onCancel = {
-            player.tele(target.tile.addY(-1))
-        }
-        if (player.tile.y == 3938) {
-            player.start("input_delay", 2)
-            player.walkTo(target.tile.addY(-1))
-            pause(2)
-        }
-        player.start("input_delay", 8)
-        player.setAnimation("climb_through_pipe", delay = 30)
-        player.exactMove(Tile(3004, 3940), startDelay = 30, delay = 96, direction = Direction.NORTH)
-        pause(4)
-        player.tele(3004, 3947)
-        pause()
-        player.setAnimation("climb_through_pipe", delay = 30)
-        player.exactMove(Tile(3004, 3950), startDelay = 30, delay = 96, direction = Direction.NORTH)
-        pause(3)
-        player.exp(Skill.Agility, 12.5)
-        player.agilityStage(1)
+    if (player.tile.y == 3938) {
+        player.start("input_delay", 2)
+        player.walkTo(target.tile.addY(-1))
+        delay(2)
     }
+    player.setAnimation("climb_through_pipe", delay = 30)
+    player.exactMove(Tile(3004, 3940), startDelay = 30, delay = 96, direction = Direction.NORTH)
+    delay(4)
+    player.tele(3004, 3947)
+    delay()
+    player.setAnimation("climb_through_pipe", delay = 30)
+    player.exactMove(Tile(3004, 3950), startDelay = 30, delay = 96, direction = Direction.NORTH)
+    delay(3)
+    player.exp(Skill.Agility, 12.5)
+    player.agilityStage(1)
 }
 
 objectOperate("Swing-on", "wilderness_rope_swing") {
@@ -152,55 +140,46 @@ objectOperate("Swing-on", "wilderness_rope_swing") {
     player.face(Direction.NORTH)
     val disable = Settings["agility.disableCourseFailure", false]
     val success = disable || Level.success(player.levels.get(Skill.Agility), 200..250)
-    player.start("input_delay", if (success) 5 else 8)
-    player.strongQueue("wilderness_rope_swing", 2) {
-        player.setAnimation("rope_swing")
-        target.animate("swing_rope")
-        pause()
-        if (success) {
-            player.exactMove(player.tile.copy(y = 3958), 60, Direction.NORTH)
-            pause()
-            player.exp(Skill.Agility, 20.0)
-            player.message("You skillfully swing across.", ChatType.Filter)
-        } else {
-            player.exactMove(player.tile.copy(y = 3957), 50, Direction.NORTH)
-            pause(2)
-            player.tele(3004, 10357)
-            player.damage((player.levels.get(Skill.Constitution) * 0.15).toInt() + 10)
-            player.message("You slip and fall to the pit below.", ChatType.Filter)
-        }
-        if (success || Settings["agility.disableFailLapSkip", false]) {
-            player.agilityStage(2)
-        }
+    delay(2)
+    player.setAnimation("rope_swing")
+    target.animate("swing_rope")
+    delay()
+    if (success) {
+        player.exactMove(player.tile.copy(y = 3958), 60, Direction.NORTH)
+        delay()
+        player.exp(Skill.Agility, 20.0)
+        player.message("You skillfully swing across.", ChatType.Filter)
+    } else {
+        player.exactMove(player.tile.copy(y = 3957), 50, Direction.NORTH)
+        delay(2)
+        player.tele(3004, 10357)
+        player.damage((player.levels.get(Skill.Constitution) * 0.15).toInt() + 10)
+        player.message("You slip and fall to the pit below.", ChatType.Filter)
+    }
+    if (success || Settings["agility.disableFailLapSkip", false]) {
+        player.agilityStage(2)
     }
 }
 
 objectOperate("Cross", "wilderness_stepping_stone") {
     player.message("You carefully start crossing the stepping stones...", ChatType.Filter)
-    player.start("input_delay", 12)
-    player.strongQueue("agility_stepping_stones") {
-        onCancel = {
-            player.tele(3002, 3960)
-        }
-        for (i in 0..5) {
-            player.setAnimation("stepping_stone_jump")
-            player.playSound("jump")
-            player.exactMove(target.tile.addX(-i), delay = 30, direction = Direction.WEST, startDelay = 15)
-            pause(2)
-            if (i == 2 && !Settings["agility.disableCourseFailure", false] && !Level.success(player.levels.get(Skill.Agility), 180..250)) {
-                player.start("input_delay", 3)
-                player.setAnimation("rope_walk_fall_down")
-                player.face(Direction.WEST)
-                player.clearRenderEmote()
-                player.message("...You lose your footing and fall into the lava.", ChatType.Filter)
-                pause(2)
-                player.damage(player.levels.get(Skill.Constitution) / 5 + 10)
-                player.tele(3002, 3963)
-                if (Settings["agility.disableFailLapSkip", false]) {
-                    player.agilityStage(3)
-                }
-                return@strongQueue
+    for (i in 0..5) {
+        player.setAnimation("stepping_stone_jump")
+        player.playSound("jump")
+        player.exactMove(target.tile.addX(-i), delay = 30, direction = Direction.WEST, startDelay = 15)
+        delay(2)
+        if (i == 2 && !Settings["agility.disableCourseFailure", false] && !Level.success(player.levels.get(Skill.Agility), 180..250)) {
+            player.setAnimation("rope_walk_fall_down")
+            player.face(Direction.WEST)
+            player.clearRenderEmote()
+            player.message("...You lose your footing and fall into the lava.", ChatType.Filter)
+            delay(2)
+            player.damage(player.levels.get(Skill.Constitution) / 5 + 10)
+            player.tele(3002, 3963)
+            if (Settings["agility.disableFailLapSkip", false]) {
+                player.agilityStage(3)
             }
+            return@objectOperate
         }
         player.message("...You safely cross to the other side.", ChatType.Filter)
         player.exp(Skill.Agility, 20.0)
@@ -209,67 +188,54 @@ objectOperate("Cross", "wilderness_stepping_stone") {
 }
 
 objectOperate("Walk-across", "wilderness_log_balance") {
-    player.strongQueue("agility_log") {
-        onCancel = {
-            player.tele(3001, 3946)
-        }
-        player.message("You walk carefully across the slippery log...", ChatType.Filter)
-        val disable = Settings["agility.disableCourseFailure", false]
-        val success = disable || Level.success(player.levels.get(Skill.Agility), 200..250)
-        if (success) {
-            player.start("input_delay", 10)
-            player.walkTo(target.tile, noCollision = true, noRun = true)
-            pause()
-            player.renderEmote = "beam_balance"
-            player.walkTo(Tile(2994, 3945), noCollision = true, noRun = true)
-            pause(7)
-            player.message("You skillfully edge across the gap.", type = ChatType.Filter)
-            player.clearRenderEmote()
-            pause()
-            player.exp(Skill.Agility, 20.0)
-            player.agilityStage(4)
-        } else {
-            player.start("input_delay", 9)
-            player.walkTo(target.tile, noCollision = true, noRun = true)
-            pause()
-            player.renderEmote = "beam_balance"
-            player.walkTo(Tile(2998, 3945), noCollision = true, noRun = true)
-            pause(4)
-            player.message("You slip and fall onto the spikes below.", type = ChatType.Filter)
-            player.setAnimation("rope_walk_fall_down")
-            player.face(Direction.NORTH)
-            pause()
-            player.tele(2998, 10346)
-            player.clearRenderEmote()
-            player.playSound("2h_stab")
-            pause()
-            player.walkTo(Tile(2998, 10345))
-            pause()
-            player.damage((player.levels.get(Skill.Constitution) * 0.15).toInt() + 10)
-            player.playSound("male_hit_1", delay = 20)
-        }
-        if (success || Settings["agility.disableFailLapSkip", false]) {
-            player.agilityStage(4)
-        }
+    player.message("You walk carefully across the slippery log...", ChatType.Filter)
+    val disable = Settings["agility.disableCourseFailure", false]
+    val success = disable || Level.success(player.levels.get(Skill.Agility), 200..250)
+    if (success) {
+        player.walkTo(target.tile, noCollision = true, noRun = true)
+        delay()
+        player.renderEmote = "beam_balance"
+        player.walkTo(Tile(2994, 3945), noCollision = true, noRun = true)
+        delay(7)
+        player.message("You skillfully edge across the gap.", type = ChatType.Filter)
+        player.clearRenderEmote()
+        delay()
+        player.exp(Skill.Agility, 20.0)
+        player.agilityStage(4)
+    } else {
+        player.walkTo(target.tile, noCollision = true, noRun = true)
+        delay()
+        player.renderEmote = "beam_balance"
+        player.walkTo(Tile(2998, 3945), noCollision = true, noRun = true)
+        delay(4)
+        player.message("You slip and fall onto the spikes below.", type = ChatType.Filter)
+        player.setAnimation("rope_walk_fall_down")
+        player.face(Direction.NORTH)
+        delay()
+        player.tele(2998, 10346)
+        player.clearRenderEmote()
+        player.playSound("2h_stab")
+        delay()
+        player.walkTo(Tile(2998, 10345))
+        delay()
+        player.damage((player.levels.get(Skill.Constitution) * 0.15).toInt() + 10)
+        player.playSound("male_hit_1", delay = 20)
+    }
+    if (success || Settings["agility.disableFailLapSkip", false]) {
+        player.agilityStage(4)
     }
 }
 
 objectOperate("Climb", "wilderness_agility_rocks") {
-    player.start("input_delay", 5)
-    player.strongQueue("agility_rocks") {
-        onCancel = {
-            player.tele(2993, 3937)
-        }
-        player.message("You walk carefully across the slippery log...", ChatType.Filter)
-        player.renderEmote = "climbing"
-        player.walkTo(player.tile.copy(y = 3933), noCollision = true, noRun = true)
-        pause(4)
-        player.clearRenderEmote()
-        player.message("You reach the top.", type = ChatType.Filter)
-        if (player.agilityStage == 4) {
-            player.agilityStage = 0
-            player.exp(Skill.Agility, 499.0)
-            player.inc("wilderness_course_laps")
-        }
+    player.message("You walk carefully across the slippery log...", ChatType.Filter)
+    player.renderEmote = "climbing"
+    player.walkTo(player.tile.copy(y = 3933), noCollision = true, noRun = true)
+    delay(4)
+    player.clearRenderEmote()
+    player.message("You reach the top.", type = ChatType.Filter)
+    if (player.agilityStage == 4) {
+        player.agilityStage = 0
+        player.exp(Skill.Agility, 499.0)
+        player.inc("wilderness_course_laps")
     }
 }

--- a/game/src/main/kotlin/world/gregs/voidps/world/activity/skill/agility/course/WildernessCourse.kts
+++ b/game/src/main/kotlin/world/gregs/voidps/world/activity/skill/agility/course/WildernessCourse.kts
@@ -24,6 +24,7 @@ import world.gregs.voidps.type.Tile
 import world.gregs.voidps.type.equals
 import world.gregs.voidps.world.interact.entity.combat.hit.damage
 import world.gregs.voidps.world.interact.entity.obj.door.Door
+import world.gregs.voidps.world.interact.entity.obj.door.enterDoor
 import world.gregs.voidps.world.interact.entity.sound.playSound
 
 val objects: GameObjects by inject()
@@ -34,7 +35,7 @@ objectOperate("Open", "wilderness_agility_door_closed") {
         return@objectOperate
     }
     if (player.tile.y > 3916) {
-        Door.enter(player, target)
+        enterDoor(target, delay = 2)
         player.clearRenderEmote()
         return@objectOperate
     }
@@ -42,8 +43,7 @@ objectOperate("Open", "wilderness_agility_door_closed") {
 //    val disable = Settings["agility.disableCourseFailure", false]
     val success = true//disable || Level.success(player.levels.get(Skill.Agility), 200..250)
     player.message("You go through the gate and try to edge over the ridge...", ChatType.Filter)
-    Door.enter(player, target)
-    delay()
+    enterDoor(target, delay = 1)
     player.renderEmote = "beam_balance"
 //    if (!success) {
 //        fallIntoPit()
@@ -55,7 +55,7 @@ objectOperate("Open", "wilderness_agility_door_closed") {
     val gateTile = Tile(2998, 3931)
     val gate = objects[gateTile, "wilderness_agility_gate_east_closed"]
     if (gate != null) {
-        Door.enter(player, gate)
+        enterDoor(gate, delay = 1)
     } else {
         player.walkTo(gateTile, noCollision = true, noRun = true)
     }
@@ -66,15 +66,14 @@ objectOperate("Open", "wilderness_agility_door_closed") {
 
 objectOperate("Open", "wilderness_agility_gate_east_closed", "wilderness_agility_gate_west_closed") {
     if (player.tile.y < 3931) {
-        Door.enter(player, target)
+        enterDoor(target, delay = 2)
         player.clearRenderEmote()
         return@objectOperate
     }
     val disable = Settings["agility.disableCourseFailure", false]
     val success = disable || Level.success(player.levels.get(Skill.Agility), 200..250)
     player.message("You go through the gate and try to edge over the ridge...", ChatType.Filter)
-    Door.enter(player, target)
-    delay(if (target.id.endsWith("west_closed")) 2 else 1)
+    enterDoor(target, delay = if (target.id.endsWith("west_closed")) 2 else 1)
     player.renderEmote = "beam_balance"
     if (!success) {
         fallIntoPit()
@@ -85,7 +84,7 @@ objectOperate("Open", "wilderness_agility_gate_east_closed", "wilderness_agility
     player.clearRenderEmote()
     val door = objects[Tile(2998, 3917), "wilderness_agility_door_closed"]
     if (door != null) {
-        Door.enter(player, door)
+        enterDoor(door, delay = 1)
     } else {
         player.walkTo(Tile(2998, 3916), noCollision = true, noRun = true)
     }

--- a/game/src/main/kotlin/world/gregs/voidps/world/activity/skill/agility/course/WildernessCourse.kts
+++ b/game/src/main/kotlin/world/gregs/voidps/world/activity/skill/agility/course/WildernessCourse.kts
@@ -23,7 +23,6 @@ import world.gregs.voidps.type.Direction
 import world.gregs.voidps.type.Tile
 import world.gregs.voidps.type.equals
 import world.gregs.voidps.world.interact.entity.combat.hit.damage
-import world.gregs.voidps.world.interact.entity.obj.door.Door
 import world.gregs.voidps.world.interact.entity.obj.door.enterDoor
 import world.gregs.voidps.world.interact.entity.sound.playSound
 

--- a/game/src/main/kotlin/world/gregs/voidps/world/activity/skill/agility/course/WildernessCourse.kts
+++ b/game/src/main/kotlin/world/gregs/voidps/world/activity/skill/agility/course/WildernessCourse.kts
@@ -1,7 +1,6 @@
 package world.gregs.voidps.world.activity.skill.agility.course
 
 import world.gregs.voidps.engine.client.message
-import world.gregs.voidps.engine.client.variable.start
 import world.gregs.voidps.engine.data.Settings
 import world.gregs.voidps.engine.entity.character.exactMove
 import world.gregs.voidps.engine.entity.character.face
@@ -19,7 +18,6 @@ import world.gregs.voidps.engine.entity.character.setAnimation
 import world.gregs.voidps.engine.entity.obj.GameObjects
 import world.gregs.voidps.engine.entity.obj.objectOperate
 import world.gregs.voidps.engine.inject
-import world.gregs.voidps.engine.queue.strongQueue
 import world.gregs.voidps.engine.suspend.SuspendableContext
 import world.gregs.voidps.type.Direction
 import world.gregs.voidps.type.Tile
@@ -43,33 +41,27 @@ objectOperate("Open", "wilderness_agility_door_closed") {
     // Not sure if you can fail going up
 //    val disable = Settings["agility.disableCourseFailure", false]
     val success = true//disable || Level.success(player.levels.get(Skill.Agility), 200..250)
-    player.strongQueue("course_enter") {
-        onCancel = {
-            player.tele(target.tile.addY(-1))
-        }
-        player.start("input_delay", if (success) 16 else 8)
-        player.message("You go through the gate and try to edge over the ridge...", ChatType.Filter)
-        Door.enter(player, target)
-        pause()
-        player.renderEmote = "beam_balance"
-//        if (!success) {
-//            fallIntoPit()
-//            return@strongQueue
-//        }
-        player.walkTo(Tile(2998, 3930), noCollision = true, noRun = true)
-        pause(13)
-        player.clearRenderEmote()
-        val gateTile = Tile(2998, 3931)
-        val gate = objects[gateTile, "wilderness_agility_gate_east_closed"]
-        if (gate != null) {
-            Door.enter(player, gate)
-        } else {
-            player.walkTo(gateTile, noCollision = true, noRun = true)
-        }
-        player.message("You skillfully balance across the ridge...", ChatType.Filter)
-        player.exp(Skill.Agility, 15.0)
-        player.agilityCourse("wilderness")
+    player.message("You go through the gate and try to edge over the ridge...", ChatType.Filter)
+    Door.enter(player, target)
+    delay()
+    player.renderEmote = "beam_balance"
+//    if (!success) {
+//        fallIntoPit()
+//        return@strongQueue
+//    }
+    player.walkTo(Tile(2998, 3930), noCollision = true, noRun = true)
+    delay(13)
+    player.clearRenderEmote()
+    val gateTile = Tile(2998, 3931)
+    val gate = objects[gateTile, "wilderness_agility_gate_east_closed"]
+    if (gate != null) {
+        Door.enter(player, gate)
+    } else {
+        player.walkTo(gateTile, noCollision = true, noRun = true)
     }
+    player.message("You skillfully balance across the ridge...", ChatType.Filter)
+    player.exp(Skill.Agility, 15.0)
+    player.agilityCourse("wilderness")
 }
 
 objectOperate("Open", "wilderness_agility_gate_east_closed", "wilderness_agility_gate_west_closed") {
@@ -89,7 +81,7 @@ objectOperate("Open", "wilderness_agility_gate_east_closed", "wilderness_agility
         return@objectOperate
     }
     player.walkTo(Tile(2998, 3917), noCollision = true, noRun = true)
-    delay(13)
+    delay(14)
     player.clearRenderEmote()
     val door = objects[Tile(2998, 3917), "wilderness_agility_door_closed"]
     if (door != null) {
@@ -118,7 +110,6 @@ objectOperate("Squeeze-through", "wilderness_obstacle_pipe") {
         return@objectOperate
     }
     if (player.tile.y == 3938) {
-        player.start("input_delay", 2)
         player.walkTo(target.tile.addY(-1))
         delay(2)
     }
@@ -181,10 +172,10 @@ objectOperate("Cross", "wilderness_stepping_stone") {
             }
             return@objectOperate
         }
-        player.message("...You safely cross to the other side.", ChatType.Filter)
-        player.exp(Skill.Agility, 20.0)
-        player.agilityStage(3)
     }
+    player.message("...You safely cross to the other side.", ChatType.Filter)
+    player.exp(Skill.Agility, 20.0)
+    player.agilityStage(3)
 }
 
 objectOperate("Walk-across", "wilderness_log_balance") {

--- a/game/src/main/kotlin/world/gregs/voidps/world/activity/skill/cooking/Filling.kts
+++ b/game/src/main/kotlin/world/gregs/voidps/world/activity/skill/cooking/Filling.kts
@@ -11,7 +11,7 @@ itemOnObjectOperate(objects = setOf("sink*", "fountain*", "well*", "water_trough
     while (player.inventory.contains(item.id)) {
         player.setAnimation("take")
         player.inventory.replace(item.id, item.def["full"])
-        pause(if (item.id == "vase") 3 else 1)
+        delay(if (item.id == "vase") 3 else 1)
         player.message("You fill the ${item.def.name.substringBefore(" (").lowercase()} from the ${target.def.name.lowercase()}", ChatType.Filter)
     }
 }

--- a/game/src/main/kotlin/world/gregs/voidps/world/activity/skill/mining/Mining.kts
+++ b/game/src/main/kotlin/world/gregs/voidps/world/activity/skill/mining/Mining.kts
@@ -28,7 +28,6 @@ import world.gregs.voidps.engine.entity.obj.objectOperate
 import world.gregs.voidps.engine.inject
 import world.gregs.voidps.engine.inv.add
 import world.gregs.voidps.engine.inv.inventory
-import world.gregs.voidps.engine.queue.softQueue
 import world.gregs.voidps.network.login.protocol.visual.update.player.EquipSlot
 import world.gregs.voidps.type.random
 import world.gregs.voidps.world.activity.bank.bank
@@ -134,7 +133,8 @@ fun addOre(player: Player, ore: String): Boolean {
         }
     }
     val added = player.inventory.add(ore)
-    if (added) { player.message("You manage to mine some ${ore.toLowerSpaceCase()}.")
+    if (added) {
+        player.message("You manage to mine some ${ore.toLowerSpaceCase()}.")
     } else {
         player.inventoryFull()
     }
@@ -155,7 +155,7 @@ fun deplete(rock: Rock, obj: GameObject): Boolean {
 
 objectApproach("Prospect") {
     approachRange(1)
-    pause()
+    arriveDelay()
     if (target.id.startsWith("depleted")) {
         player.message("There is currently no ore available in this rock.")
         return@objectApproach
@@ -164,13 +164,11 @@ objectApproach("Prospect") {
         return@objectApproach
     }
     player.message("You examine the rock for ores...")
-    player.start("movement_delay", 4)
-    player.softQueue("prospect", 4) {
-        val ore = def.getOrNull<Rock>("mining")?.ores?.firstOrNull()
-        if (ore == null) {
-            player.message("This rock contains no ore.")
-        } else {
-            player.message("This rock contains ${ore.toLowerSpaceCase()}.")
-        }
+    delay(4)
+    val ore = def.getOrNull<Rock>("mining")?.ores?.firstOrNull()
+    if (ore == null) {
+        player.message("This rock contains no ore.")
+    } else {
+        player.message("This rock contains ${ore.toLowerSpaceCase()}.")
     }
 }

--- a/game/src/main/kotlin/world/gregs/voidps/world/activity/skill/smithing/Cannonballs.kts
+++ b/game/src/main/kotlin/world/gregs/voidps/world/activity/skill/smithing/Cannonballs.kts
@@ -18,6 +18,7 @@ import world.gregs.voidps.engine.inv.transact.TransactionError
 import world.gregs.voidps.engine.inv.transact.operation.AddItem.add
 import world.gregs.voidps.engine.inv.transact.operation.RemoveItem.remove
 import world.gregs.voidps.engine.queue.weakQueue
+import world.gregs.voidps.world.activity.quest.quest
 import world.gregs.voidps.world.interact.dialogue.type.makeAmount
 import world.gregs.voidps.world.interact.dialogue.type.statement
 import world.gregs.voidps.world.interact.entity.sound.playSound
@@ -25,10 +26,10 @@ import world.gregs.voidps.world.interact.entity.sound.playSound
 val logger = InlineLogger()
 
 itemOnObjectOperate("steel_bar", "furnace*") {
-//    if (player.quest("dwarf_cannon") != "completed") {
-//        player.noInterest()
-//        return@itemOnObjectOperate
-//    }
+    if (player.quest("dwarf_cannon") != "completed") {
+        player.noInterest()
+        return@itemOnObjectOperate
+    }
     if (!player.inventory.contains("ammo_mould")) {
         statement("You need a mould to make cannonballs with.")
         return@itemOnObjectOperate

--- a/game/src/main/kotlin/world/gregs/voidps/world/activity/skill/smithing/Cannonballs.kts
+++ b/game/src/main/kotlin/world/gregs/voidps/world/activity/skill/smithing/Cannonballs.kts
@@ -4,8 +4,10 @@ import com.github.michaelbull.logging.InlineLogger
 import world.gregs.voidps.engine.client.message
 import world.gregs.voidps.engine.client.ui.interact.itemOnObjectOperate
 import world.gregs.voidps.engine.entity.character.face
+import world.gregs.voidps.engine.entity.character.mode.interact.Interaction
 import world.gregs.voidps.engine.entity.character.player.Player
 import world.gregs.voidps.engine.entity.character.player.chat.ChatType
+import world.gregs.voidps.engine.entity.character.player.chat.noInterest
 import world.gregs.voidps.engine.entity.character.player.skill.Skill
 import world.gregs.voidps.engine.entity.character.player.skill.exp.exp
 import world.gregs.voidps.engine.entity.character.player.skill.level.Level.has
@@ -16,7 +18,6 @@ import world.gregs.voidps.engine.inv.transact.TransactionError
 import world.gregs.voidps.engine.inv.transact.operation.AddItem.add
 import world.gregs.voidps.engine.inv.transact.operation.RemoveItem.remove
 import world.gregs.voidps.engine.queue.weakQueue
-import world.gregs.voidps.world.activity.quest.quest
 import world.gregs.voidps.world.interact.dialogue.type.makeAmount
 import world.gregs.voidps.world.interact.dialogue.type.statement
 import world.gregs.voidps.world.interact.entity.sound.playSound
@@ -24,9 +25,10 @@ import world.gregs.voidps.world.interact.entity.sound.playSound
 val logger = InlineLogger()
 
 itemOnObjectOperate("steel_bar", "furnace*") {
-    if (player.quest("dwarf_cannon") != "completed") {
-        return@itemOnObjectOperate
-    }
+//    if (player.quest("dwarf_cannon") != "completed") {
+//        player.noInterest()
+//        return@itemOnObjectOperate
+//    }
     if (!player.inventory.contains("ammo_mould")) {
         statement("You need a mould to make cannonballs with.")
         return@itemOnObjectOperate
@@ -36,7 +38,7 @@ itemOnObjectOperate("steel_bar", "furnace*") {
     smelt(player, target, item, amount)
 }
 
-fun smelt(player: Player, target: GameObject, id: String, amount: Int) {
+suspend fun Interaction<Player>.smelt(player: Player, target: GameObject, id: String, amount: Int) {
     if (amount <= 0) {
         return
     }
@@ -47,28 +49,25 @@ fun smelt(player: Player, target: GameObject, id: String, amount: Int) {
     player.setAnimation("furnace_smelt")
     player.playSound("smelt_bar")
     player.message("You heat the steel bar into a liquid state.", ChatType.Filter)
-    player.weakQueue("cannonball_melt", 3) {
-        player.message("You poor the molten metal into your cannonball mould.", ChatType.Filter)
-        player.weakQueue("cannonball_poor", 1) {
-            player.message("The molten metal cools slowly to form 4 cannonballs.", ChatType.Filter)
-        }
-        player.setAnimation("climb_down")
-        player.weakQueue("cannonball_remove", 4) {
-            player.setAnimation("climb_down")
-            player.message("You remove the cannonballs from the mould.", ChatType.Filter)
-            player.inventory.transaction {
-                remove("steel_bar")
-                add("cannonball", 4)
-            }
-            when (player.inventory.transaction.error) {
-                TransactionError.None -> {
-                    player.exp(Skill.Smithing, 25.6)
-                    player.weakQueue("cannonball_make", 3) {
-                        smelt(player, target, id, amount - 1)
-                    }
-                }
-                else -> logger.warn { "Cannonball transaction error $player $id $amount ${player.inventory.transaction.error}" }
+    delay(3)
+    player.message("You poor the molten metal into your cannonball mould.", ChatType.Filter)
+    player.setAnimation("climb_down")
+    delay(1)
+    player.message("The molten metal cools slowly to form 4 cannonballs.", ChatType.Filter)
+    delay(3)
+    player.setAnimation("climb_down")
+    player.message("You remove the cannonballs from the mould.", ChatType.Filter)
+    player.inventory.transaction {
+        remove("steel_bar")
+        add("cannonball", 4)
+    }
+    when (player.inventory.transaction.error) {
+        TransactionError.None -> {
+            player.exp(Skill.Smithing, 25.6)
+            player.weakQueue("cannonball_smelting", 3) {
+                smelt(player, target, id, amount - 1)
             }
         }
+        else -> logger.warn { "Cannonball transaction error $player $id $amount ${player.inventory.transaction.error}" }
     }
 }

--- a/game/src/main/kotlin/world/gregs/voidps/world/activity/skill/smithing/Furnace.kts
+++ b/game/src/main/kotlin/world/gregs/voidps/world/activity/skill/smithing/Furnace.kts
@@ -121,9 +121,8 @@ fun smelt(player: Player, target: GameObject, id: String, amount: Int) {
                 } else {
                     player.message("The ore is too impure and you fail to refine it.", ChatType.Filter)
                 }
-                player.weakQueue("smelting", 1) {
-                    smelt(player, target, id, amount - removed)
-                }
+                pause(1)
+                smelt(player, target, id, amount - removed)
             }
             else -> logger.warn { "Smelting transaction error $player $id $amount ${player.inventory.transaction.error}" }
         }

--- a/game/src/main/kotlin/world/gregs/voidps/world/activity/skill/thieving/Pickpocketing.kts
+++ b/game/src/main/kotlin/world/gregs/voidps/world/activity/skill/thieving/Pickpocketing.kts
@@ -3,7 +3,6 @@ package world.gregs.voidps.world.activity.skill.thieving
 import com.github.michaelbull.logging.InlineLogger
 import world.gregs.voidps.engine.client.message
 import world.gregs.voidps.engine.client.variable.hasClock
-import world.gregs.voidps.engine.client.variable.start
 import world.gregs.voidps.engine.data.definition.AnimationDefinitions
 import world.gregs.voidps.engine.data.definition.data.Pocket
 import world.gregs.voidps.engine.entity.World
@@ -11,7 +10,6 @@ import world.gregs.voidps.engine.entity.character.face
 import world.gregs.voidps.engine.entity.character.forceChat
 import world.gregs.voidps.engine.entity.character.npc.NPC
 import world.gregs.voidps.engine.entity.character.npc.npcApproach
-import world.gregs.voidps.engine.entity.character.npc.npcOperate
 import world.gregs.voidps.engine.entity.character.player.Player
 import world.gregs.voidps.engine.entity.character.player.chat.ChatType
 import world.gregs.voidps.engine.entity.character.player.chat.inventoryFull

--- a/game/src/main/kotlin/world/gregs/voidps/world/activity/transport/teleport/Ectophial.kts
+++ b/game/src/main/kotlin/world/gregs/voidps/world/activity/transport/teleport/Ectophial.kts
@@ -27,11 +27,11 @@ inventoryItem("Empty", "ectophial", "inventory") {
         player.setGraphic("empty_ectophial")
         player.message("You empty the ectoplasm onto the ground around your feet...", ChatType.Filter)
         player.start("movement_delay", 4)
-        pause(4)
+        delay(4)
         itemTeleport(player, inventory, slot, areas["ectophial_teleport"], "ectophial")
-        pause(2)
+        delay(2)
         player.message("... and the world changes around you.", ChatType.Filter)
-        pause(4)
+        delay(4)
         val ectofuntus = objects[Tile(3658, 3518), "ectofuntus"] ?: return@strongQueue
         player.mode = Interact(player, ectofuntus, ItemOnObject(player, ectofuntus, inventory, inventory, Item("ectophial_empty"), slot, inventory))
     }

--- a/game/src/main/kotlin/world/gregs/voidps/world/activity/transport/teleport/Teleports.kts
+++ b/game/src/main/kotlin/world/gregs/voidps/world/activity/transport/teleport/Teleports.kts
@@ -46,12 +46,12 @@ interfaceOption("Cast", "*_teleport", "*_spellbook") {
         player.start("movement_delay", 2)
         player.playAnimation("teleport_$book", canInterrupt = false)
         player.tele(areas[component].random(player)!!)
-        pause(1)
+        delay(1)
         player.playSound("teleport_land")
         player.setGraphic("teleport_land_$book")
         player.playAnimation("teleport_land_$book", canInterrupt = false)
         if (book == "ancient") {
-            pause(1)
+            delay(1)
             player.clearAnimation()
         }
     }
@@ -72,7 +72,7 @@ inventoryItem("*", "*_teleport") {
             player.setGraphic("teleport_$type")
             player.start("movement_delay", 2)
             player.setAnimation("teleport_$type")
-            pause(3)
+            delay(3)
             player.tele(map.random(player)!!)
             player.playAnimation("teleport_land", canInterrupt = false)
         }

--- a/game/src/main/kotlin/world/gregs/voidps/world/command/debug/PlayerUpdatingCommands.kts
+++ b/game/src/main/kotlin/world/gregs/voidps/world/command/debug/PlayerUpdatingCommands.kts
@@ -1,9 +1,7 @@
 package world.gregs.voidps.world.command.debug
 
-import kotlinx.coroutines.GlobalScope
-import kotlinx.coroutines.delay
-import kotlinx.coroutines.launch
 import net.pearx.kasechange.toScreamingSnakeCase
+import world.gregs.voidps.bot.isBot
 import world.gregs.voidps.engine.client.message
 import world.gregs.voidps.engine.client.ui.event.adminCommand
 import world.gregs.voidps.engine.client.ui.event.modCommand
@@ -21,17 +19,11 @@ import world.gregs.voidps.world.interact.entity.proj.shoot
 val players: Players by inject()
 
 adminCommand("kill", "remove all bots") {
-    players.forEach { bot ->
-        if (bot.name.startsWith("Bot")) {
-            players.remove(bot)
-        }
-    }
-    GlobalScope.launch {
-        delay(600)
-        players.forEach { bot ->
-            if (bot.name.startsWith("Bot")) {
-                players.remove(bot)
-            }
+    val it = players.iterator()
+    while (it.hasNext()) {
+        val p = it.next()
+        if (p.isBot) {
+            it.remove()
         }
     }
 }

--- a/game/src/main/kotlin/world/gregs/voidps/world/interact/entity/death/NPCDeath.kts
+++ b/game/src/main/kotlin/world/gregs/voidps/world/interact/entity/death/NPCDeath.kts
@@ -51,7 +51,7 @@ npcDeath { npc ->
         npc.setAnimation(deathAnimation(npc))
         val name = npc.def.name.toSnakeCase()
         (killer as? Player)?.playSound(deathSound(npc))
-        pause(4)
+        delay(4)
         dropLoot(npc, killer, name, tile)
         npc.attackers.clear()
         npc.softTimers.stopAll()
@@ -59,7 +59,7 @@ npcDeath { npc ->
         val respawn = npc.get<Tile>("respawn_tile")
         if (respawn != null) {
             npc.tele(respawn)
-            pause(npc["respawn_delay", 60])
+            delay(npc["respawn_delay", 60])
             npc.damageDealers.clear()
             npc.levels.clear()
             npc.face(npc["respawn_direction", Direction.NORTH], update = false)

--- a/game/src/main/kotlin/world/gregs/voidps/world/interact/entity/death/PlayerDeath.kts
+++ b/game/src/main/kotlin/world/gregs/voidps/world/interact/entity/death/PlayerDeath.kts
@@ -62,7 +62,7 @@ playerDeath { player ->
         wrath(player)
         player.message("Oh dear, you are dead!")
         player.setAnimation("human_death")
-        pause(5)
+        delay(5)
         player.clearAnimation()
         player.attackers.clear()
         player.damageDealers.clear()

--- a/game/src/main/kotlin/world/gregs/voidps/world/interact/entity/npc/combat/type/GiantMole.kts
+++ b/game/src/main/kotlin/world/gregs/voidps/world/interact/entity/npc/combat/type/GiantMole.kts
@@ -98,23 +98,21 @@ fun giantMoleBurrow(mole: NPC) {
     var tileToDust = mole.tile.add(getRandomFacing(mole.facing).delta)
     mole.queue("await_mole_to_face", 1) {
         if (tileToDust == Tile.EMPTY) {
-            logger.info { "failed to get facing tile for Giant Mole, using default tile." }
+            logger.warn { "failed to get facing tile for Giant Mole, using default tile." }
             tileToDust = initialCaveTile
         }
         mole.face(tileToDust)
-        mole.queue("display_burrow_dust", 1) {
-            if (shouldThrowDirt()) {
-                handleDirtOnScreen(mole.tile)
-            }
-            mole.setAnimation("giant_mole_burrow")
-            areaSound("giant_mole_burrow_down", mole.tile)
-            areaGraphic("burrow_dust", tileToDust)
-            mole.queue("await_mole_burrowing", 1) {
-                val newLocation = gianMoleSpawns.random(mole)
-                mole.tele(newLocation!!)
-                mole.setAnimation("mole_burrow_up")
-            }
+        pause(1)
+        if (shouldThrowDirt()) {
+            handleDirtOnScreen(mole.tile)
         }
+        mole.setAnimation("giant_mole_burrow")
+        areaSound("giant_mole_burrow_down", mole.tile)
+        areaGraphic("burrow_dust", tileToDust)
+        pause(1)
+        val newLocation = gianMoleSpawns.random(mole)
+        mole.tele(newLocation!!)
+        mole.setAnimation("mole_burrow_up")
     }
 }
 

--- a/game/src/main/kotlin/world/gregs/voidps/world/interact/entity/obj/Teleport.kt
+++ b/game/src/main/kotlin/world/gregs/voidps/world/interact/entity/obj/Teleport.kt
@@ -16,7 +16,6 @@ data class Teleport(
     val option: String
 ) : CancellableEvent(), Context<Player> {
     var delay: Int? = null
-    override var onCancel: (() -> Unit)? = null
     var land: Boolean = false
 
     override val size = 5

--- a/game/src/main/kotlin/world/gregs/voidps/world/interact/entity/obj/door/Door.kt
+++ b/game/src/main/kotlin/world/gregs/voidps/world/interact/entity/obj/door/Door.kt
@@ -35,7 +35,6 @@ object Door {
         } else {
             tile(door, 1)
         }
-        player.start("input_delay", ticks)
         player.walkTo(target, noCollision = true, noRun = true)
         openDoor(player, door, def, ticks, collision = false)
     }

--- a/game/src/main/kotlin/world/gregs/voidps/world/interact/entity/obj/door/Door.kt
+++ b/game/src/main/kotlin/world/gregs/voidps/world/interact/entity/obj/door/Door.kt
@@ -2,7 +2,6 @@ package world.gregs.voidps.world.interact.entity.obj.door
 
 import world.gregs.voidps.cache.definition.data.ObjectDefinition
 import world.gregs.voidps.engine.client.message
-import world.gregs.voidps.engine.client.variable.start
 import world.gregs.voidps.engine.entity.character.mode.interact.Interaction
 import world.gregs.voidps.engine.entity.character.move.walkTo
 import world.gregs.voidps.engine.entity.character.player.Player

--- a/game/src/main/kotlin/world/gregs/voidps/world/interact/entity/obj/door/Door.kt
+++ b/game/src/main/kotlin/world/gregs/voidps/world/interact/entity/obj/door/Door.kt
@@ -3,6 +3,7 @@ package world.gregs.voidps.world.interact.entity.obj.door
 import world.gregs.voidps.cache.definition.data.ObjectDefinition
 import world.gregs.voidps.engine.client.message
 import world.gregs.voidps.engine.client.variable.start
+import world.gregs.voidps.engine.entity.character.mode.interact.Interaction
 import world.gregs.voidps.engine.entity.character.move.walkTo
 import world.gregs.voidps.engine.entity.character.player.Player
 import world.gregs.voidps.engine.entity.obj.GameObject
@@ -162,3 +163,11 @@ object Door {
     fun ObjectDefinition.isDoor() = (name.contains("door", true) && !name.contains("trap", true)) || name.contains("gate", true) || this["door", false]
 }
 
+
+/**
+ * Enter through a door
+ */
+suspend fun Interaction<Player>.enterDoor(door: GameObject, def: ObjectDefinition = door.def, ticks: Int = 3, delay: Int = ticks) {
+    Door.enter(player, door, def, ticks)
+    delay(delay)
+}

--- a/game/src/main/kotlin/world/gregs/voidps/world/interact/entity/obj/door/Doors.kts
+++ b/game/src/main/kotlin/world/gregs/voidps/world/interact/entity/obj/door/Doors.kts
@@ -30,7 +30,7 @@ objectOperate("Open") {
         return@objectOperate
     }
     if (openDoor(player, target, def)) {
-        pause(1)
+        delay(0)
         player.emit(DoorOpened)
     }
 }

--- a/game/src/main/kotlin/world/gregs/voidps/world/map/MilkCow.kts
+++ b/game/src/main/kotlin/world/gregs/voidps/world/map/MilkCow.kts
@@ -3,11 +3,7 @@ package world.gregs.voidps.world.map
 import world.gregs.voidps.engine.client.message
 import world.gregs.voidps.engine.entity.character.setAnimation
 import world.gregs.voidps.engine.entity.obj.objectOperate
-import world.gregs.voidps.engine.inv.add
-import world.gregs.voidps.engine.inv.holdsItem
-import world.gregs.voidps.engine.inv.inventory
-import world.gregs.voidps.engine.inv.remove
-import world.gregs.voidps.engine.queue.softQueue
+import world.gregs.voidps.engine.inv.*
 import world.gregs.voidps.world.activity.bank.bank
 import world.gregs.voidps.world.activity.quest.quest
 import world.gregs.voidps.world.interact.dialogue.Chuckle
@@ -32,24 +28,18 @@ objectOperate("Milk", "prized_dairy_cow") {
     }
     player.setAnimation("milk_cow")
     player.playSound("milk_cow")
-    player["delay"] = 5
-    player.softQueue("milk", 5) {
-        player.inventory.remove("bucket")
-        player.inventory.add("top_quality_milk")
-        player.message("You milk the cow for top-quality milk.")
-    }
+    delay(5)
+    player.inventory.replace("bucket", "top_quality_milk")
+    player.message("You milk the cow for top-quality milk.")
 }
 
 objectOperate("Milk", "dairy_cow") {
     if (player.holdsItem("bucket")) {
         player.setAnimation("milk_cow")
         player.playSound("milk_cow")
-        player["delay"] = 5
-        player.softQueue("milk", 5) {
-            player.inventory.remove("bucket")
-            player.inventory.add("bucket_of_milk")
-            player.message("You milk the cow.")
-        }
+        delay(5)
+        player.inventory.replace("bucket", "bucket_of_milk")
+        player.message("You milk the cow.")
     } else {
         npc<Chuckle>("gillie_groats", "Tee hee! You've never milked a cow before, have you?")
         player<Quiz>("Erm...no. How could you tell?")

--- a/game/src/main/kotlin/world/gregs/voidps/world/map/al_kharid/Tollgate.kts
+++ b/game/src/main/kotlin/world/gregs/voidps/world/map/al_kharid/Tollgate.kts
@@ -27,7 +27,7 @@ import world.gregs.voidps.world.interact.dialogue.Upset
 import world.gregs.voidps.world.interact.dialogue.type.choice
 import world.gregs.voidps.world.interact.dialogue.type.npc
 import world.gregs.voidps.world.interact.dialogue.type.player
-import world.gregs.voidps.world.interact.entity.obj.door.Door
+import world.gregs.voidps.world.interact.entity.obj.door.enterDoor
 
 val objects: GameObjects by inject()
 
@@ -38,7 +38,7 @@ objectOperate("Pay-toll(10gp)", "toll_gate_al_kharid*") {
         return@objectOperate
     }
     player.message("You pay the guard.")
-    Door.enter(player, target)
+    enterDoor(target, delay = 2)
 }
 
 objectOperate("Open", "toll_gate_al_kharid*") {

--- a/game/src/main/kotlin/world/gregs/voidps/world/map/barbarian_outpost/BarbarianOutpostGate.kts
+++ b/game/src/main/kotlin/world/gregs/voidps/world/map/barbarian_outpost/BarbarianOutpostGate.kts
@@ -10,6 +10,7 @@ import world.gregs.voidps.engine.inject
 import world.gregs.voidps.engine.queue.strongQueue
 import world.gregs.voidps.world.activity.quest.questComplete
 import world.gregs.voidps.world.interact.entity.obj.door.Door
+import world.gregs.voidps.world.interact.entity.obj.door.enterDoor
 
 val npcs: NPCs by inject()
 
@@ -24,5 +25,5 @@ objectOperate("Open", "barbarian_outpost_gate_left_closed", "barbarian_outpost_g
         player.walkTo(player.tile.copy(y = player.tile.y.coerceIn(2569, 3570)))
         delay()
     }
-    Door.enter(player, target)
+    enterDoor(target, delay = 2)
 }

--- a/game/src/main/kotlin/world/gregs/voidps/world/map/barbarian_outpost/BarbarianOutpostGate.kts
+++ b/game/src/main/kotlin/world/gregs/voidps/world/map/barbarian_outpost/BarbarianOutpostGate.kts
@@ -7,9 +7,7 @@ import world.gregs.voidps.engine.entity.character.npc.NPCOption
 import world.gregs.voidps.engine.entity.character.npc.NPCs
 import world.gregs.voidps.engine.entity.obj.objectOperate
 import world.gregs.voidps.engine.inject
-import world.gregs.voidps.engine.queue.strongQueue
 import world.gregs.voidps.world.activity.quest.questComplete
-import world.gregs.voidps.world.interact.entity.obj.door.Door
 import world.gregs.voidps.world.interact.entity.obj.door.enterDoor
 
 val npcs: NPCs by inject()

--- a/game/src/main/kotlin/world/gregs/voidps/world/map/barbarian_outpost/BarbarianOutpostGate.kts
+++ b/game/src/main/kotlin/world/gregs/voidps/world/map/barbarian_outpost/BarbarianOutpostGate.kts
@@ -20,11 +20,9 @@ objectOperate("Open", "barbarian_outpost_gate_left_closed", "barbarian_outpost_g
         player.mode = Interact(player, guard, NPCOption(player, guard, guard.def, "Talk-to"))
         return@objectOperate
     }
-    player.strongQueue("enter") {
-        if (player.tile.y !in 2569..3570) {
-            player.walkTo(player.tile.copy(y = player.tile.y.coerceIn(2569, 3570)))
-            pause()
-        }
-        Door.enter(player, target)
+    if (player.tile.y !in 2569..3570) {
+        player.walkTo(player.tile.copy(y = player.tile.y.coerceIn(2569, 3570)))
+        delay()
     }
+    Door.enter(player, target)
 }

--- a/game/src/main/kotlin/world/gregs/voidps/world/map/falador/DressingRoom.kt
+++ b/game/src/main/kotlin/world/gregs/voidps/world/map/falador/DressingRoom.kt
@@ -8,9 +8,9 @@ import world.gregs.voidps.engine.entity.character.setGraphic
 
 internal suspend fun Interaction<Player>.openDressingRoom(id: String) {
     player.closeDialogue()
-    pause(1)
+    delay(1)
     player.setGraphic("dressing_room_start")
-    pause(1)
+    delay(1)
     player.open(id)
     player.softTimers.start("dressing_room")
 }

--- a/game/src/main/kotlin/world/gregs/voidps/world/map/lumbridge/LumbridgeFlag.kts
+++ b/game/src/main/kotlin/world/gregs/voidps/world/map/lumbridge/LumbridgeFlag.kts
@@ -2,7 +2,6 @@ package world.gregs.voidps.world.map.lumbridge
 
 import world.gregs.voidps.engine.entity.character.forceChat
 import world.gregs.voidps.engine.entity.obj.objectOperate
-import world.gregs.voidps.engine.queue.strongQueue
 import world.gregs.voidps.engine.suspend.playAnimation
 
 objectOperate("Raise", "lumbridge_flag") {

--- a/game/src/main/kotlin/world/gregs/voidps/world/map/lumbridge/LumbridgeFlag.kts
+++ b/game/src/main/kotlin/world/gregs/voidps/world/map/lumbridge/LumbridgeFlag.kts
@@ -6,12 +6,10 @@ import world.gregs.voidps.engine.queue.strongQueue
 import world.gregs.voidps.engine.suspend.playAnimation
 
 objectOperate("Raise", "lumbridge_flag") {
-    player.strongQueue("lumbridge_flag") {
-        target.animate("lumbridge_flag")
-        player.playAnimation("lumbridge_flag_raise")
-        player.playAnimation("lumbridge_flag_stop_raise")
-        player.forceChat = "All Hail the Duke!"
-        player.playAnimation("emote_salute")
-        player["raise_the_roof_task"] = true
-    }
+    target.animate("lumbridge_flag")
+    player.playAnimation("lumbridge_flag_raise")
+    player.playAnimation("lumbridge_flag_stop_raise")
+    player.forceChat = "All Hail the Duke!"
+    player.playAnimation("emote_salute")
+    player["raise_the_roof_task"] = true
 }

--- a/game/src/main/kotlin/world/gregs/voidps/world/map/ourania/ZamorakCrafter.kts
+++ b/game/src/main/kotlin/world/gregs/voidps/world/map/ourania/ZamorakCrafter.kts
@@ -9,8 +9,6 @@ import world.gregs.voidps.engine.entity.character.setGraphic
 import world.gregs.voidps.engine.entity.npcSpawn
 import world.gregs.voidps.engine.entity.obj.GameObjects
 import world.gregs.voidps.engine.inject
-import world.gregs.voidps.engine.queue.queue
-import world.gregs.voidps.engine.queue.softQueue
 import world.gregs.voidps.type.Tile
 
 val objects: GameObjects by inject()
@@ -26,19 +24,16 @@ npcMove("zamorak_crafter*", to = Tile(3314, 4811)) {
     if (altar != null) {
         npc.face(altar)
     }
-    npc.queue("bind", 4) {
-        npc.setAnimation("bind_runes")
-        npc.setGraphic("bind_runes")
-    }
-    npc.softQueue("return_to_bank", 8) {
-        val patrol = patrols.get("zamorak_crafter_to_bank")
-        npc.mode = Patrol(npc, patrol.waypoints)
-    }
+    delay(4)
+    npc.setAnimation("bind_runes")
+    npc.setGraphic("bind_runes")
+    delay(4)
+    val patrol = patrols.get("zamorak_crafter_to_bank")
+    npc.mode = Patrol(npc, patrol.waypoints)
 }
 
 npcMove("zamorak_crafter*", to = Tile(3270, 4856)) {
-    npc.softQueue("return_to_altar", 5) {
-        val patrol = patrols.get("zamorak_crafter_to_altar")
-        npc.mode = Patrol(npc, patrol.waypoints)
-    }
+    delay(5)
+    val patrol = patrols.get("zamorak_crafter_to_altar")
+    npc.mode = Patrol(npc, patrol.waypoints)
 }

--- a/game/src/main/kotlin/world/gregs/voidps/world/map/rimmington/CraftingGuild.kts
+++ b/game/src/main/kotlin/world/gregs/voidps/world/map/rimmington/CraftingGuild.kts
@@ -15,7 +15,6 @@ import world.gregs.voidps.world.interact.dialogue.*
 import world.gregs.voidps.world.interact.dialogue.type.choice
 import world.gregs.voidps.world.interact.dialogue.type.npc
 import world.gregs.voidps.world.interact.dialogue.type.player
-import world.gregs.voidps.world.interact.entity.obj.door.Door
 import world.gregs.voidps.world.interact.entity.obj.door.enterDoor
 
 val logger = InlineLogger()

--- a/game/src/main/kotlin/world/gregs/voidps/world/map/rimmington/CraftingGuild.kts
+++ b/game/src/main/kotlin/world/gregs/voidps/world/map/rimmington/CraftingGuild.kts
@@ -16,12 +16,13 @@ import world.gregs.voidps.world.interact.dialogue.type.choice
 import world.gregs.voidps.world.interact.dialogue.type.npc
 import world.gregs.voidps.world.interact.dialogue.type.player
 import world.gregs.voidps.world.interact.entity.obj.door.Door
+import world.gregs.voidps.world.interact.entity.obj.door.enterDoor
 
 val logger = InlineLogger()
 
 objectOperate("Open", "guild_door_2_closed") {
     if (player.tile.y == 3288) {
-        Door.enter(player, target)
+        enterDoor(target, delay = 2)
         return@objectOperate
     }
     if (!player.has(Skill.Crafting, 40)) {
@@ -32,7 +33,7 @@ objectOperate("Open", "guild_door_2_closed") {
         npc<Neutral>("master_crafter", "Where's your brown apron? You can't come in here unless you're wearing one.")
         return@objectOperate
     }
-    Door.enter(player, target)
+    enterDoor(target, delay = 2)
     npc<Happy>("master_crafter", "Welcome to the Guild of Master Craftsmen.")
 }
 

--- a/game/src/main/kotlin/world/gregs/voidps/world/map/taverley/TaverleyDungeon.kts
+++ b/game/src/main/kotlin/world/gregs/voidps/world/map/taverley/TaverleyDungeon.kts
@@ -18,7 +18,6 @@ import world.gregs.voidps.engine.queue.softQueue
 import world.gregs.voidps.engine.timer.toTicks
 import world.gregs.voidps.type.Tile
 import world.gregs.voidps.world.activity.quest.quest
-import world.gregs.voidps.world.interact.entity.obj.door.Door
 import world.gregs.voidps.world.interact.entity.obj.door.enterDoor
 import java.util.concurrent.TimeUnit
 

--- a/game/src/main/kotlin/world/gregs/voidps/world/map/taverley/TaverleyDungeon.kts
+++ b/game/src/main/kotlin/world/gregs/voidps/world/map/taverley/TaverleyDungeon.kts
@@ -19,6 +19,7 @@ import world.gregs.voidps.engine.timer.toTicks
 import world.gregs.voidps.type.Tile
 import world.gregs.voidps.world.activity.quest.quest
 import world.gregs.voidps.world.interact.entity.obj.door.Door
+import world.gregs.voidps.world.interact.entity.obj.door.enterDoor
 import java.util.concurrent.TimeUnit
 
 val npcs: NPCs by inject()
@@ -29,7 +30,7 @@ val rightSpawn = Tile(2887, 9829)
 
 objectOperate("Open", "door_taverley_1_closed", "door_taverley_2_closed") {
     if (player.tile.x >= 2889 || !spawn(player, leftSpawn) && !spawn(player, rightSpawn)) {
-        Door.enter(player, target)
+        enterDoor(target)
     }
 }
 

--- a/game/src/main/kotlin/world/gregs/voidps/world/map/tree_gnome_stronghold/TreeGnomeStronghold.kts
+++ b/game/src/main/kotlin/world/gregs/voidps/world/map/tree_gnome_stronghold/TreeGnomeStronghold.kts
@@ -5,17 +5,15 @@ import world.gregs.voidps.engine.entity.character.face
 import world.gregs.voidps.engine.entity.character.move.walkTo
 import world.gregs.voidps.engine.entity.obj.objectOperate
 import world.gregs.voidps.engine.entity.obj.replace
-import world.gregs.voidps.engine.queue.strongQueue
 
 objectOperate("Open", "tree_gnome_door_east_closed", "tree_gnome_door_west_closed") {
     player.start("input_delay", 4)
-    player.strongQueue("enter_tree_gnome_door") {
-        if (player.tile.x !in 2465..2466) {
-            player.walkTo(player.tile.copy(x = player.tile.x.coerceIn(2465..2466)))
-            pause(1)
-            player.face(target)
-        }
-        player.walkTo(player.tile.addY(if (player.tile.y < target.tile.y) 2 else -2), noCollision = true, noRun = true)
-        target.replace(target.id.replace("_closed", "_opened"), ticks = 4)
+    if (player.tile.x !in 2465..2466) {
+        player.walkTo(player.tile.copy(x = player.tile.x.coerceIn(2465..2466)))
+        delay()
+        player.face(target)
     }
+    player.walkTo(player.tile.addY(if (player.tile.y < target.tile.y) 2 else -2), noCollision = true, noRun = true)
+    delay()
+    target.replace(target.id.replace("_closed", "_opened"), ticks = 4)
 }

--- a/game/src/main/kotlin/world/gregs/voidps/world/map/tree_gnome_stronghold/TreeGnomeStronghold.kts
+++ b/game/src/main/kotlin/world/gregs/voidps/world/map/tree_gnome_stronghold/TreeGnomeStronghold.kts
@@ -1,13 +1,11 @@
 package world.gregs.voidps.world.map.tree_gnome_stronghold
 
-import world.gregs.voidps.engine.client.variable.start
 import world.gregs.voidps.engine.entity.character.face
 import world.gregs.voidps.engine.entity.character.move.walkTo
 import world.gregs.voidps.engine.entity.obj.objectOperate
 import world.gregs.voidps.engine.entity.obj.replace
 
 objectOperate("Open", "tree_gnome_door_east_closed", "tree_gnome_door_west_closed") {
-    player.start("input_delay", 4)
     if (player.tile.x !in 2465..2466) {
         player.walkTo(player.tile.copy(x = player.tile.x.coerceIn(2465..2466)))
         delay()

--- a/game/src/main/kotlin/world/gregs/voidps/world/map/varrock/abyss/AbyssObstacles.kts
+++ b/game/src/main/kotlin/world/gregs/voidps/world/map/varrock/abyss/AbyssObstacles.kts
@@ -14,7 +14,6 @@ import world.gregs.voidps.engine.entity.character.player.skill.level.Level
 import world.gregs.voidps.engine.entity.character.setAnimation
 import world.gregs.voidps.engine.entity.obj.objectOperate
 import world.gregs.voidps.engine.inv.inventory
-import world.gregs.voidps.engine.queue.strongQueue
 import world.gregs.voidps.type.Direction
 import world.gregs.voidps.type.Tile
 import world.gregs.voidps.world.activity.skill.mining.Pickaxe
@@ -49,40 +48,38 @@ objectOperate("Mine", "abyss_rock") {
         return@objectOperate
     }
     player.setAnimation("${pickaxe.id}_swing_low")
-    pause(7)
+    delay(7)
     val success = Level.success(player.levels.get(Skill.Mining), chance)
     if (!success) {
         player.message("...but fail to break-up the rock.", ChatType.Filter)
         player.clearAnimation()
         return@objectOperate
     }
-    player.strongQueue("abyss_rock") {
-        pause(1)
-        val offset = target.tile.add(direction(target.tile))
-        player.moveCamera(offset, 2500, 0, 0)
-        player.turnCamera(target.tile, 0, 10, 10)
-        pause(1)
-        player["abyss_obstacles"] = 12
-        pause(2)
-        player["abyss_obstacles"] = 13
-        val (walkTile, teleTile) = positions[target.tile]!!
-        player.walkTo(walkTile)
-        pause(2)
-        player.message("...and manage to break through the rock.", ChatType.Filter)
-        player.clearAnimation()
-        player.tele(teleTile)
-        pause(1)
-        player["abyss_obstacles"] = 0
-        player.turnCamera(player.tile.region.tile, 0, 0, 0)
-        player.moveCamera(offset, 0, 0, 0)
-        player.clearCamera()
-        player.exp(Skill.Mining, 25.0)
-    }
+    delay(1)
+    val offset = target.tile.add(direction(target.tile))
+    player.moveCamera(offset, 2500, 0, 0)
+    player.turnCamera(target.tile, 0, 10, 10)
+    delay(1)
+    player["abyss_obstacles"] = 12
+    delay(2)
+    player["abyss_obstacles"] = 13
+    val (walkTile, teleTile) = positions[target.tile]!!
+    player.walkTo(walkTile)
+    delay(2)
+    player.message("...and manage to break through the rock.", ChatType.Filter)
+    player.clearAnimation()
+    player.tele(teleTile)
+    delay(1)
+    player["abyss_obstacles"] = 0
+    player.turnCamera(player.tile.region.tile, 0, 0, 0)
+    player.moveCamera(offset, 0, 0, 0)
+    player.clearCamera()
+    player.exp(Skill.Mining, 25.0)
 }
 
 objectOperate("Chop", "abyss_tendrils") {
     player.message("You attempt to chop your way through...", ChatType.Filter)
-    pause(4)
+    delay(4)
     val hatchet = Hatchet.best(player)
     if (hatchet == null) {
         player.message("You need a hatchet to chop through the tendrils.")
@@ -90,39 +87,37 @@ objectOperate("Chop", "abyss_tendrils") {
         return@objectOperate
     }
     player.setAnimation("${hatchet.id}_chop")
-    pause(2)
+    delay(2)
     val success = Level.success(player.levels.get(Skill.Woodcutting), chance)
     if (!success) {
         player.message("...but fail to cut through the tendrils.", ChatType.Filter)
         return@objectOperate
     }
-    player.strongQueue("abyss_tentacles") {
-        val offset = target.tile.add(direction(target.tile))
-        player.moveCamera(offset, 2500, 0, 0)
-        player.turnCamera(target.tile, 0, 10, 10)
-        pause(2)
-        player["abyss_obstacles"] = 14
-        player.setAnimation("${hatchet.id}_chop")
-        pause(2)
-        player["abyss_obstacles"] = 15
-         val (walkTile, teleTile) = positions[target.tile]!!
-        player.walkTo(walkTile)
-        pause(2)
-        player.message("...and manage to cut a way through the tendrils.", ChatType.Filter)
-        pause(1)
-        player.tele(teleTile)
-        pause(1)
-        player["abyss_obstacles"] = 0
-        player.turnCamera(player.tile.region.tile, 0, 0, 0)
-        player.moveCamera(offset, 0, 0, 0)
-        player.clearCamera()
-        player.exp(Skill.Woodcutting, 25.0)
-    }
+    val offset = target.tile.add(direction(target.tile))
+    player.moveCamera(offset, 2500, 0, 0)
+    player.turnCamera(target.tile, 0, 10, 10)
+    delay(2)
+    player["abyss_obstacles"] = 14
+    player.setAnimation("${hatchet.id}_chop")
+    delay(2)
+    player["abyss_obstacles"] = 15
+    val (walkTile, teleTile) = positions[target.tile]!!
+    player.walkTo(walkTile)
+    delay(2)
+    player.message("...and manage to cut a way through the tendrils.", ChatType.Filter)
+    delay(1)
+    player.tele(teleTile)
+    delay(1)
+    player["abyss_obstacles"] = 0
+    player.turnCamera(player.tile.region.tile, 0, 0, 0)
+    player.moveCamera(offset, 0, 0, 0)
+    player.clearCamera()
+    player.exp(Skill.Woodcutting, 25.0)
 }
 
 objectOperate("Burn-down", "abyss_boil") {
     player.message("You attempt to set the blockade on fire...", ChatType.Filter)
-    pause(3)
+    delay(3)
     if (!player.inventory.contains("tinderbox")) {
         player.message("...but you don't have a tinderbox to burn it!")
         return@objectOperate
@@ -132,63 +127,59 @@ objectOperate("Burn-down", "abyss_boil") {
         player.message("...but fail to burn it out of your way.", ChatType.Filter)
         return@objectOperate
     }
-    player.strongQueue("abyss_boil") {
-        player.setAnimation("light_fire")
-        val offset = target.tile.add(direction(target.tile))
-        player.moveCamera(offset, 2500, 0, 0)
-        player.turnCamera(target.tile, 0, 10, 10)
-        pause(6)
-        player["abyss_obstacles"] = 16
-        pause(6)
-        player["abyss_obstacles"] = 17
-         val (walkTile, teleTile) = positions[target.tile]!!
-        player.walkTo(walkTile)
-        areaGraphic("fire_wave_hit", target.tile, height = 128)
-        player.playSound("boil_burst")
-        pause(2)
-        player.message("...and manage to burn it down and get past.", ChatType.Filter)
-        pause(1)
-        player.tele(teleTile)
-        pause(1)
-        player["abyss_obstacles"] = 0
-        player.turnCamera(player.tile.region.tile, 0, 0, 0)
-        player.moveCamera(offset, 0, 0, 0)
-        player.clearCamera()
-        player.exp(Skill.Firemaking, 25.0)
-    }
+    player.setAnimation("light_fire")
+    val offset = target.tile.add(direction(target.tile))
+    player.moveCamera(offset, 2500, 0, 0)
+    player.turnCamera(target.tile, 0, 10, 10)
+    delay(6)
+    player["abyss_obstacles"] = 16
+    delay(6)
+    player["abyss_obstacles"] = 17
+    val (walkTile, teleTile) = positions[target.tile]!!
+    player.walkTo(walkTile)
+    areaGraphic("fire_wave_hit", target.tile, height = 128)
+    player.playSound("boil_burst")
+    delay(2)
+    player.message("...and manage to burn it down and get past.", ChatType.Filter)
+    delay()
+    player.tele(teleTile)
+    delay()
+    player["abyss_obstacles"] = 0
+    player.turnCamera(player.tile.region.tile, 0, 0, 0)
+    player.moveCamera(offset, 0, 0, 0)
+    player.clearCamera()
+    player.exp(Skill.Firemaking, 25.0)
 }
 
 objectOperate("Distract", "abyss_eyes") {
     player.message("You use your thieving skills to misdirect the eyes...", ChatType.Filter)
-    pause(2)
+    delay(2)
     val success = Level.success(player.levels.get(Skill.Thieving), chance)
     if (!success) {
         player.message("...but fail to distract them enough to get past.", ChatType.Filter)
         return@objectOperate
     }
-    player.strongQueue("abyss_eyes") {
-        player.setAnimation(distractions.random())
-        val offset = target.tile.add(direction(target.tile))
-        player.moveCamera(offset, 2500, 0, 0)
-        player.turnCamera(target.tile, 0, 10, 10)
-        pause(4)
-        player["abyss_obstacles"] = 18
-        player.setAnimation(distractions.random())
-        pause(2)
-        player["abyss_obstacles"] = 19
-         val (walkTile, teleTile) = positions[target.tile]!!
-        player.walkTo(walkTile)
-        pause(2)
-        player.message("...and sneak past while they're not looking.", ChatType.Filter)
-        pause(1)
-        player.tele(teleTile)
-        pause(1)
-        player["abyss_obstacles"] = 0
-        player.turnCamera(player.tile.region.tile, 0, 0, 0)
-        player.moveCamera(offset, 0, 0, 0)
-        player.clearCamera()
-        player.exp(Skill.Thieving, 25.0)
-    }
+    player.setAnimation(distractions.random())
+    val offset = target.tile.add(direction(target.tile))
+    player.moveCamera(offset, 2500, 0, 0)
+    player.turnCamera(target.tile, 0, 10, 10)
+    delay(4)
+    player["abyss_obstacles"] = 18
+    player.setAnimation(distractions.random())
+    delay(2)
+    player["abyss_obstacles"] = 19
+    val (walkTile, teleTile) = positions[target.tile]!!
+    player.walkTo(walkTile)
+    delay(2)
+    player.message("...and sneak past while they're not looking.", ChatType.Filter)
+    delay(1)
+    player.tele(teleTile)
+    delay(1)
+    player["abyss_obstacles"] = 0
+    player.turnCamera(player.tile.region.tile, 0, 0, 0)
+    player.moveCamera(offset, 0, 0, 0)
+    player.clearCamera()
+    player.exp(Skill.Thieving, 25.0)
 }
 
 val distractions = arrayOf(
@@ -199,35 +190,34 @@ val distractions = arrayOf(
 
 objectOperate("Squeeze-through", "abyss_gap") {
     player.message("You attempt to squeeze through the narrow gap...", ChatType.Filter)
-    pause(4)
+    delay(4)
     player.setAnimation("abyss_kneel")
-    pause(2)
+    delay(2)
     val success = Level.success(player.levels.get(Skill.Agility), chance)
     if (!success) {
         player.message("...but you are not agile enough to get through the gap.", ChatType.Filter)
         player.setAnimation("abyss_stand")
         return@objectOperate
     }
-    player.strongQueue("abyss_gap", 2) {
-        player.message("...and you manage to crawl through.", ChatType.Filter)
-        player.setAnimation("crawling_cave")
-        val (_, teleTile) = positions[target.tile]!!
-        player.tele(teleTile)
-        val offset = target.tile.add(direction(target.tile))
-        player.moveCamera(offset, 2500, 0, 0)
-        player.turnCamera(target.tile, 0, 10, 10)
-        player.playSound("abyssal_squeezethrough", repeat = 4)
-        pause(1)
-        player["abyss_obstacles"] = 0
-        player.turnCamera(player.tile.region.tile, 0, 0, 0)
-        player.moveCamera(offset, 0, 0, 0)
-        player.clearCamera()
-        player.exp(Skill.Agility, 25.0)
-    }
+    delay(2)
+    player.message("...and you manage to crawl through.", ChatType.Filter)
+    player.setAnimation("crawling_cave")
+    val (_, teleTile) = positions[target.tile]!!
+    player.tele(teleTile)
+    val offset = target.tile.add(direction(target.tile))
+    player.moveCamera(offset, 2500, 0, 0)
+    player.turnCamera(target.tile, 0, 10, 10)
+    player.playSound("abyssal_squeezethrough", repeat = 4)
+    delay(1)
+    player["abyss_obstacles"] = 0
+    player.turnCamera(player.tile.region.tile, 0, 0, 0)
+    player.moveCamera(offset, 0, 0, 0)
+    player.clearCamera()
+    player.exp(Skill.Agility, 25.0)
 }
 
 objectOperate("Go-through", "abyss_passage") {
-    pause(2)
+    delay(2)
     val (_, teleTile) = positions[target.tile]!!
     player.tele(teleTile)
 }

--- a/game/src/main/kotlin/world/gregs/voidps/world/map/varrock/abyss/MageOfZamorak.kts
+++ b/game/src/main/kotlin/world/gregs/voidps/world/map/varrock/abyss/MageOfZamorak.kts
@@ -279,11 +279,11 @@ fun teleport(player: Player, target: NPC) {
         target.setAnimation("tele_other")
         player.playSound("tele_other_cast")
         target.forceChat = "Veniens! Sallakar! Rinnesset!"
-        pause(2)
+        delay(2)
         player.setAnimation("lunar_teleport")
         player.setGraphic("tele_other_receive")
         player.playSound("teleport_all")
-        pause(2)
+        delay(2)
         player["abyss_obstacles"] = random.nextInt(0, 12)
         var tile = abyss.random(player)
         var count = 0

--- a/game/src/main/kotlin/world/gregs/voidps/world/map/varrock/palace/VarrockPalaceDrain.kts
+++ b/game/src/main/kotlin/world/gregs/voidps/world/map/varrock/palace/VarrockPalaceDrain.kts
@@ -58,12 +58,10 @@ itemOnObjectOperate("*of_water", "varrock_palace_drain") {
     player.setGraphic("toss_water")
     player.playSound("demon_slayer_drain")
     player.playSound("demon_slayer_key_fall")
-    player.weakQueue("demon_slayer_dislodge_key") {
-        if (player.quest("demon_slayer") == "key_hunt") {
-            player<Happy>("OK, I think I've washed the key down into the sewer. I'd better go down and get it!")
-        } else {
-            player<Shifty>("I think that dislodged something from the drain. It's probably gone down to the sewers below.")
-        }
+    if (player.quest("demon_slayer") == "key_hunt") {
+        player<Happy>("OK, I think I've washed the key down into the sewer. I'd better go down and get it!")
+    } else {
+        player<Shifty>("I think that dislodged something from the drain. It's probably gone down to the sewers below.")
     }
 }
 

--- a/game/src/main/kotlin/world/gregs/voidps/world/map/varrock/palace/VarrockPalaceDrain.kts
+++ b/game/src/main/kotlin/world/gregs/voidps/world/map/varrock/palace/VarrockPalaceDrain.kts
@@ -10,7 +10,6 @@ import world.gregs.voidps.engine.entity.playerSpawn
 import world.gregs.voidps.engine.inv.add
 import world.gregs.voidps.engine.inv.inventory
 import world.gregs.voidps.engine.inv.replace
-import world.gregs.voidps.engine.queue.weakQueue
 import world.gregs.voidps.world.activity.bank.ownsItem
 import world.gregs.voidps.world.activity.quest.quest
 import world.gregs.voidps.world.interact.dialogue.Happy

--- a/game/src/test/kotlin/world/gregs/voidps/world/activity/skill/agility/course/BarbarianAdvancedTest.kt
+++ b/game/src/test/kotlin/world/gregs/voidps/world/activity/skill/agility/course/BarbarianAdvancedTest.kt
@@ -52,7 +52,7 @@ internal class BarbarianAdvancedTest : WorldTest() {
         val pipe = objects[Tile(2532, 3544, 3), "barbarian_outpost_spring"]!!
 
         player.objectOption(pipe, "Fire")
-        tick(9)
+        tick(10)
 
         assertEquals(Tile(2532, 3553, 3), player.tile)
         assertEquals(15.0, player.experience.get(Skill.Agility))

--- a/game/src/test/kotlin/world/gregs/voidps/world/activity/skill/agility/course/GnomeAdvancedTest.kt
+++ b/game/src/test/kotlin/world/gregs/voidps/world/activity/skill/agility/course/GnomeAdvancedTest.kt
@@ -85,7 +85,7 @@ internal class GnomeAdvancedTest : WorldTest() {
         val barrier = objects[Tile(2485, 3433, 3), "gnome_barrier_advanced"]!!
 
         player.objectOption(barrier, "Jump-over")
-        tick(4)
+        tick(5)
 
         assertEquals(Tile(2485, 3436), player.tile)
         assertEquals(25.0, player.experience.get(Skill.Agility))
@@ -98,7 +98,7 @@ internal class GnomeAdvancedTest : WorldTest() {
         player.agilityCourse("gnome")
         player.agilityStage = 6
         player.objectOption(barrier, "Jump-over")
-        tick(4)
+        tick(5)
 
         assertEquals(Tile(2485, 3436), player.tile)
         assertEquals(630.0, player.experience.get(Skill.Agility))

--- a/game/src/test/kotlin/world/gregs/voidps/world/activity/skill/agility/course/GnomeStrongholdTest.kt
+++ b/game/src/test/kotlin/world/gregs/voidps/world/activity/skill/agility/course/GnomeStrongholdTest.kt
@@ -50,7 +50,7 @@ internal class GnomeStrongholdTest : WorldTest() {
         val rope = objects[Tile(2478, 3420, 2), "gnome_balancing_rope"]!!
 
         player.objectOption(rope, "Walk-on")
-        tick(8)
+        tick(9)
 
         assertEquals(Tile(2483, 3420, 2), player.tile)
         assertEquals(7.5, player.experience.get(Skill.Agility))
@@ -74,7 +74,7 @@ internal class GnomeStrongholdTest : WorldTest() {
         val net = objects[Tile(2487, 3426), "gnome_obstacle_net_free_standing"]!!
 
         player.objectOption(net, "Climb-over")
-        tick(3)
+        tick(4)
 
         assertEquals(Tile(2487, 3427), player.tile)
         assertEquals(7.5, player.experience.get(Skill.Agility))
@@ -98,7 +98,7 @@ internal class GnomeStrongholdTest : WorldTest() {
         val pipe = objects[Tile(2487, 3431), "gnome_obstacle_pipe_east"]!!
 
         player.objectOption(pipe, "Squeeze-through")
-        tick(10)
+        tick(11)
 
         assertEquals(Tile(2487, 3437), player.tile)
         assertEquals(7.5, player.experience.get(Skill.Agility))

--- a/game/src/test/kotlin/world/gregs/voidps/world/activity/skill/agility/course/WildernessCourseTest.kt
+++ b/game/src/test/kotlin/world/gregs/voidps/world/activity/skill/agility/course/WildernessCourseTest.kt
@@ -40,7 +40,7 @@ internal class WildernessCourseTest : WorldTest() {
         val door = objects[Tile(2998, 3931), "wilderness_agility_gate_east_closed"]!!
 
         player.objectOption(door, "Open")
-        tick(16)
+        tick(17)
 
         assertEquals(Tile(2998, 3916), player.tile)
         assertEquals(15.0, player.experience.get(Skill.Agility))

--- a/game/src/test/kotlin/world/gregs/voidps/world/interact/dialogue/DialogueTest.kt
+++ b/game/src/test/kotlin/world/gregs/voidps/world/interact/dialogue/DialogueTest.kt
@@ -68,7 +68,6 @@ abstract class DialogueTest : KoinMock() {
         }
         context = spyk(object : SuspendableContext<Player> {
             override val character = this@DialogueTest.player
-            override var onCancel: (() -> Unit)? = null
             override suspend fun pause(ticks: Int) {
             }
         })


### PR DESCRIPTION
#585

- Remove "input_delay"
- Remove "onCancel" from most contexts
- Convert a lot of interactions which use queue's to delay (agility, thieving, prospecting)
- Leave interruptible skills (cooking, crafting, fletching etc..) as the only usages of pause()