### PR TITLE
Fix door traversal logic in Gnome Stronghold

### DIFF
--- a/game/src/main/kotlin/world/gregs/voidps/world/map/tree_gnome_stronghold/TreeGnomeStronghold.kts
+++ b/game/src/main/kotlin/world/gregs/voidps/world/map/tree_gnome_stronghold/TreeGnomeStronghold.kts
@@ -12,6 +12,6 @@ objectOperate("Open", "tree_gnome_door_east_closed", "tree_gnome_door_west_close
         delay()
         player.face(target)
     }
-    player.walkOver(player.tile.addY(if (player.tile.y < target.tile.y) 2 else -2))
     target.replace(target.id.replace("_closed", "_opened"), ticks = 4)
+    player.walkOver(player.tile.addY(if (player.tile.y < target.tile.y) 2 else -2))
 }


### PR DESCRIPTION
### Description

This pull request addresses the traversal logic for doors within the Tree Gnome Stronghold, ensuring smoother and more reliable navigation for players.