### PR TITLE
Improved naming 1 - ForceChat, RenderEmote

### DIFF
--- a/engine/src/main/kotlin/world/gregs/voidps/engine/entity/character/Character.kt
+++ b/engine/src/main/kotlin/world/gregs/voidps/engine/entity/character/Character.kt
@@ -33,6 +33,12 @@ interface Character : Entity, Variable, EventDispatcher, Comparable<Character> {
     override fun compareTo(other: Character): Int {
         return index.compareTo(other.index)
     }
+
+    fun say(message: String) {
+        visuals.say.text = message
+        flagSay()
+    }
+
 }
 
 val Entity.size: Int

--- a/engine/src/main/kotlin/world/gregs/voidps/engine/entity/character/Character.kt
+++ b/engine/src/main/kotlin/world/gregs/voidps/engine/entity/character/Character.kt
@@ -6,15 +6,21 @@ import world.gregs.voidps.engine.client.variable.Variables
 import world.gregs.voidps.engine.entity.Entity
 import world.gregs.voidps.engine.entity.character.mode.Mode
 import world.gregs.voidps.engine.entity.character.mode.move.Steps
+import world.gregs.voidps.engine.entity.character.move.tele
 import world.gregs.voidps.engine.entity.character.npc.NPC
 import world.gregs.voidps.engine.entity.character.player.Player
 import world.gregs.voidps.engine.entity.character.player.appearance
+import world.gregs.voidps.engine.entity.character.player.movementType
 import world.gregs.voidps.engine.entity.character.player.skill.level.Levels
 import world.gregs.voidps.engine.event.EventDispatcher
 import world.gregs.voidps.engine.queue.ActionQueue
 import world.gregs.voidps.engine.suspend.Suspension
 import world.gregs.voidps.engine.timer.Timers
 import world.gregs.voidps.network.login.protocol.visual.Visuals
+import world.gregs.voidps.network.login.protocol.visual.update.player.MoveType
+import world.gregs.voidps.type.Delta
+import world.gregs.voidps.type.Direction
+import world.gregs.voidps.type.Tile
 import kotlin.coroutines.Continuation
 
 interface Character : Entity, Variable, EventDispatcher, Comparable<Character> {
@@ -32,6 +38,30 @@ interface Character : Entity, Variable, EventDispatcher, Comparable<Character> {
 
     override fun compareTo(other: Character): Int {
         return index.compareTo(other.index)
+    }
+
+    /**
+     * Gradually move the characters appeared location to [delta] over [delay] time
+     */
+    fun exactMove(delta: Delta, delay: Int = tile.distanceTo(tile.add(delta)) * 30, direction: Direction = Direction.NONE) {
+        val start = tile
+        tele(delta)
+        if (this is Player) {
+            movementType = MoveType.Walk
+        }
+        setExactMovement(Delta.EMPTY, delay, start.delta(tile), direction = direction)
+    }
+
+    /**
+     * Gradually move the characters appeared location to [target] over [delay] time
+     */
+    fun exactMove(target: Tile, delay: Int = tile.distanceTo(target) * 30, direction: Direction = Direction.NONE, startDelay: Int = 0) {
+        val start = tile
+        tele(target)
+        if (this is Player) {
+            movementType = MoveType.Walk
+        }
+        setExactMovement(Delta.EMPTY, delay, start.delta(tile), startDelay, direction = direction)
     }
 
     fun say(message: String) {

--- a/engine/src/main/kotlin/world/gregs/voidps/engine/entity/character/Visuals.kt
+++ b/engine/src/main/kotlin/world/gregs/voidps/engine/entity/character/Visuals.kt
@@ -177,7 +177,7 @@ fun Character.setExactMovement(
     flagExactMovement()
 }
 
-fun Character.setExactMove(delta: Delta, delay: Int = tile.distanceTo(tile.add(delta)) * 30, direction: Direction = Direction.NONE) {
+fun Character.exactMove(delta: Delta, delay: Int = tile.distanceTo(tile.add(delta)) * 30, direction: Direction = Direction.NONE) {
     val start = tile
     tele(delta)
     if (this is Player) {
@@ -186,12 +186,12 @@ fun Character.setExactMove(delta: Delta, delay: Int = tile.distanceTo(tile.add(d
     setExactMovement(Delta.EMPTY, delay, start.delta(tile), direction = direction)
 }
 
-context(SuspendableContext<*>) suspend fun Character.exactMove(delta: Delta, delay: Int = tile.distanceTo(tile.add(delta)) * 30, direction: Direction = Direction.NONE) {
-    character.setExactMove(delta, delay, direction)
+context(SuspendableContext<*>) suspend fun Character.exactMoveDelay(delta: Delta, delay: Int = tile.distanceTo(tile.add(delta)) * 30, direction: Direction = Direction.NONE) {
+    character.exactMove(delta, delay, direction)
     delay(delay / 30)
 }
 
-fun Character.setExactMove(target: Tile, delay: Int = tile.distanceTo(target) * 30, direction: Direction = Direction.NONE, startDelay: Int = 0) {
+fun Character.exactMove(target: Tile, delay: Int = tile.distanceTo(target) * 30, direction: Direction = Direction.NONE, startDelay: Int = 0) {
     val start = tile
     tele(target)
     if (this is Player) {
@@ -200,8 +200,8 @@ fun Character.setExactMove(target: Tile, delay: Int = tile.distanceTo(target) * 
     setExactMovement(Delta.EMPTY, delay, start.delta(tile), startDelay, direction = direction)
 }
 
-context(SuspendableContext<*>) suspend fun Character.exactMove(target: Tile, delay: Int = tile.distanceTo(target) * 30, direction: Direction = Direction.NONE, startDelay: Int = 0) {
-    character.setExactMove(target, delay, direction, startDelay)
+context(SuspendableContext<*>) suspend fun Character.exactMoveDelay(target: Tile, delay: Int = tile.distanceTo(target) * 30, direction: Direction = Direction.NONE, startDelay: Int = 0) {
+    character.exactMove(target, delay, direction, startDelay)
     delay((startDelay + delay) / 30)
 }
 

--- a/engine/src/main/kotlin/world/gregs/voidps/engine/entity/character/Visuals.kt
+++ b/engine/src/main/kotlin/world/gregs/voidps/engine/entity/character/Visuals.kt
@@ -27,7 +27,7 @@ fun Character.flagAnimation() = visuals.flag(if (this is Player) VisualMask.PLAY
 
 fun Character.flagColourOverlay() = visuals.flag(if (this is Player) VisualMask.PLAYER_COLOUR_OVERLAY_MASK else VisualMask.NPC_COLOUR_OVERLAY_MASK)
 
-fun Character.flagForceChat() = visuals.flag(if (this is Player) VisualMask.PLAYER_SAY_MASK else VisualMask.NPC_SAY_MASK)
+fun Character.flagSay() = visuals.flag(if (this is Player) VisualMask.PLAYER_SAY_MASK else VisualMask.NPC_SAY_MASK)
 
 fun Character.flagHits() = visuals.flag(if (this is Player) VisualMask.PLAYER_HITS_MASK else VisualMask.NPC_HITS_MASK)
 
@@ -89,16 +89,9 @@ fun Character.colourOverlay(colour: Int, delay: Int, duration: Int) {
     softTimers.start("colour_overlay")
 }
 
-var Character.forceChat: String
-    get() = visuals.say.text
-    set(value) {
-        visuals.say.text = value
-        flagForceChat()
-    }
-
 fun Character.say(message: String) {
     visuals.say.text = message
-    flagForceChat()
+    flagSay()
 }
 
 private fun getPlayerMask(index: Int) = when (index) {

--- a/engine/src/main/kotlin/world/gregs/voidps/engine/entity/character/Visuals.kt
+++ b/engine/src/main/kotlin/world/gregs/voidps/engine/entity/character/Visuals.kt
@@ -177,24 +177,6 @@ fun Character.setExactMovement(
     flagExactMovement()
 }
 
-fun Character.exactMove(delta: Delta, delay: Int = tile.distanceTo(tile.add(delta)) * 30, direction: Direction = Direction.NONE) {
-    val start = tile
-    tele(delta)
-    if (this is Player) {
-        movementType = MoveType.Walk
-    }
-    setExactMovement(Delta.EMPTY, delay, start.delta(tile), direction = direction)
-}
-
-fun Character.exactMove(target: Tile, delay: Int = tile.distanceTo(target) * 30, direction: Direction = Direction.NONE, startDelay: Int = 0) {
-    val start = tile
-    tele(target)
-    if (this is Player) {
-        movementType = MoveType.Walk
-    }
-    setExactMovement(Delta.EMPTY, delay, start.delta(tile), startDelay, direction = direction)
-}
-
 val Character.turn: Delta
     get() = Tile(visuals.turn.targetX, visuals.turn.targetY, tile.level).delta(tile)
 

--- a/engine/src/main/kotlin/world/gregs/voidps/engine/entity/character/Visuals.kt
+++ b/engine/src/main/kotlin/world/gregs/voidps/engine/entity/character/Visuals.kt
@@ -27,7 +27,7 @@ fun Character.flagAnimation() = visuals.flag(if (this is Player) VisualMask.PLAY
 
 fun Character.flagColourOverlay() = visuals.flag(if (this is Player) VisualMask.PLAYER_COLOUR_OVERLAY_MASK else VisualMask.NPC_COLOUR_OVERLAY_MASK)
 
-fun Character.flagForceChat() = visuals.flag(if (this is Player) VisualMask.PLAYER_FORCE_CHAT_MASK else VisualMask.NPC_FORCE_CHAT_MASK)
+fun Character.flagForceChat() = visuals.flag(if (this is Player) VisualMask.PLAYER_SAY_MASK else VisualMask.NPC_SAY_MASK)
 
 fun Character.flagHits() = visuals.flag(if (this is Player) VisualMask.PLAYER_HITS_MASK else VisualMask.NPC_HITS_MASK)
 
@@ -90,11 +90,16 @@ fun Character.colourOverlay(colour: Int, delay: Int, duration: Int) {
 }
 
 var Character.forceChat: String
-    get() = visuals.forceChat.text
+    get() = visuals.say.text
     set(value) {
-        visuals.forceChat.text = value
+        visuals.say.text = value
         flagForceChat()
     }
+
+fun Character.say(message: String) {
+    visuals.say.text = message
+    flagForceChat()
+}
 
 private fun getPlayerMask(index: Int) = when (index) {
     1 -> VisualMask.PLAYER_GRAPHIC_2_MASK

--- a/engine/src/main/kotlin/world/gregs/voidps/engine/entity/character/Visuals.kt
+++ b/engine/src/main/kotlin/world/gregs/voidps/engine/entity/character/Visuals.kt
@@ -186,11 +186,6 @@ fun Character.exactMove(delta: Delta, delay: Int = tile.distanceTo(tile.add(delt
     setExactMovement(Delta.EMPTY, delay, start.delta(tile), direction = direction)
 }
 
-context(SuspendableContext<*>) suspend fun Character.exactMoveDelay(delta: Delta, delay: Int = tile.distanceTo(tile.add(delta)) * 30, direction: Direction = Direction.NONE) {
-    character.exactMove(delta, delay, direction)
-    delay(delay / 30)
-}
-
 fun Character.exactMove(target: Tile, delay: Int = tile.distanceTo(target) * 30, direction: Direction = Direction.NONE, startDelay: Int = 0) {
     val start = tile
     tele(target)
@@ -198,11 +193,6 @@ fun Character.exactMove(target: Tile, delay: Int = tile.distanceTo(target) * 30,
         movementType = MoveType.Walk
     }
     setExactMovement(Delta.EMPTY, delay, start.delta(tile), startDelay, direction = direction)
-}
-
-context(SuspendableContext<*>) suspend fun Character.exactMoveDelay(target: Tile, delay: Int = tile.distanceTo(target) * 30, direction: Direction = Direction.NONE, startDelay: Int = 0) {
-    character.exactMove(target, delay, direction, startDelay)
-    delay((startDelay + delay) / 30)
 }
 
 val Character.turn: Delta

--- a/engine/src/main/kotlin/world/gregs/voidps/engine/entity/character/player/PlayerVisuals.kt
+++ b/engine/src/main/kotlin/world/gregs/voidps/engine/entity/character/player/PlayerVisuals.kt
@@ -58,7 +58,7 @@ var Player.headIcon: Int
         headIcon = value
     }
 
-fun Player.setRenderEmote(id: String) = flag {
+fun Player.renderEmote(id: String) = flag {
     val definition = get<RenderEmoteDefinitions>().get(id)
     appearance.emote = definition.id
 }

--- a/engine/src/main/kotlin/world/gregs/voidps/engine/entity/character/player/PlayerVisuals.kt
+++ b/engine/src/main/kotlin/world/gregs/voidps/engine/entity/character/player/PlayerVisuals.kt
@@ -58,11 +58,10 @@ var Player.headIcon: Int
         headIcon = value
     }
 
-var Player.renderEmote: String
-    get() = get<RenderEmoteDefinitions>().get(appearance.emote).stringId
-    set(value) = flag {
-        emote = get<RenderEmoteDefinitions>().get(value).id
-    }
+fun Player.setRenderEmote(id: String) = flag {
+    val definition = get<RenderEmoteDefinitions>().get(id)
+    appearance.emote = definition.id
+}
 
 fun Player.clearRenderEmote() = flag {
     emote = 1426

--- a/engine/src/main/kotlin/world/gregs/voidps/engine/suspend/SuspendableContext.kt
+++ b/engine/src/main/kotlin/world/gregs/voidps/engine/suspend/SuspendableContext.kt
@@ -2,7 +2,11 @@ package world.gregs.voidps.engine.suspend
 
 import kotlinx.coroutines.suspendCancellableCoroutine
 import world.gregs.voidps.engine.entity.character.Character
+import world.gregs.voidps.engine.entity.character.exactMove
 import world.gregs.voidps.engine.event.Context
+import world.gregs.voidps.type.Delta
+import world.gregs.voidps.type.Direction
+import world.gregs.voidps.type.Tile
 
 interface SuspendableContext<C : Character> : Context<C> {
     /**
@@ -24,5 +28,18 @@ interface SuspendableContext<C : Character> : Context<C> {
         suspendCancellableCoroutine {
             character.delay = it
         }
+    }
+
+    suspend fun Character.exactMoveDelay(delta: Delta, delay: Int = tile.distanceTo(tile.add(delta)) * 30, direction: Direction = Direction.NONE) {
+        character.exactMove(delta, delay, direction)
+        delay(delay / 30)
+    }
+
+    /**
+     * Gradually move the characters appeared location over time
+     */
+    suspend fun Character.exactMoveDelay(target: Tile, delay: Int = tile.distanceTo(target) * 30, direction: Direction = Direction.NONE, startDelay: Int = 0) {
+        character.exactMove(target, delay, direction, startDelay)
+        delay((startDelay + delay) / 30)
     }
 }

--- a/engine/src/main/kotlin/world/gregs/voidps/engine/suspend/SuspendableContext.kt
+++ b/engine/src/main/kotlin/world/gregs/voidps/engine/suspend/SuspendableContext.kt
@@ -2,7 +2,6 @@ package world.gregs.voidps.engine.suspend
 
 import kotlinx.coroutines.suspendCancellableCoroutine
 import world.gregs.voidps.engine.entity.character.Character
-import world.gregs.voidps.engine.entity.character.exactMove
 import world.gregs.voidps.engine.event.Context
 import world.gregs.voidps.type.Delta
 import world.gregs.voidps.type.Direction
@@ -30,13 +29,16 @@ interface SuspendableContext<C : Character> : Context<C> {
         }
     }
 
+    /**
+     * Delay until the appeared location of the character has moved [delta] in [delay] time
+     */
     suspend fun Character.exactMoveDelay(delta: Delta, delay: Int = tile.distanceTo(tile.add(delta)) * 30, direction: Direction = Direction.NONE) {
         character.exactMove(delta, delay, direction)
         delay(delay / 30)
     }
 
     /**
-     * Gradually move the characters appeared location over time
+     * Delay until the appeared location of the character has moved to [target] in [delay] time
      */
     suspend fun Character.exactMoveDelay(target: Tile, delay: Int = tile.distanceTo(target) * 30, direction: Direction = Direction.NONE, startDelay: Int = 0) {
         character.exactMove(target, delay, direction, startDelay)

--- a/game/src/main/kotlin/world/gregs/voidps/world/activity/dnd/shootingstar/ShootingStar.kts
+++ b/game/src/main/kotlin/world/gregs/voidps/world/activity/dnd/shootingstar/ShootingStar.kts
@@ -10,7 +10,7 @@ import world.gregs.voidps.engine.data.Settings
 import world.gregs.voidps.engine.data.definition.data.Rock
 import world.gregs.voidps.engine.data.settingsReload
 import world.gregs.voidps.engine.entity.World
-import world.gregs.voidps.engine.entity.character.setExactMove
+import world.gregs.voidps.engine.entity.character.exactMove
 import world.gregs.voidps.engine.entity.character.mode.interact.Interact
 import world.gregs.voidps.engine.entity.character.move.walkTo
 import world.gregs.voidps.engine.entity.character.npc.NPC
@@ -120,7 +120,7 @@ fun startCrashedStarEvent() {
         for (player in under) {
             player.damage(random.nextInt(10, 50))
             val direction = Direction.all.first { !player.blocked(it) }
-            player.setExactMove(direction.delta, 1, direction = direction.inverse())
+            player.exactMove(direction.delta, 1, direction = direction.inverse())
             player.setAnimation("step_back_startled")
         }
         World.queue("falling_star_object_removal", 1) {

--- a/game/src/main/kotlin/world/gregs/voidps/world/activity/dnd/shootingstar/ShootingStar.kts
+++ b/game/src/main/kotlin/world/gregs/voidps/world/activity/dnd/shootingstar/ShootingStar.kts
@@ -10,7 +10,6 @@ import world.gregs.voidps.engine.data.Settings
 import world.gregs.voidps.engine.data.definition.data.Rock
 import world.gregs.voidps.engine.data.settingsReload
 import world.gregs.voidps.engine.entity.World
-import world.gregs.voidps.engine.entity.character.exactMove
 import world.gregs.voidps.engine.entity.character.mode.interact.Interact
 import world.gregs.voidps.engine.entity.character.move.walkTo
 import world.gregs.voidps.engine.entity.character.npc.NPC

--- a/game/src/main/kotlin/world/gregs/voidps/world/activity/skill/agility/course/BarbarianAdvanced.kts
+++ b/game/src/main/kotlin/world/gregs/voidps/world/activity/skill/agility/course/BarbarianAdvanced.kts
@@ -1,7 +1,7 @@
 package world.gregs.voidps.world.activity.skill.agility.course
 
+import world.gregs.voidps.engine.entity.character.exactMoveDelay
 import world.gregs.voidps.engine.entity.character.exactMove
-import world.gregs.voidps.engine.entity.character.setExactMove
 import world.gregs.voidps.engine.entity.character.face
 import world.gregs.voidps.engine.entity.character.move.tele
 import world.gregs.voidps.engine.entity.character.move.walkTo
@@ -25,7 +25,7 @@ objectOperate("Run-up", "barbarian_outpost_run_wall") {
     player.setAnimation("barbarian_wall_jump_climb")
     delay(7)
     player.setAnimation("barbarian_wall_jump")
-    player.exactMove(Tile(2538, 3545, 2), 30, Direction.NORTH)
+    player.exactMoveDelay(Tile(2538, 3545, 2), 30, Direction.NORTH)
     delay(1)
     player.exp(Skill.Agility, 15.0)
     player.agilityStage(3)
@@ -53,7 +53,7 @@ objectOperate("Fire", "barbarian_outpost_spring") {
     delay(1)
     player.tele(2533, 3547, 3)
     player.setAnimation("barbarian_spring_shoot")
-    player.exactMove(Tile(2532, 3553, 3), 60, Direction.NORTH)
+    player.exactMoveDelay(Tile(2532, 3553, 3), 60, Direction.NORTH)
     target.animate("barbarian_spring_reset")
     delay(2)
     player.exp(Skill.Agility, 15.0)
@@ -65,7 +65,7 @@ objectOperate("Cross", "barbarian_outpost_balance_beam") {
     delay()
     player.setAnimation("circus_cartwheel")
     delay()
-    player.exactMove(Tile(2536, 3553, 3), 45, Direction.EAST)
+    player.exactMoveDelay(Tile(2536, 3553, 3), 45, Direction.EAST)
     player.renderEmote("beam_balance")
     delay()
     player.exp(Skill.Agility, 15.0)
@@ -85,9 +85,9 @@ objectOperate("Jump-over", "barbarian_outpost_gap") {
 
 objectOperate("Slide-down", "barbarian_outpost_roof") {
     player.setAnimation("barbarian_slide_start")
-    player.exactMove(player.tile.copy(x = 2540), 30, Direction.EAST)
+    player.exactMoveDelay(player.tile.copy(x = 2540), 30, Direction.EAST)
     player.setAnimation("barbarian_slide")
-    player.setExactMove(player.tile.copy(x = 2543, level = 1), 90, Direction.EAST)
+    player.exactMove(player.tile.copy(x = 2543, level = 1), 90, Direction.EAST)
     delay()
     player.setAnimation("barbarian_slide")
     delay()

--- a/game/src/main/kotlin/world/gregs/voidps/world/activity/skill/agility/course/BarbarianAdvanced.kts
+++ b/game/src/main/kotlin/world/gregs/voidps/world/activity/skill/agility/course/BarbarianAdvanced.kts
@@ -1,6 +1,5 @@
 package world.gregs.voidps.world.activity.skill.agility.course
 
-import world.gregs.voidps.engine.entity.character.exactMove
 import world.gregs.voidps.engine.entity.character.face
 import world.gregs.voidps.engine.entity.character.move.tele
 import world.gregs.voidps.engine.entity.character.move.walkTo

--- a/game/src/main/kotlin/world/gregs/voidps/world/activity/skill/agility/course/BarbarianAdvanced.kts
+++ b/game/src/main/kotlin/world/gregs/voidps/world/activity/skill/agility/course/BarbarianAdvanced.kts
@@ -6,7 +6,7 @@ import world.gregs.voidps.engine.entity.character.face
 import world.gregs.voidps.engine.entity.character.move.tele
 import world.gregs.voidps.engine.entity.character.move.walkTo
 import world.gregs.voidps.engine.entity.character.player.clearRenderEmote
-import world.gregs.voidps.engine.entity.character.player.setRenderEmote
+import world.gregs.voidps.engine.entity.character.player.renderEmote
 import world.gregs.voidps.engine.entity.character.player.skill.Skill
 import world.gregs.voidps.engine.entity.character.player.skill.exp.exp
 import world.gregs.voidps.engine.entity.character.player.skill.level.Level.has
@@ -66,7 +66,7 @@ objectOperate("Cross", "barbarian_outpost_balance_beam") {
     player.setAnimation("circus_cartwheel")
     delay()
     player.exactMove(Tile(2536, 3553, 3), 45, Direction.EAST)
-    player.setRenderEmote("beam_balance")
+    player.renderEmote("beam_balance")
     delay()
     player.exp(Skill.Agility, 15.0)
     player.agilityStage(6)

--- a/game/src/main/kotlin/world/gregs/voidps/world/activity/skill/agility/course/BarbarianAdvanced.kts
+++ b/game/src/main/kotlin/world/gregs/voidps/world/activity/skill/agility/course/BarbarianAdvanced.kts
@@ -6,7 +6,7 @@ import world.gregs.voidps.engine.entity.character.face
 import world.gregs.voidps.engine.entity.character.move.tele
 import world.gregs.voidps.engine.entity.character.move.walkTo
 import world.gregs.voidps.engine.entity.character.player.clearRenderEmote
-import world.gregs.voidps.engine.entity.character.player.renderEmote
+import world.gregs.voidps.engine.entity.character.player.setRenderEmote
 import world.gregs.voidps.engine.entity.character.player.skill.Skill
 import world.gregs.voidps.engine.entity.character.player.skill.exp.exp
 import world.gregs.voidps.engine.entity.character.player.skill.level.Level.has
@@ -66,7 +66,7 @@ objectOperate("Cross", "barbarian_outpost_balance_beam") {
     player.setAnimation("circus_cartwheel")
     delay()
     player.exactMove(Tile(2536, 3553, 3), 45, Direction.EAST)
-    player.renderEmote = "beam_balance"
+    player.setRenderEmote("beam_balance")
     delay()
     player.exp(Skill.Agility, 15.0)
     player.agilityStage(6)

--- a/game/src/main/kotlin/world/gregs/voidps/world/activity/skill/agility/course/BarbarianAdvanced.kts
+++ b/game/src/main/kotlin/world/gregs/voidps/world/activity/skill/agility/course/BarbarianAdvanced.kts
@@ -1,6 +1,5 @@
 package world.gregs.voidps.world.activity.skill.agility.course
 
-import world.gregs.voidps.engine.entity.character.exactMoveDelay
 import world.gregs.voidps.engine.entity.character.exactMove
 import world.gregs.voidps.engine.entity.character.face
 import world.gregs.voidps.engine.entity.character.move.tele

--- a/game/src/main/kotlin/world/gregs/voidps/world/activity/skill/agility/course/BarbarianOutpost.kts
+++ b/game/src/main/kotlin/world/gregs/voidps/world/activity/skill/agility/course/BarbarianOutpost.kts
@@ -2,7 +2,6 @@ package world.gregs.voidps.world.activity.skill.agility.course
 
 import world.gregs.voidps.engine.client.message
 import world.gregs.voidps.engine.data.Settings
-import world.gregs.voidps.engine.entity.character.exactMoveDelay
 import world.gregs.voidps.engine.entity.character.exactMove
 import world.gregs.voidps.engine.entity.character.face
 import world.gregs.voidps.engine.entity.character.move.tele

--- a/game/src/main/kotlin/world/gregs/voidps/world/activity/skill/agility/course/BarbarianOutpost.kts
+++ b/game/src/main/kotlin/world/gregs/voidps/world/activity/skill/agility/course/BarbarianOutpost.kts
@@ -10,7 +10,7 @@ import world.gregs.voidps.engine.entity.character.move.walkOver
 import world.gregs.voidps.engine.entity.character.move.walkTo
 import world.gregs.voidps.engine.entity.character.player.chat.ChatType
 import world.gregs.voidps.engine.entity.character.player.clearRenderEmote
-import world.gregs.voidps.engine.entity.character.player.renderEmote
+import world.gregs.voidps.engine.entity.character.player.setRenderEmote
 import world.gregs.voidps.engine.entity.character.player.skill.Skill
 import world.gregs.voidps.engine.entity.character.player.skill.exp.exp
 import world.gregs.voidps.engine.entity.character.player.skill.level.Level
@@ -74,7 +74,7 @@ objectOperate("Walk-across", "barbarian_outpost_log_balance") {
     val disable = Settings["agility.disableCourseFailure", false]
     val success = disable || Level.success(player.levels.get(Skill.Agility), 93) // 62.1% success rate at 35
     player.message("You walk carefully across the slippery log...", ChatType.Filter)
-    player.renderEmote = "rope_balance"
+    player.setRenderEmote("rope_balance")
     if (success) {
         player.walkOver(Tile(2541, 3546))
         player.clearRenderEmote()
@@ -88,7 +88,7 @@ objectOperate("Walk-across", "barbarian_outpost_log_balance") {
         delay()
         player.message("... but you lose your footing and fall into the water.", ChatType.Filter)
         player.tele(2545, 3545)
-        player.renderEmote = "tread_water"
+        player.setRenderEmote("tread_water")
         delay()
         player.walkOver(Tile(2545, 3543))
         player.message("Something in the water bites you.", ChatType.Filter)
@@ -114,7 +114,7 @@ objectOperate("Walk-across", "barbarian_outpost_balancing_ledge") {
     val disable = Settings["agility.disableCourseFailure", false]
     val success = disable || Level.success(player.levels.get(Skill.Agility), 93) // 62.1% success rate
     delay()
-    player.renderEmote = "ledge_balance"
+    player.setRenderEmote("ledge_balance")
     player.message("You put your foot on the ledge and try to edge across...", ChatType.Filter)
     if (success) {
         player.walkOver(Tile(2532, 3547, 1))
@@ -131,7 +131,7 @@ objectOperate("Walk-across", "barbarian_outpost_balancing_ledge") {
         delay()
         player.tele(2534, 3546, 1)
         player.face(Direction.SOUTH)
-        player.renderEmote = "falling"
+        player.setRenderEmote("falling")
         delay()
         player.tele(2534, 3546, 0)
         player.clearRenderEmote()

--- a/game/src/main/kotlin/world/gregs/voidps/world/activity/skill/agility/course/BarbarianOutpost.kts
+++ b/game/src/main/kotlin/world/gregs/voidps/world/activity/skill/agility/course/BarbarianOutpost.kts
@@ -10,7 +10,7 @@ import world.gregs.voidps.engine.entity.character.move.walkOver
 import world.gregs.voidps.engine.entity.character.move.walkTo
 import world.gregs.voidps.engine.entity.character.player.chat.ChatType
 import world.gregs.voidps.engine.entity.character.player.clearRenderEmote
-import world.gregs.voidps.engine.entity.character.player.setRenderEmote
+import world.gregs.voidps.engine.entity.character.player.renderEmote
 import world.gregs.voidps.engine.entity.character.player.skill.Skill
 import world.gregs.voidps.engine.entity.character.player.skill.exp.exp
 import world.gregs.voidps.engine.entity.character.player.skill.level.Level
@@ -74,7 +74,7 @@ objectOperate("Walk-across", "barbarian_outpost_log_balance") {
     val disable = Settings["agility.disableCourseFailure", false]
     val success = disable || Level.success(player.levels.get(Skill.Agility), 93) // 62.1% success rate at 35
     player.message("You walk carefully across the slippery log...", ChatType.Filter)
-    player.setRenderEmote("rope_balance")
+    player.renderEmote("rope_balance")
     if (success) {
         player.walkOver(Tile(2541, 3546))
         player.clearRenderEmote()
@@ -88,7 +88,7 @@ objectOperate("Walk-across", "barbarian_outpost_log_balance") {
         delay()
         player.message("... but you lose your footing and fall into the water.", ChatType.Filter)
         player.tele(2545, 3545)
-        player.setRenderEmote("tread_water")
+        player.renderEmote("tread_water")
         delay()
         player.walkOver(Tile(2545, 3543))
         player.message("Something in the water bites you.", ChatType.Filter)
@@ -114,7 +114,7 @@ objectOperate("Walk-across", "barbarian_outpost_balancing_ledge") {
     val disable = Settings["agility.disableCourseFailure", false]
     val success = disable || Level.success(player.levels.get(Skill.Agility), 93) // 62.1% success rate
     delay()
-    player.setRenderEmote("ledge_balance")
+    player.renderEmote("ledge_balance")
     player.message("You put your foot on the ledge and try to edge across...", ChatType.Filter)
     if (success) {
         player.walkOver(Tile(2532, 3547, 1))
@@ -131,7 +131,7 @@ objectOperate("Walk-across", "barbarian_outpost_balancing_ledge") {
         delay()
         player.tele(2534, 3546, 1)
         player.face(Direction.SOUTH)
-        player.setRenderEmote("falling")
+        player.renderEmote("falling")
         delay()
         player.tele(2534, 3546, 0)
         player.clearRenderEmote()

--- a/game/src/main/kotlin/world/gregs/voidps/world/activity/skill/agility/course/BarbarianOutpost.kts
+++ b/game/src/main/kotlin/world/gregs/voidps/world/activity/skill/agility/course/BarbarianOutpost.kts
@@ -2,8 +2,8 @@ package world.gregs.voidps.world.activity.skill.agility.course
 
 import world.gregs.voidps.engine.client.message
 import world.gregs.voidps.engine.data.Settings
+import world.gregs.voidps.engine.entity.character.exactMoveDelay
 import world.gregs.voidps.engine.entity.character.exactMove
-import world.gregs.voidps.engine.entity.character.setExactMove
 import world.gregs.voidps.engine.entity.character.face
 import world.gregs.voidps.engine.entity.character.move.tele
 import world.gregs.voidps.engine.entity.character.move.walkOver
@@ -36,7 +36,7 @@ objectOperate("Squeeze-through", "barbarian_outpost_entrance") {
     }
     player.setAnimation("climb_through_pipe")
     val end = if (player.tile.y >= 3560) 3558 else 3561
-    player.exactMove(Tile(2552, end), 60, direction = if (player.tile.y >= 3560) Direction.SOUTH else Direction.NORTH)
+    player.exactMoveDelay(Tile(2552, end), 60, direction = if (player.tile.y >= 3560) Direction.SOUTH else Direction.NORTH)
 }
 
 objectOperate("Swing-on", "barbarian_outpost_rope_swing") {
@@ -51,12 +51,12 @@ objectOperate("Swing-on", "barbarian_outpost_rope_swing") {
     target.animate("swing_rope")
     delay()
     if (success) {
-        player.setExactMove(player.tile.copy(y = 3549), 60, Direction.SOUTH)
+        player.exactMove(player.tile.copy(y = 3549), 60, Direction.SOUTH)
         delay()
         player.exp(Skill.Agility, 22.0)
         player.message("You skillfully swing across.", ChatType.Filter)
     } else {
-        player.exactMove(player.tile.copy(y = 3550), 50, Direction.SOUTH)
+        player.exactMoveDelay(player.tile.copy(y = 3550), 50, Direction.SOUTH)
         delay(1)
         player.tele(player.tile.copy(y = 9950))
         player.damage(50)
@@ -156,7 +156,7 @@ objectOperate("Climb-over", "barbarian_outpost_crumbling_wall") {
     }
     player.message("You climb the low wall...", ChatType.Filter)
     player.setAnimation("climb_over_wall")
-    player.setExactMove(target.tile.addX(1), 60, Direction.EAST)
+    player.exactMove(target.tile.addX(1), 60, Direction.EAST)
     delay()
     if (target.tile.equals(2542, 3553)) {
         if (player.agilityStage == 5) {

--- a/game/src/main/kotlin/world/gregs/voidps/world/activity/skill/agility/course/BarbarianOutpost.kts
+++ b/game/src/main/kotlin/world/gregs/voidps/world/activity/skill/agility/course/BarbarianOutpost.kts
@@ -2,7 +2,6 @@ package world.gregs.voidps.world.activity.skill.agility.course
 
 import world.gregs.voidps.engine.client.message
 import world.gregs.voidps.engine.data.Settings
-import world.gregs.voidps.engine.entity.character.exactMove
 import world.gregs.voidps.engine.entity.character.face
 import world.gregs.voidps.engine.entity.character.move.tele
 import world.gregs.voidps.engine.entity.character.move.walkOver

--- a/game/src/main/kotlin/world/gregs/voidps/world/activity/skill/agility/course/GnomeAdvanced.kts
+++ b/game/src/main/kotlin/world/gregs/voidps/world/activity/skill/agility/course/GnomeAdvanced.kts
@@ -47,10 +47,10 @@ objectApproach("Run-across", "gnome_sign_post_advanced") {
     player.setAnimation("gnome_wall_${if (success) "run" else "fail"}")
     delay(1)
     if (!success) {
-        player.exactMove(Tile(2480, 3418, 3), 30, Direction.EAST)
+        player.exactMoveDelay(Tile(2480, 3418, 3), 30, Direction.EAST)
         delay(5)
     }
-    player.exactMove(Tile(2484, 3418, 3), if (success) 60 else 210, Direction.EAST)
+    player.exactMoveDelay(Tile(2484, 3418, 3), if (success) 60 else 210, Direction.EAST)
     if (success) {
         player.exp(Skill.Agility, 25.0)
     } else {
@@ -75,14 +75,14 @@ objectApproach("Swing-to", "gnome_pole_advanced") {
     player.face(Direction.NORTH)
     delay()
     player.setAnimation("gnome_run_up")
-    player.exactMove(tile.copy(y = 3421), 60, Direction.NORTH)
+    player.exactMoveDelay(tile.copy(y = 3421), 60, Direction.NORTH)
     player.setAnimation("gnome_jump")
-    player.exactMove(tile.copy(y = 3425), 30, Direction.NORTH)
+    player.exactMoveDelay(tile.copy(y = 3425), 30, Direction.NORTH)
     player.setAnimation("gnome_swing")
     delay(4)
-    player.exactMove(tile.copy(y = 3429), 30, Direction.NORTH)
+    player.exactMoveDelay(tile.copy(y = 3429), 30, Direction.NORTH)
     delay(4)
-    player.exactMove(tile.copy(y = 3432), 30, Direction.NORTH)
+    player.exactMoveDelay(tile.copy(y = 3432), 30, Direction.NORTH)
     delay(1)
     player.agilityStage(6)
     player.exp(Skill.Agility, 25.0)
@@ -91,7 +91,7 @@ objectApproach("Swing-to", "gnome_pole_advanced") {
 objectOperate("Jump-over", "gnome_barrier_advanced") {
     player.setAnimation("gnome_jump_barrier")
     delay()
-    player.exactMove(Tile(2485, 3434, 3), 30, Direction.NORTH)
+    player.exactMoveDelay(Tile(2485, 3434, 3), 30, Direction.NORTH)
     delay(1)
     player.tele(2485, 3436, 0)
     player.setAnimation("gnome_pipe_land")

--- a/game/src/main/kotlin/world/gregs/voidps/world/activity/skill/agility/course/GnomeAgility.kt
+++ b/game/src/main/kotlin/world/gregs/voidps/world/activity/skill/agility/course/GnomeAgility.kt
@@ -1,6 +1,5 @@
 package world.gregs.voidps.world.activity.skill.agility.course
 
-import world.gregs.voidps.engine.entity.character.say
 import world.gregs.voidps.engine.entity.character.npc.NPCs
 import world.gregs.voidps.type.Zone
 import world.gregs.voidps.type.random

--- a/game/src/main/kotlin/world/gregs/voidps/world/activity/skill/agility/course/GnomeAgility.kt
+++ b/game/src/main/kotlin/world/gregs/voidps/world/activity/skill/agility/course/GnomeAgility.kt
@@ -1,19 +1,19 @@
 package world.gregs.voidps.world.activity.skill.agility.course
 
-import world.gregs.voidps.engine.entity.character.forceChat
+import world.gregs.voidps.engine.entity.character.say
 import world.gregs.voidps.engine.entity.character.npc.NPCs
 import world.gregs.voidps.type.Zone
 import world.gregs.voidps.type.random
 
 internal fun NPCs.gnomeTrainer(message: String, zone: Zone) {
     val trainer = get(zone).randomOrNull(random) ?: return
-    trainer.forceChat = message
+    trainer.say(message)
 }
 
 internal fun NPCs.gnomeTrainer(message: String, zones: List<Zone>) {
     for (zone in zones) {
         val trainer = get(zone).randomOrNull(random) ?: continue
-        trainer.forceChat = message
+        trainer.say(message)
         break
     }
 }

--- a/game/src/main/kotlin/world/gregs/voidps/world/activity/skill/agility/course/GnomeStronghold.kts
+++ b/game/src/main/kotlin/world/gregs/voidps/world/activity/skill/agility/course/GnomeStronghold.kts
@@ -8,7 +8,7 @@ import world.gregs.voidps.engine.entity.character.move.walkOver
 import world.gregs.voidps.engine.entity.character.npc.NPCs
 import world.gregs.voidps.engine.entity.character.player.chat.ChatType
 import world.gregs.voidps.engine.entity.character.player.clearRenderEmote
-import world.gregs.voidps.engine.entity.character.player.setRenderEmote
+import world.gregs.voidps.engine.entity.character.player.renderEmote
 import world.gregs.voidps.engine.entity.character.player.skill.Skill
 import world.gregs.voidps.engine.entity.character.player.skill.exp.exp
 import world.gregs.voidps.engine.entity.character.setAnimation
@@ -23,7 +23,7 @@ val npcs: NPCs by inject()
 objectOperate("Walk-across", "gnome_log_balance") {
     player.agilityCourse("gnome")
     npcs.gnomeTrainer("Okay get over that log, quick quick!", listOf(Zone(878901), Zone(878900), Zone(876852)))
-    player.setRenderEmote("rope_balance")
+    player.renderEmote("rope_balance")
     player.message("You walk carefully across the slippery log...", ChatType.Filter)
     player.walkOver(Tile(2474, 3429))
     player.clearRenderEmote()
@@ -57,7 +57,7 @@ objectOperate("Climb", "gnome_tree_branch_up") {
 
 objectOperate("Walk-on", "gnome_balancing_rope") {
     npcs.gnomeTrainer("Come on scaredy cat, get across that rope!", Zone(9263413))
-    player.setRenderEmote("rope_balance")
+    player.renderEmote("rope_balance")
     player.walkOver(Tile(2483, 3420, 2))
     player.agilityStage(4)
     player.clearRenderEmote()
@@ -66,7 +66,7 @@ objectOperate("Walk-on", "gnome_balancing_rope") {
 }
 
 objectOperate("Walk-on", "gnome_balancing_rope_end") {
-    player.setRenderEmote("rope_balance")
+    player.renderEmote("rope_balance")
     player.walkOver(Tile(2477, 3420, 2))
     player.clearRenderEmote()
     player.exp(Skill.Agility, 7.5)

--- a/game/src/main/kotlin/world/gregs/voidps/world/activity/skill/agility/course/GnomeStronghold.kts
+++ b/game/src/main/kotlin/world/gregs/voidps/world/activity/skill/agility/course/GnomeStronghold.kts
@@ -1,7 +1,7 @@
 package world.gregs.voidps.world.activity.skill.agility.course
 
 import world.gregs.voidps.engine.client.message
-import world.gregs.voidps.engine.entity.character.exactMove
+import world.gregs.voidps.engine.entity.character.exactMoveDelay
 import world.gregs.voidps.engine.entity.character.face
 import world.gregs.voidps.engine.entity.character.move.tele
 import world.gregs.voidps.engine.entity.character.move.walkOver
@@ -101,11 +101,11 @@ objectOperate("Squeeze-through", "gnome_obstacle_pipe_*") {
     player.message("You pull yourself through the pipes..", ChatType.Filter)
     delay()
     player.setAnimation("climb_through_pipe")
-    player.exactMove(target.tile.addY(2))
+    player.exactMoveDelay(target.tile.addY(2))
     player.face(Direction.NORTH)
     player.tele(target.tile.addY(3))
     player.setAnimation("climb_through_pipe", delay = 1)
-    player.exactMove(target.tile.addY(6))
+    player.exactMoveDelay(target.tile.addY(6))
     if (player.agilityStage == 6) {
         player.agilityStage = 0
         player.inc("gnome_course_laps")

--- a/game/src/main/kotlin/world/gregs/voidps/world/activity/skill/agility/course/GnomeStronghold.kts
+++ b/game/src/main/kotlin/world/gregs/voidps/world/activity/skill/agility/course/GnomeStronghold.kts
@@ -1,7 +1,6 @@
 package world.gregs.voidps.world.activity.skill.agility.course
 
 import world.gregs.voidps.engine.client.message
-import world.gregs.voidps.engine.entity.character.exactMoveDelay
 import world.gregs.voidps.engine.entity.character.face
 import world.gregs.voidps.engine.entity.character.move.tele
 import world.gregs.voidps.engine.entity.character.move.walkOver

--- a/game/src/main/kotlin/world/gregs/voidps/world/activity/skill/agility/course/GnomeStronghold.kts
+++ b/game/src/main/kotlin/world/gregs/voidps/world/activity/skill/agility/course/GnomeStronghold.kts
@@ -8,7 +8,7 @@ import world.gregs.voidps.engine.entity.character.move.walkOver
 import world.gregs.voidps.engine.entity.character.npc.NPCs
 import world.gregs.voidps.engine.entity.character.player.chat.ChatType
 import world.gregs.voidps.engine.entity.character.player.clearRenderEmote
-import world.gregs.voidps.engine.entity.character.player.renderEmote
+import world.gregs.voidps.engine.entity.character.player.setRenderEmote
 import world.gregs.voidps.engine.entity.character.player.skill.Skill
 import world.gregs.voidps.engine.entity.character.player.skill.exp.exp
 import world.gregs.voidps.engine.entity.character.setAnimation
@@ -23,7 +23,7 @@ val npcs: NPCs by inject()
 objectOperate("Walk-across", "gnome_log_balance") {
     player.agilityCourse("gnome")
     npcs.gnomeTrainer("Okay get over that log, quick quick!", listOf(Zone(878901), Zone(878900), Zone(876852)))
-    player.renderEmote = "rope_balance"
+    player.setRenderEmote("rope_balance")
     player.message("You walk carefully across the slippery log...", ChatType.Filter)
     player.walkOver(Tile(2474, 3429))
     player.clearRenderEmote()
@@ -57,7 +57,7 @@ objectOperate("Climb", "gnome_tree_branch_up") {
 
 objectOperate("Walk-on", "gnome_balancing_rope") {
     npcs.gnomeTrainer("Come on scaredy cat, get across that rope!", Zone(9263413))
-    player.renderEmote = "rope_balance"
+    player.setRenderEmote("rope_balance")
     player.walkOver(Tile(2483, 3420, 2))
     player.agilityStage(4)
     player.clearRenderEmote()
@@ -66,7 +66,7 @@ objectOperate("Walk-on", "gnome_balancing_rope") {
 }
 
 objectOperate("Walk-on", "gnome_balancing_rope_end") {
-    player.renderEmote = "rope_balance"
+    player.setRenderEmote("rope_balance")
     player.walkOver(Tile(2477, 3420, 2))
     player.clearRenderEmote()
     player.exp(Skill.Agility, 7.5)

--- a/game/src/main/kotlin/world/gregs/voidps/world/activity/skill/agility/course/WildernessCourse.kts
+++ b/game/src/main/kotlin/world/gregs/voidps/world/activity/skill/agility/course/WildernessCourse.kts
@@ -2,7 +2,6 @@ package world.gregs.voidps.world.activity.skill.agility.course
 
 import world.gregs.voidps.engine.client.message
 import world.gregs.voidps.engine.data.Settings
-import world.gregs.voidps.engine.entity.character.exactMoveDelay
 import world.gregs.voidps.engine.entity.character.face
 import world.gregs.voidps.engine.entity.character.move.tele
 import world.gregs.voidps.engine.entity.character.move.walkOver

--- a/game/src/main/kotlin/world/gregs/voidps/world/activity/skill/agility/course/WildernessCourse.kts
+++ b/game/src/main/kotlin/world/gregs/voidps/world/activity/skill/agility/course/WildernessCourse.kts
@@ -10,7 +10,7 @@ import world.gregs.voidps.engine.entity.character.move.walkTo
 import world.gregs.voidps.engine.entity.character.player.Player
 import world.gregs.voidps.engine.entity.character.player.chat.ChatType
 import world.gregs.voidps.engine.entity.character.player.clearRenderEmote
-import world.gregs.voidps.engine.entity.character.player.renderEmote
+import world.gregs.voidps.engine.entity.character.player.setRenderEmote
 import world.gregs.voidps.engine.entity.character.player.skill.Skill
 import world.gregs.voidps.engine.entity.character.player.skill.exp.exp
 import world.gregs.voidps.engine.entity.character.player.skill.level.Level
@@ -44,7 +44,7 @@ objectOperate("Open", "wilderness_agility_door_closed") {
     val success = true//disable || Level.success(player.levels.get(Skill.Agility), 200..250)
     player.message("You go through the gate and try to edge over the ridge...", ChatType.Filter)
     enterDoor(target, delay = 1)
-    player.renderEmote = "beam_balance"
+    player.setRenderEmote("beam_balance")
 //    if (!success) {
 //        fallIntoPit()
 //        return@strongQueue
@@ -74,7 +74,7 @@ objectOperate("Open", "wilderness_agility_gate_east_closed", "wilderness_agility
     player.message("You go through the gate and try to edge over the ridge...", ChatType.Filter)
     player.walkTo(player.tile.copy(x = player.tile.x.coerceIn(2997, 2998)))
     enterDoor(target)
-    player.renderEmote = "beam_balance"
+    player.setRenderEmote("beam_balance")
     if (!success) {
         fallIntoPit()
         return@objectOperate
@@ -176,7 +176,7 @@ objectOperate("Walk-across", "wilderness_log_balance") {
     val success = disable || Level.success(player.levels.get(Skill.Agility), 200..250)
     if (success) {
         player.walkOver(target.tile)
-        player.renderEmote = "beam_balance"
+        player.setRenderEmote("beam_balance")
         player.walkOver(Tile(2994, 3945))
         player.message("You skillfully edge across the gap.", type = ChatType.Filter)
         player.clearRenderEmote()
@@ -185,7 +185,7 @@ objectOperate("Walk-across", "wilderness_log_balance") {
         player.agilityStage(4)
     } else {
         player.walkOver(target.tile)
-        player.renderEmote = "beam_balance"
+        player.setRenderEmote("beam_balance")
         player.walkOver(Tile(2998, 3945))
         player.message("You slip and fall onto the spikes below.", type = ChatType.Filter)
         player.setAnimation("rope_walk_fall_down")
@@ -206,7 +206,7 @@ objectOperate("Walk-across", "wilderness_log_balance") {
 
 objectOperate("Climb", "wilderness_agility_rocks") {
     player.message("You walk carefully across the slippery log...", ChatType.Filter)
-    player.renderEmote = "climbing"
+    player.setRenderEmote("climbing")
     player.walkOver(player.tile.copy(y = 3933))
     player.clearRenderEmote()
     player.message("You reach the top.", type = ChatType.Filter)

--- a/game/src/main/kotlin/world/gregs/voidps/world/activity/skill/agility/course/WildernessCourse.kts
+++ b/game/src/main/kotlin/world/gregs/voidps/world/activity/skill/agility/course/WildernessCourse.kts
@@ -10,7 +10,7 @@ import world.gregs.voidps.engine.entity.character.move.walkTo
 import world.gregs.voidps.engine.entity.character.player.Player
 import world.gregs.voidps.engine.entity.character.player.chat.ChatType
 import world.gregs.voidps.engine.entity.character.player.clearRenderEmote
-import world.gregs.voidps.engine.entity.character.player.setRenderEmote
+import world.gregs.voidps.engine.entity.character.player.renderEmote
 import world.gregs.voidps.engine.entity.character.player.skill.Skill
 import world.gregs.voidps.engine.entity.character.player.skill.exp.exp
 import world.gregs.voidps.engine.entity.character.player.skill.level.Level
@@ -44,7 +44,7 @@ objectOperate("Open", "wilderness_agility_door_closed") {
     val success = true//disable || Level.success(player.levels.get(Skill.Agility), 200..250)
     player.message("You go through the gate and try to edge over the ridge...", ChatType.Filter)
     enterDoor(target, delay = 1)
-    player.setRenderEmote("beam_balance")
+    player.renderEmote("beam_balance")
 //    if (!success) {
 //        fallIntoPit()
 //        return@strongQueue
@@ -74,7 +74,7 @@ objectOperate("Open", "wilderness_agility_gate_east_closed", "wilderness_agility
     player.message("You go through the gate and try to edge over the ridge...", ChatType.Filter)
     player.walkTo(player.tile.copy(x = player.tile.x.coerceIn(2997, 2998)))
     enterDoor(target)
-    player.setRenderEmote("beam_balance")
+    player.renderEmote("beam_balance")
     if (!success) {
         fallIntoPit()
         return@objectOperate
@@ -176,7 +176,7 @@ objectOperate("Walk-across", "wilderness_log_balance") {
     val success = disable || Level.success(player.levels.get(Skill.Agility), 200..250)
     if (success) {
         player.walkOver(target.tile)
-        player.setRenderEmote("beam_balance")
+        player.renderEmote("beam_balance")
         player.walkOver(Tile(2994, 3945))
         player.message("You skillfully edge across the gap.", type = ChatType.Filter)
         player.clearRenderEmote()
@@ -185,7 +185,7 @@ objectOperate("Walk-across", "wilderness_log_balance") {
         player.agilityStage(4)
     } else {
         player.walkOver(target.tile)
-        player.setRenderEmote("beam_balance")
+        player.renderEmote("beam_balance")
         player.walkOver(Tile(2998, 3945))
         player.message("You slip and fall onto the spikes below.", type = ChatType.Filter)
         player.setAnimation("rope_walk_fall_down")
@@ -206,7 +206,7 @@ objectOperate("Walk-across", "wilderness_log_balance") {
 
 objectOperate("Climb", "wilderness_agility_rocks") {
     player.message("You walk carefully across the slippery log...", ChatType.Filter)
-    player.setRenderEmote("climbing")
+    player.renderEmote("climbing")
     player.walkOver(player.tile.copy(y = 3933))
     player.clearRenderEmote()
     player.message("You reach the top.", type = ChatType.Filter)

--- a/game/src/main/kotlin/world/gregs/voidps/world/activity/skill/agility/course/WildernessCourse.kts
+++ b/game/src/main/kotlin/world/gregs/voidps/world/activity/skill/agility/course/WildernessCourse.kts
@@ -2,7 +2,7 @@ package world.gregs.voidps.world.activity.skill.agility.course
 
 import world.gregs.voidps.engine.client.message
 import world.gregs.voidps.engine.data.Settings
-import world.gregs.voidps.engine.entity.character.exactMove
+import world.gregs.voidps.engine.entity.character.exactMoveDelay
 import world.gregs.voidps.engine.entity.character.face
 import world.gregs.voidps.engine.entity.character.move.tele
 import world.gregs.voidps.engine.entity.character.move.walkOver
@@ -98,7 +98,7 @@ suspend fun SuspendableContext<Player>.fallIntoPit() {
     player.setAnimation("rope_walk_fall_down")
     player.message("You lose your footing and fall into the wolf pit.", ChatType.Filter)
     delay()
-    player.exactMove(Tile(3001, 3923), 25, Direction.SOUTH)
+    player.exactMoveDelay(Tile(3001, 3923), 25, Direction.SOUTH)
 }
 
 objectOperate("Squeeze-through", "wilderness_obstacle_pipe") {
@@ -110,11 +110,11 @@ objectOperate("Squeeze-through", "wilderness_obstacle_pipe") {
         player.walkTo(target.tile.addY(-1))
     }
     player.setAnimation("climb_through_pipe", delay = 30)
-    player.exactMove(Tile(3004, 3940), startDelay = 30, delay = 96, direction = Direction.NORTH)
+    player.exactMoveDelay(Tile(3004, 3940), startDelay = 30, delay = 96, direction = Direction.NORTH)
     player.tele(3004, 3947)
     delay()
     player.setAnimation("climb_through_pipe", delay = 30)
-    player.exactMove(Tile(3004, 3950), startDelay = 30, delay = 96, direction = Direction.NORTH)
+    player.exactMoveDelay(Tile(3004, 3950), startDelay = 30, delay = 96, direction = Direction.NORTH)
     player.exp(Skill.Agility, 12.5)
     player.agilityStage(1)
 }
@@ -129,11 +129,11 @@ objectOperate("Swing-on", "wilderness_rope_swing") {
     target.animate("swing_rope")
     delay()
     if (success) {
-        player.exactMove(player.tile.copy(y = 3958), 60, Direction.NORTH)
+        player.exactMoveDelay(player.tile.copy(y = 3958), 60, Direction.NORTH)
         player.exp(Skill.Agility, 20.0)
         player.message("You skillfully swing across.", ChatType.Filter)
     } else {
-        player.exactMove(player.tile.copy(y = 3957), 50, Direction.NORTH)
+        player.exactMoveDelay(player.tile.copy(y = 3957), 50, Direction.NORTH)
         delay(1)
         player.tele(3004, 10357)
         player.damage((player.levels.get(Skill.Constitution) * 0.15).toInt() + 10)
@@ -149,7 +149,7 @@ objectOperate("Cross", "wilderness_stepping_stone") {
     for (i in 0..5) {
         player.setAnimation("stepping_stone_jump")
         player.playSound("jump")
-        player.exactMove(target.tile.addX(-i), delay = 30, direction = Direction.WEST, startDelay = 15)
+        player.exactMoveDelay(target.tile.addX(-i), delay = 30, direction = Direction.WEST, startDelay = 15)
         delay(1)
         if (i == 2 && !Settings["agility.disableCourseFailure", false] && !Level.success(player.levels.get(Skill.Agility), 180..250)) {
             player.setAnimation("rope_walk_fall_down")

--- a/game/src/main/kotlin/world/gregs/voidps/world/activity/skill/prayer/BoneBurying.kts
+++ b/game/src/main/kotlin/world/gregs/voidps/world/activity/skill/prayer/BoneBurying.kts
@@ -6,6 +6,7 @@ import world.gregs.voidps.engine.client.variable.hasClock
 import world.gregs.voidps.engine.client.variable.start
 import world.gregs.voidps.engine.entity.character.player.chat.ChatType
 import world.gregs.voidps.engine.entity.character.player.skill.Skill
+import world.gregs.voidps.engine.entity.character.player.skill.exp.exp
 import world.gregs.voidps.engine.entity.character.setAnimation
 import world.gregs.voidps.engine.inv.inventory
 import world.gregs.voidps.engine.inv.remove
@@ -32,7 +33,7 @@ inventoryOption("Bury", "inventory") {
     }
     player.start("bone_delay", 1)
     player.setAnimation("bend_down")
-    player.experience.add(Skill.Prayer, xp)
+    player.exp(Skill.Prayer, xp)
     player["i_wonder_if_itll_sprout_task"] = true
     player.weakQueue("bury", 1, onCancel = null) {
         player.message("You bury the ${item.def.name.lowercase()}.", ChatType.Filter)

--- a/game/src/main/kotlin/world/gregs/voidps/world/activity/skill/runecrafting/EssenceMine.kt
+++ b/game/src/main/kotlin/world/gregs/voidps/world/activity/skill/runecrafting/EssenceMine.kt
@@ -3,7 +3,6 @@ package world.gregs.voidps.world.activity.skill.runecrafting
 import world.gregs.voidps.engine.client.message
 import world.gregs.voidps.engine.data.definition.AreaDefinitions
 import world.gregs.voidps.engine.entity.character.face
-import world.gregs.voidps.engine.entity.character.say
 import world.gregs.voidps.engine.entity.character.move.tele
 import world.gregs.voidps.engine.entity.character.npc.NPC
 import world.gregs.voidps.engine.entity.character.player.Player

--- a/game/src/main/kotlin/world/gregs/voidps/world/activity/skill/runecrafting/EssenceMine.kt
+++ b/game/src/main/kotlin/world/gregs/voidps/world/activity/skill/runecrafting/EssenceMine.kt
@@ -3,7 +3,7 @@ package world.gregs.voidps.world.activity.skill.runecrafting
 import world.gregs.voidps.engine.client.message
 import world.gregs.voidps.engine.data.definition.AreaDefinitions
 import world.gregs.voidps.engine.entity.character.face
-import world.gregs.voidps.engine.entity.character.forceChat
+import world.gregs.voidps.engine.entity.character.say
 import world.gregs.voidps.engine.entity.character.move.tele
 import world.gregs.voidps.engine.entity.character.npc.NPC
 import world.gregs.voidps.engine.entity.character.player.Player
@@ -18,7 +18,7 @@ import world.gregs.voidps.world.interact.entity.proj.shoot
 
 object EssenceMine {
     fun teleport(npc: NPC, player: Player) {
-        npc.forceChat = "Senventior Disthine Molenko!"
+        npc.say("Senventior Disthine Molenko!")
         npc.setGraphic("curse_cast")
         npc.face(player)
         if (!npc.contains("old_model")) {

--- a/game/src/main/kotlin/world/gregs/voidps/world/activity/skill/thieving/Pickpocketing.kts
+++ b/game/src/main/kotlin/world/gregs/voidps/world/activity/skill/thieving/Pickpocketing.kts
@@ -7,7 +7,7 @@ import world.gregs.voidps.engine.data.definition.AnimationDefinitions
 import world.gregs.voidps.engine.data.definition.data.Pocket
 import world.gregs.voidps.engine.entity.World
 import world.gregs.voidps.engine.entity.character.face
-import world.gregs.voidps.engine.entity.character.forceChat
+import world.gregs.voidps.engine.entity.character.say
 import world.gregs.voidps.engine.entity.character.npc.NPC
 import world.gregs.voidps.engine.entity.character.npc.npcApproach
 import world.gregs.voidps.engine.entity.character.player.Player
@@ -59,7 +59,7 @@ npcApproach("Pickpocket") {
         player.exp(Skill.Thieving, pocket.xp)
     } else {
         target.face(player)
-        target.forceChat = pocket.caughtMessage
+        target.say(pocket.caughtMessage)
         target.setAnimation(NPCAttack.animation(target, animationDefinitions))
         player.message("You fail to pick the ${name}'s pocket.", ChatType.Filter)
         target.stun(player, pocket.stunTicks, pocket.stunHit)

--- a/game/src/main/kotlin/world/gregs/voidps/world/activity/skill/thieving/Pickpocketing.kts
+++ b/game/src/main/kotlin/world/gregs/voidps/world/activity/skill/thieving/Pickpocketing.kts
@@ -7,7 +7,6 @@ import world.gregs.voidps.engine.data.definition.AnimationDefinitions
 import world.gregs.voidps.engine.data.definition.data.Pocket
 import world.gregs.voidps.engine.entity.World
 import world.gregs.voidps.engine.entity.character.face
-import world.gregs.voidps.engine.entity.character.say
 import world.gregs.voidps.engine.entity.character.npc.NPC
 import world.gregs.voidps.engine.entity.character.npc.npcApproach
 import world.gregs.voidps.engine.entity.character.player.Player

--- a/game/src/main/kotlin/world/gregs/voidps/world/command/debug/NPCUpdatingCommands.kts
+++ b/game/src/main/kotlin/world/gregs/voidps/world/command/debug/NPCUpdatingCommands.kts
@@ -45,7 +45,7 @@ adminCommand("npcoverlay") {
 
 adminCommand("npcchat") {
     val npc = npcs[player.tile.addY(1)].first()
-    npc.forceChat = "Testing"
+    npc.say("Testing")
 }
 
 adminCommand("npcgfx") {

--- a/game/src/main/kotlin/world/gregs/voidps/world/command/debug/PlayerUpdatingCommands.kts
+++ b/game/src/main/kotlin/world/gregs/voidps/world/command/debug/PlayerUpdatingCommands.kts
@@ -41,8 +41,8 @@ adminCommand("anim (anim-id)", "perform animation by int or string id (-1 to cle
 
 adminCommand("emote (emote-id)", "perform render emote by int or string id (-1 to clear)") {
     when (content) {
-        "-1", "" -> player.renderEmote = "human_stand"
-        else -> player.renderEmote = content
+        "-1", "" -> player.setRenderEmote("human_stand")
+        else -> player.setRenderEmote(content)
     }
 }
 

--- a/game/src/main/kotlin/world/gregs/voidps/world/command/debug/PlayerUpdatingCommands.kts
+++ b/game/src/main/kotlin/world/gregs/voidps/world/command/debug/PlayerUpdatingCommands.kts
@@ -66,7 +66,7 @@ adminCommand("overlay") {
 }
 
 adminCommand("chat (message)", "force a chat message over players head") {
-    player.forceChat = content
+    player.say(content)
 }
 
 adminCommand("move") {

--- a/game/src/main/kotlin/world/gregs/voidps/world/command/debug/PlayerUpdatingCommands.kts
+++ b/game/src/main/kotlin/world/gregs/voidps/world/command/debug/PlayerUpdatingCommands.kts
@@ -41,8 +41,8 @@ adminCommand("anim (anim-id)", "perform animation by int or string id (-1 to cle
 
 adminCommand("emote (emote-id)", "perform render emote by int or string id (-1 to clear)") {
     when (content) {
-        "-1", "" -> player.setRenderEmote("human_stand")
-        else -> player.setRenderEmote(content)
+        "-1", "" -> player.renderEmote("human_stand")
+        else -> player.renderEmote(content)
     }
 }
 

--- a/game/src/main/kotlin/world/gregs/voidps/world/interact/entity/npc/Cows.kts
+++ b/game/src/main/kotlin/world/gregs/voidps/world/interact/entity/npc/Cows.kts
@@ -2,7 +2,7 @@ package world.gregs.voidps.world.interact.entity.npc
 
 import world.gregs.voidps.engine.client.message
 import world.gregs.voidps.engine.client.ui.interact.itemOnNPCOperate
-import world.gregs.voidps.engine.entity.character.forceChat
+import world.gregs.voidps.engine.entity.character.say
 import world.gregs.voidps.engine.entity.character.mode.EmptyMode
 import world.gregs.voidps.engine.entity.character.setAnimation
 import world.gregs.voidps.engine.entity.npcSpawn
@@ -21,7 +21,7 @@ npcTimerStart("eat_grass") { npc ->
 
 npcTimerTick("eat_grass") { npc ->
     if (npc.mode == EmptyMode) {
-        npc.forceChat = "Moo"
+        npc.say("Moo")
         npc.setAnimation("cow_eat_grass")
     }
 }

--- a/game/src/main/kotlin/world/gregs/voidps/world/interact/entity/npc/Cows.kts
+++ b/game/src/main/kotlin/world/gregs/voidps/world/interact/entity/npc/Cows.kts
@@ -2,7 +2,6 @@ package world.gregs.voidps.world.interact.entity.npc
 
 import world.gregs.voidps.engine.client.message
 import world.gregs.voidps.engine.client.ui.interact.itemOnNPCOperate
-import world.gregs.voidps.engine.entity.character.say
 import world.gregs.voidps.engine.entity.character.mode.EmptyMode
 import world.gregs.voidps.engine.entity.character.setAnimation
 import world.gregs.voidps.engine.entity.npcSpawn

--- a/game/src/main/kotlin/world/gregs/voidps/world/interact/entity/npc/move/Ducklings.kts
+++ b/game/src/main/kotlin/world/gregs/voidps/world/interact/entity/npc/move/Ducklings.kts
@@ -1,6 +1,6 @@
 package world.gregs.voidps.world.interact.entity.npc.move
 
-import world.gregs.voidps.engine.entity.character.forceChat
+import world.gregs.voidps.engine.entity.character.say
 import world.gregs.voidps.engine.entity.character.mode.EmptyMode
 import world.gregs.voidps.engine.entity.character.mode.Follow
 import world.gregs.voidps.engine.entity.character.mode.Wander
@@ -25,7 +25,7 @@ fun isDuck(it: NPC) = it.id.startsWith("duck") && it.id.endsWith("swim")
 
 npcDeath("duck*swim") { npc ->
     val ducklings: NPC = npc["ducklings"] ?: return@npcDeath
-    ducklings.forceChat = "Eek!"
+    ducklings.say("Eek!")
     followParent(ducklings)
 }
 
@@ -41,9 +41,9 @@ npcTimerTick("follow_parent") { npc ->
     npc.mode = Follow(npc, parent)
     parent["ducklings"] = npc
     if (random.nextInt(300) < 1) {
-        parent.forceChat = "Quack?"
+        parent.say("Quack?")
         npc.softQueue("quack", 1) {
-            npc.forceChat = if (random.nextBoolean()) "Cheep Cheep!" else "Eep!"
+            npc.say(if (random.nextBoolean()) "Cheep Cheep!" else "Eep!")
         }
     }
     cancel()

--- a/game/src/main/kotlin/world/gregs/voidps/world/interact/entity/npc/move/Ducklings.kts
+++ b/game/src/main/kotlin/world/gregs/voidps/world/interact/entity/npc/move/Ducklings.kts
@@ -1,6 +1,5 @@
 package world.gregs.voidps.world.interact.entity.npc.move
 
-import world.gregs.voidps.engine.entity.character.say
 import world.gregs.voidps.engine.entity.character.mode.EmptyMode
 import world.gregs.voidps.engine.entity.character.mode.Follow
 import world.gregs.voidps.engine.entity.character.mode.Wander

--- a/game/src/main/kotlin/world/gregs/voidps/world/interact/entity/player/combat/consume/drink/Tea.kts
+++ b/game/src/main/kotlin/world/gregs/voidps/world/interact/entity/player/combat/consume/drink/Tea.kts
@@ -2,7 +2,6 @@ package world.gregs.voidps.world.interact.entity.player.combat.consume.drink
 
 import world.gregs.voidps.engine.client.message
 import world.gregs.voidps.engine.client.ui.interact.itemOnItem
-import world.gregs.voidps.engine.entity.character.say
 import world.gregs.voidps.engine.entity.character.player.skill.Skill
 import world.gregs.voidps.engine.inv.charges
 import world.gregs.voidps.engine.inv.discharge

--- a/game/src/main/kotlin/world/gregs/voidps/world/interact/entity/player/combat/consume/drink/Tea.kts
+++ b/game/src/main/kotlin/world/gregs/voidps/world/interact/entity/player/combat/consume/drink/Tea.kts
@@ -2,7 +2,7 @@ package world.gregs.voidps.world.interact.entity.player.combat.consume.drink
 
 import world.gregs.voidps.engine.client.message
 import world.gregs.voidps.engine.client.ui.interact.itemOnItem
-import world.gregs.voidps.engine.entity.character.forceChat
+import world.gregs.voidps.engine.entity.character.say
 import world.gregs.voidps.engine.entity.character.player.skill.Skill
 import world.gregs.voidps.engine.inv.charges
 import world.gregs.voidps.engine.inv.discharge
@@ -54,7 +54,7 @@ inventoryItem("Drink", "tea_flask") {
         return@inventoryItem
     }
 
-    player.forceChat = "Ahhh, tea is so refreshing!"
+    player.say("Ahhh, tea is so refreshing!")
     player.levels.boost(Skill.Attack, 3)
     player.levels.restore(Skill.Constitution, 30)
     player.message("You take a drink from the flask...")

--- a/game/src/main/kotlin/world/gregs/voidps/world/interact/entity/player/combat/consume/food/Kebab.kts
+++ b/game/src/main/kotlin/world/gregs/voidps/world/interact/entity/player/combat/consume/food/Kebab.kts
@@ -1,7 +1,6 @@
 package world.gregs.voidps.world.interact.entity.player.combat.consume.food
 
 import world.gregs.voidps.engine.client.message
-import world.gregs.voidps.engine.entity.character.say
 import world.gregs.voidps.engine.entity.character.player.chat.ChatType
 import world.gregs.voidps.engine.entity.character.player.skill.Skill
 import world.gregs.voidps.type.random

--- a/game/src/main/kotlin/world/gregs/voidps/world/interact/entity/player/combat/consume/food/Kebab.kts
+++ b/game/src/main/kotlin/world/gregs/voidps/world/interact/entity/player/combat/consume/food/Kebab.kts
@@ -1,7 +1,7 @@
 package world.gregs.voidps.world.interact.entity.player.combat.consume.food
 
 import world.gregs.voidps.engine.client.message
-import world.gregs.voidps.engine.entity.character.forceChat
+import world.gregs.voidps.engine.entity.character.say
 import world.gregs.voidps.engine.entity.character.player.chat.ChatType
 import world.gregs.voidps.engine.entity.character.player.skill.Skill
 import world.gregs.voidps.type.random
@@ -48,6 +48,6 @@ val phrases = listOf("Lovely!", "Scrummy!", "Delicious!", "Yum!")
 
 consume("ugthanki_kebab") { player ->
     if (player.levels.get(Skill.Constitution) != player.levels.getMax(Skill.Constitution)) {
-        player.forceChat = phrases.random()
+        player.say(phrases.random())
     }
 }

--- a/game/src/main/kotlin/world/gregs/voidps/world/interact/entity/player/combat/magic/spell/book/lunar/Vengeance.kts
+++ b/game/src/main/kotlin/world/gregs/voidps/world/interact/entity/player/combat/magic/spell/book/lunar/Vengeance.kts
@@ -6,7 +6,7 @@ import world.gregs.voidps.engine.client.variable.remaining
 import world.gregs.voidps.engine.client.variable.start
 import world.gregs.voidps.engine.client.variable.stop
 import world.gregs.voidps.engine.data.definition.SpellDefinitions
-import world.gregs.voidps.engine.entity.character.forceChat
+import world.gregs.voidps.engine.entity.character.say
 import world.gregs.voidps.engine.entity.character.player.skill.Skill
 import world.gregs.voidps.engine.entity.character.setAnimation
 import world.gregs.voidps.engine.entity.character.setGraphic
@@ -43,7 +43,7 @@ combatHit { player ->
     if (!player.contains("vengeance") || type == "damage" || damage < 4) {
         return@combatHit
     }
-    player.forceChat = "Taste vengeance!"
+    player.say("Taste vengeance!")
     player.hit(target = source, type = "damage", delay = 0, damage = (damage * 0.75).toInt())
     player.stop("vengeance")
 }

--- a/game/src/main/kotlin/world/gregs/voidps/world/interact/entity/player/combat/magic/spell/book/lunar/Vengeance.kts
+++ b/game/src/main/kotlin/world/gregs/voidps/world/interact/entity/player/combat/magic/spell/book/lunar/Vengeance.kts
@@ -6,7 +6,6 @@ import world.gregs.voidps.engine.client.variable.remaining
 import world.gregs.voidps.engine.client.variable.start
 import world.gregs.voidps.engine.client.variable.stop
 import world.gregs.voidps.engine.data.definition.SpellDefinitions
-import world.gregs.voidps.engine.entity.character.say
 import world.gregs.voidps.engine.entity.character.player.skill.Skill
 import world.gregs.voidps.engine.entity.character.setAnimation
 import world.gregs.voidps.engine.entity.character.setGraphic

--- a/game/src/main/kotlin/world/gregs/voidps/world/interact/entity/player/combat/melee/special/DragonBattleaxe.kts
+++ b/game/src/main/kotlin/world/gregs/voidps/world/interact/entity/player/combat/melee/special/DragonBattleaxe.kts
@@ -1,6 +1,6 @@
 package world.gregs.voidps.world.interact.entity.player.combat.melee.special
 
-import world.gregs.voidps.engine.entity.character.forceChat
+import world.gregs.voidps.engine.entity.character.say
 import world.gregs.voidps.engine.entity.character.player.skill.Skill
 import world.gregs.voidps.engine.entity.character.setAnimation
 import world.gregs.voidps.engine.entity.character.setGraphic
@@ -16,7 +16,7 @@ specialAttackPrepare("rampage") { player ->
     player.setAnimation("${id}_special")
     player.setGraphic("${id}_special")
     player.playSound("${id}_special")
-    player.forceChat = "Raarrrrrgggggghhhhhhh!"
+    player.say("Raarrrrrgggggghhhhhhh!")
     player.levels.drain(Skill.Attack, multiplier = 0.10)
     player.levels.drain(Skill.Defence, multiplier = 0.10)
     player.levels.drain(Skill.Magic, multiplier = 0.10)

--- a/game/src/main/kotlin/world/gregs/voidps/world/interact/entity/player/combat/melee/special/DragonBattleaxe.kts
+++ b/game/src/main/kotlin/world/gregs/voidps/world/interact/entity/player/combat/melee/special/DragonBattleaxe.kts
@@ -1,6 +1,5 @@
 package world.gregs.voidps.world.interact.entity.player.combat.melee.special
 
-import world.gregs.voidps.engine.entity.character.say
 import world.gregs.voidps.engine.entity.character.player.skill.Skill
 import world.gregs.voidps.engine.entity.character.setAnimation
 import world.gregs.voidps.engine.entity.character.setGraphic

--- a/game/src/main/kotlin/world/gregs/voidps/world/interact/entity/player/combat/melee/special/Excalibur.kts
+++ b/game/src/main/kotlin/world/gregs/voidps/world/interact/entity/player/combat/melee/special/Excalibur.kts
@@ -1,6 +1,5 @@
 package world.gregs.voidps.world.interact.entity.player.combat.melee.special
 
-import world.gregs.voidps.engine.entity.character.say
 import world.gregs.voidps.engine.entity.character.player.Player
 import world.gregs.voidps.engine.entity.character.player.skill.Skill
 import world.gregs.voidps.engine.entity.character.setAnimation

--- a/game/src/main/kotlin/world/gregs/voidps/world/interact/entity/player/combat/melee/special/Excalibur.kts
+++ b/game/src/main/kotlin/world/gregs/voidps/world/interact/entity/player/combat/melee/special/Excalibur.kts
@@ -1,6 +1,6 @@
 package world.gregs.voidps.world.interact.entity.player.combat.melee.special
 
-import world.gregs.voidps.engine.entity.character.forceChat
+import world.gregs.voidps.engine.entity.character.say
 import world.gregs.voidps.engine.entity.character.player.Player
 import world.gregs.voidps.engine.entity.character.player.skill.Skill
 import world.gregs.voidps.engine.entity.character.setAnimation
@@ -25,7 +25,7 @@ specialAttackPrepare("sanctuary") { player ->
     player.setAnimation("${id}_special")
     player.setGraphic("${id}_special")
     player.playSound("${id}_special")
-    player.forceChat = "For Camelot!"
+    player.say("For Camelot!")
     if (player.weapon.id.startsWith("enhanced")) {
         player.levels.boost(Skill.Defence, multiplier = 0.15)
         player[id] = TimeUnit.SECONDS.toTicks(if (seersVillageEliteTasks(player)) 24 else 12) / 4

--- a/game/src/main/kotlin/world/gregs/voidps/world/interact/entity/player/combat/melee/special/SpearShove.kts
+++ b/game/src/main/kotlin/world/gregs/voidps/world/interact/entity/player/combat/melee/special/SpearShove.kts
@@ -2,7 +2,6 @@ package world.gregs.voidps.world.interact.entity.player.combat.melee.special
 
 import world.gregs.voidps.engine.client.message
 import world.gregs.voidps.engine.client.variable.hasClock
-import world.gregs.voidps.engine.entity.character.exactMove
 import world.gregs.voidps.engine.entity.character.player.Player
 import world.gregs.voidps.engine.entity.character.setAnimation
 import world.gregs.voidps.engine.entity.character.setGraphic

--- a/game/src/main/kotlin/world/gregs/voidps/world/interact/entity/player/combat/melee/special/SpearShove.kts
+++ b/game/src/main/kotlin/world/gregs/voidps/world/interact/entity/player/combat/melee/special/SpearShove.kts
@@ -2,7 +2,7 @@ package world.gregs.voidps.world.interact.entity.player.combat.melee.special
 
 import world.gregs.voidps.engine.client.message
 import world.gregs.voidps.engine.client.variable.hasClock
-import world.gregs.voidps.engine.entity.character.setExactMove
+import world.gregs.voidps.engine.entity.character.exactMove
 import world.gregs.voidps.engine.entity.character.player.Player
 import world.gregs.voidps.engine.entity.character.setAnimation
 import world.gregs.voidps.engine.entity.character.setGraphic
@@ -41,6 +41,6 @@ specialAttack("shove") { player ->
     val direction = target.tile.delta(actual).toDirection()
     val delta = direction.delta
     if (!target.blocked(direction)) {
-        target.setExactMove(delta, 30, direction.inverse())
+        target.exactMove(delta, 30, direction.inverse())
     }
 }

--- a/game/src/main/kotlin/world/gregs/voidps/world/interact/entity/player/display/tab/ItemEmotes.kts
+++ b/game/src/main/kotlin/world/gregs/voidps/world/interact/entity/player/display/tab/ItemEmotes.kts
@@ -214,12 +214,12 @@ inventoryItem("Play-with", "toy_horsey_*") {
         player.message("Please wait till you've finished performing your current emote.")
         return@inventoryItem
     }
-    player.forceChat = when (random.nextInt(0, 3)) {
+    player.say(when (random.nextInt(0, 3)) {
         0 -> "Come on Dobbin, we can win the race!"
         1 -> "Hi-ho Silver, and away!"
         else -> "Neaahhhyyy! Giddy-up horsey!"
-    }
-//    player.forceChat = "Just say neigh to gambling!"
+    })
+//    player.say("Just say neigh to gambling!")
     player.animate("emote_${item.id}")
 }
 

--- a/game/src/main/kotlin/world/gregs/voidps/world/map/ardougne/WizardCromperty.kts
+++ b/game/src/main/kotlin/world/gregs/voidps/world/map/ardougne/WizardCromperty.kts
@@ -1,7 +1,7 @@
 package world.gregs.voidps.world.map.ardougne
 
 import world.gregs.voidps.engine.client.message
-import world.gregs.voidps.engine.entity.character.forceChat
+import world.gregs.voidps.engine.entity.character.say
 import world.gregs.voidps.engine.entity.character.move.tele
 import world.gregs.voidps.engine.entity.character.npc.NPCOption
 import world.gregs.voidps.engine.entity.character.npc.npcOperate
@@ -77,7 +77,7 @@ fun ChoiceBuilder<NPCOption<Player>>.teleportMe() {
                 npc<Happy>("Okey dokey! Ready?")
                 player.setGraphic("curse_hit")
                 target.setGraphic("curse_cast")
-                target.forceChat = "Dipsolum sententa sententi!"
+                target.say("Dipsolum sententa sententi!")
                 target.shoot("curse", player.tile, offset = 64)
                 player.softQueue("cromperty_teleport", 2) {
                     player.tele(2649, 3271)

--- a/game/src/main/kotlin/world/gregs/voidps/world/map/ardougne/WizardCromperty.kts
+++ b/game/src/main/kotlin/world/gregs/voidps/world/map/ardougne/WizardCromperty.kts
@@ -1,7 +1,6 @@
 package world.gregs.voidps.world.map.ardougne
 
 import world.gregs.voidps.engine.client.message
-import world.gregs.voidps.engine.entity.character.say
 import world.gregs.voidps.engine.entity.character.move.tele
 import world.gregs.voidps.engine.entity.character.npc.NPCOption
 import world.gregs.voidps.engine.entity.character.npc.npcOperate

--- a/game/src/main/kotlin/world/gregs/voidps/world/map/falador/MakeoverMage.kts
+++ b/game/src/main/kotlin/world/gregs/voidps/world/map/falador/MakeoverMage.kts
@@ -6,7 +6,6 @@ import world.gregs.voidps.engine.client.ui.event.interfaceClose
 import world.gregs.voidps.engine.client.ui.event.interfaceOpen
 import world.gregs.voidps.engine.client.ui.interfaceOption
 import world.gregs.voidps.engine.data.definition.EnumDefinitions
-import world.gregs.voidps.engine.entity.character.say
 import world.gregs.voidps.engine.entity.character.npc.NPCOption
 import world.gregs.voidps.engine.entity.character.npc.NPCs
 import world.gregs.voidps.engine.entity.character.npc.npcOperate

--- a/game/src/main/kotlin/world/gregs/voidps/world/map/falador/MakeoverMage.kts
+++ b/game/src/main/kotlin/world/gregs/voidps/world/map/falador/MakeoverMage.kts
@@ -6,7 +6,7 @@ import world.gregs.voidps.engine.client.ui.event.interfaceClose
 import world.gregs.voidps.engine.client.ui.event.interfaceOpen
 import world.gregs.voidps.engine.client.ui.interfaceOption
 import world.gregs.voidps.engine.data.definition.EnumDefinitions
-import world.gregs.voidps.engine.entity.character.forceChat
+import world.gregs.voidps.engine.entity.character.say
 import world.gregs.voidps.engine.entity.character.npc.NPCOption
 import world.gregs.voidps.engine.entity.character.npc.NPCs
 import world.gregs.voidps.engine.entity.character.npc.npcOperate
@@ -222,6 +222,6 @@ npcTimerTick("makeover") { npc ->
     npc.setGraphic("curse_hit", delay = 15)
     npc.setAnimation("bind_staff")
     npc.softQueue("transform", 1) {
-        npc.forceChat = if (toFemale) "Ooh!" else "Aha!"
+        npc.say(if (toFemale) "Ooh!" else "Aha!")
     }
 }

--- a/game/src/main/kotlin/world/gregs/voidps/world/map/karamja/BartenderZambo.kts
+++ b/game/src/main/kotlin/world/gregs/voidps/world/map/karamja/BartenderZambo.kts
@@ -1,7 +1,7 @@
 package world.gregs.voidps.world.map.karamja
 
 import world.gregs.voidps.engine.client.ui.interact.itemOnNPCOperate
-import world.gregs.voidps.engine.entity.character.forceChat
+import world.gregs.voidps.engine.entity.character.say
 import world.gregs.voidps.engine.entity.character.mode.interact.TargetInteraction
 import world.gregs.voidps.engine.entity.character.npc.NPC
 import world.gregs.voidps.engine.entity.character.npc.npcOperate
@@ -37,6 +37,6 @@ itemOnNPCOperate("barcrawl_card", "bartender_zambo") {
 
 suspend fun TargetInteraction<Player, NPC>.barCrawl() = barCrawlDrink(
     effects = {
-        player.forceChat = "Mmmmm, dat was luverly..."
+        player.say("Mmmmm, dat was luverly...")
     }
 )

--- a/game/src/main/kotlin/world/gregs/voidps/world/map/karamja/BartenderZambo.kts
+++ b/game/src/main/kotlin/world/gregs/voidps/world/map/karamja/BartenderZambo.kts
@@ -1,7 +1,6 @@
 package world.gregs.voidps.world.map.karamja
 
 import world.gregs.voidps.engine.client.ui.interact.itemOnNPCOperate
-import world.gregs.voidps.engine.entity.character.say
 import world.gregs.voidps.engine.entity.character.mode.interact.TargetInteraction
 import world.gregs.voidps.engine.entity.character.npc.NPC
 import world.gregs.voidps.engine.entity.character.npc.npcOperate

--- a/game/src/main/kotlin/world/gregs/voidps/world/map/lumbridge/Hans.kts
+++ b/game/src/main/kotlin/world/gregs/voidps/world/map/lumbridge/Hans.kts
@@ -1,6 +1,5 @@
 package world.gregs.voidps.world.map.lumbridge
 
-import world.gregs.voidps.engine.entity.character.say
 import world.gregs.voidps.engine.entity.character.mode.Retreat
 import world.gregs.voidps.engine.entity.character.npc.npcOperate
 import world.gregs.voidps.world.interact.dialogue.EvilLaugh

--- a/game/src/main/kotlin/world/gregs/voidps/world/map/lumbridge/Hans.kts
+++ b/game/src/main/kotlin/world/gregs/voidps/world/map/lumbridge/Hans.kts
@@ -1,6 +1,6 @@
 package world.gregs.voidps.world.map.lumbridge
 
-import world.gregs.voidps.engine.entity.character.forceChat
+import world.gregs.voidps.engine.entity.character.say
 import world.gregs.voidps.engine.entity.character.mode.Retreat
 import world.gregs.voidps.engine.entity.character.npc.npcOperate
 import world.gregs.voidps.world.interact.dialogue.EvilLaugh
@@ -16,7 +16,7 @@ npcOperate("Talk-to", "hans") {
             npc<Talk>("Who, the Duke? He's in his study, on the first floor.")
         }
         option<EvilLaugh>("I have come to kill everyone in this castle!") {
-            target.forceChat = "Help! Help!"
+            target.say("Help! Help!")
             target.mode = Retreat(target, player)
         }
         option<Uncertain>("I don't know. I'm lost. Where am I?") {

--- a/game/src/main/kotlin/world/gregs/voidps/world/map/lumbridge/LumbridgeChurch.kts
+++ b/game/src/main/kotlin/world/gregs/voidps/world/map/lumbridge/LumbridgeChurch.kts
@@ -8,7 +8,7 @@ import world.gregs.voidps.engine.client.ui.interact.itemOnObjectOperate
 import world.gregs.voidps.engine.entity.character.animate
 import world.gregs.voidps.engine.event.Context
 import world.gregs.voidps.engine.entity.character.face
-import world.gregs.voidps.engine.entity.character.forceChat
+import world.gregs.voidps.engine.entity.character.say
 import world.gregs.voidps.engine.entity.character.mode.interact.Interaction
 import world.gregs.voidps.engine.entity.character.move.tele
 import world.gregs.voidps.engine.entity.character.npc.NPCs
@@ -100,9 +100,9 @@ suspend fun Interaction<Player>.returnSkull() {
     player.turnCamera(Tile(3248, 3193).add(offset), 320)
     delay(2)
     player.face(Direction.NORTH)
-    restlessGhost.forceChat = "Release! Thank you"
+    restlessGhost.say("Release! Thank you")
     delay(4)
-    restlessGhost.forceChat = "stranger."
+    restlessGhost.say("stranger.")
     restlessGhost.animate("restless_ghost_ascends")
     restlessGhost.shoot("restless_ghost", Tile(3243, 3193).add(offset), height = 20, endHeight = 0, flightTime = 50)
     delay(2)

--- a/game/src/main/kotlin/world/gregs/voidps/world/map/lumbridge/LumbridgeChurch.kts
+++ b/game/src/main/kotlin/world/gregs/voidps/world/map/lumbridge/LumbridgeChurch.kts
@@ -8,7 +8,6 @@ import world.gregs.voidps.engine.client.ui.interact.itemOnObjectOperate
 import world.gregs.voidps.engine.entity.character.animate
 import world.gregs.voidps.engine.event.Context
 import world.gregs.voidps.engine.entity.character.face
-import world.gregs.voidps.engine.entity.character.say
 import world.gregs.voidps.engine.entity.character.mode.interact.Interaction
 import world.gregs.voidps.engine.entity.character.move.tele
 import world.gregs.voidps.engine.entity.character.npc.NPCs

--- a/game/src/main/kotlin/world/gregs/voidps/world/map/lumbridge/LumbridgeFlag.kts
+++ b/game/src/main/kotlin/world/gregs/voidps/world/map/lumbridge/LumbridgeFlag.kts
@@ -1,7 +1,6 @@
 package world.gregs.voidps.world.map.lumbridge
 
 import world.gregs.voidps.engine.entity.character.animate
-import world.gregs.voidps.engine.entity.character.say
 import world.gregs.voidps.engine.entity.obj.objectOperate
 
 objectOperate("Raise", "lumbridge_flag") {

--- a/game/src/main/kotlin/world/gregs/voidps/world/map/lumbridge/LumbridgeFlag.kts
+++ b/game/src/main/kotlin/world/gregs/voidps/world/map/lumbridge/LumbridgeFlag.kts
@@ -1,14 +1,14 @@
 package world.gregs.voidps.world.map.lumbridge
 
 import world.gregs.voidps.engine.entity.character.animate
-import world.gregs.voidps.engine.entity.character.forceChat
+import world.gregs.voidps.engine.entity.character.say
 import world.gregs.voidps.engine.entity.obj.objectOperate
 
 objectOperate("Raise", "lumbridge_flag") {
     target.animate("lumbridge_flag")
     player.animate("lumbridge_flag_raise")
     player.animate("lumbridge_flag_stop_raise")
-    player.forceChat = "All Hail the Duke!"
+    player.say("All Hail the Duke!")
     player.animate("emote_salute")
     player["raise_the_roof_task"] = true
 }

--- a/game/src/main/kotlin/world/gregs/voidps/world/map/port_sarim/BartenderRustyAnchor.kts
+++ b/game/src/main/kotlin/world/gregs/voidps/world/map/port_sarim/BartenderRustyAnchor.kts
@@ -2,7 +2,7 @@ package world.gregs.voidps.world.map.port_sarim
 
 import world.gregs.voidps.engine.client.message
 import world.gregs.voidps.engine.client.ui.interact.itemOnNPCOperate
-import world.gregs.voidps.engine.entity.character.forceChat
+import world.gregs.voidps.engine.entity.character.say
 import world.gregs.voidps.engine.entity.character.mode.interact.TargetInteraction
 import world.gregs.voidps.engine.entity.character.npc.NPC
 import world.gregs.voidps.engine.entity.character.npc.npcOperate
@@ -49,6 +49,6 @@ suspend fun TargetInteraction<Player, NPC>.barCrawl() = barCrawlDrink(
         npc<Talk>("Ok one Black Skull Ale coming up, 8 coins please.")
     },
     effects = {
-        player.forceChat = "Hiccup!"
+        player.say("Hiccup!")
     }
 )

--- a/game/src/main/kotlin/world/gregs/voidps/world/map/port_sarim/BartenderRustyAnchor.kts
+++ b/game/src/main/kotlin/world/gregs/voidps/world/map/port_sarim/BartenderRustyAnchor.kts
@@ -2,7 +2,6 @@ package world.gregs.voidps.world.map.port_sarim
 
 import world.gregs.voidps.engine.client.message
 import world.gregs.voidps.engine.client.ui.interact.itemOnNPCOperate
-import world.gregs.voidps.engine.entity.character.say
 import world.gregs.voidps.engine.entity.character.mode.interact.TargetInteraction
 import world.gregs.voidps.engine.entity.character.npc.NPC
 import world.gregs.voidps.engine.entity.character.npc.npcOperate

--- a/game/src/main/kotlin/world/gregs/voidps/world/map/varrock/BartenderBlueMoonInn.kts
+++ b/game/src/main/kotlin/world/gregs/voidps/world/map/varrock/BartenderBlueMoonInn.kts
@@ -3,7 +3,6 @@ package world.gregs.voidps.world.map.varrock
 import world.gregs.voidps.engine.client.message
 import world.gregs.voidps.engine.client.ui.interact.itemOnNPCApproach
 import world.gregs.voidps.engine.data.Settings
-import world.gregs.voidps.engine.entity.character.say
 import world.gregs.voidps.engine.entity.character.mode.interact.TargetInteraction
 import world.gregs.voidps.engine.entity.character.npc.NPC
 import world.gregs.voidps.engine.entity.character.npc.npcApproach

--- a/game/src/main/kotlin/world/gregs/voidps/world/map/varrock/BartenderBlueMoonInn.kts
+++ b/game/src/main/kotlin/world/gregs/voidps/world/map/varrock/BartenderBlueMoonInn.kts
@@ -3,7 +3,7 @@ package world.gregs.voidps.world.map.varrock
 import world.gregs.voidps.engine.client.message
 import world.gregs.voidps.engine.client.ui.interact.itemOnNPCApproach
 import world.gregs.voidps.engine.data.Settings
-import world.gregs.voidps.engine.entity.character.forceChat
+import world.gregs.voidps.engine.entity.character.say
 import world.gregs.voidps.engine.entity.character.mode.interact.TargetInteraction
 import world.gregs.voidps.engine.entity.character.npc.NPC
 import world.gregs.voidps.engine.entity.character.npc.npcApproach
@@ -75,6 +75,6 @@ suspend fun TargetInteraction<Player, NPC>.barCrawl() = barCrawlDrink(
         player.levels.drain(Skill.Strength, 6)
         player.levels.drain(Skill.Smithing, 6)
         player.damage(0)
-        player.forceChat = "Blearrgh!"
+        player.say("Blearrgh!")
     }
 )

--- a/game/src/main/kotlin/world/gregs/voidps/world/map/varrock/Delrith.kts
+++ b/game/src/main/kotlin/world/gregs/voidps/world/map/varrock/Delrith.kts
@@ -160,7 +160,7 @@ suspend fun SuspendableContext<Player>.cutscene() {
     player.moveCamera(Tile(3231, 3376).add(offset), 475, 1, 1)
     npc<Happy>("denath", "Arise, O mighty Delrith! Bring destruction to this soft, weak city!")
     for (wizard in wizards) {
-        wizard.forceChat = "Arise, Delrith!"
+        wizard.say("Arise, Delrith!")
     }
     npc<Neutral>("dark_wizard_water", "Arise, Delrith!", title = "Dark wizards")
 
@@ -250,7 +250,7 @@ npcOperate("*", "delrith") {
             val selected = words[choice - 1]
             val suffix = if (index == 4) "!" else "..."
             val text = "$selected$suffix"
-            player.forceChat = text
+            player.say(text)
             player<Talk>(text, largeHead = true, clickToContinue = false)
             val expected = DemonSlayerSpell.getWord(player, index + 1)
             if (selected != expected) {

--- a/game/src/main/kotlin/world/gregs/voidps/world/map/varrock/abyss/MageOfZamorak.kts
+++ b/game/src/main/kotlin/world/gregs/voidps/world/map/varrock/abyss/MageOfZamorak.kts
@@ -278,7 +278,7 @@ fun teleport(player: Player, target: NPC) {
         target.setGraphic("tele_other")
         target.setAnimation("tele_other")
         player.playSound("tele_other_cast")
-        target.forceChat = "Veniens! Sallakar! Rinnesset!"
+        target.say("Veniens! Sallakar! Rinnesset!")
         delay(2)
         player.setAnimation("lunar_teleport")
         player.setGraphic("tele_other_receive")

--- a/network/src/main/kotlin/world/gregs/voidps/network/login/protocol/Encoders.kt
+++ b/network/src/main/kotlin/world/gregs/voidps/network/login/protocol/Encoders.kt
@@ -1,7 +1,7 @@
 package world.gregs.voidps.network.login.protocol
 
 import world.gregs.voidps.network.login.protocol.visual.*
-import world.gregs.voidps.network.login.protocol.visual.encode.ForceChatEncoder
+import world.gregs.voidps.network.login.protocol.visual.encode.SayEncoder
 import world.gregs.voidps.network.login.protocol.visual.encode.WatchEncoder
 import world.gregs.voidps.network.login.protocol.visual.encode.npc.*
 import world.gregs.voidps.network.login.protocol.visual.encode.player.*
@@ -9,7 +9,7 @@ import world.gregs.voidps.network.login.protocol.visual.encode.player.*
 fun playerVisualEncoders() = castOf<PlayerVisuals>(
     WatchEncoder(VisualMask.PLAYER_WATCH_MASK),
     PlayerTimeBarEncoder(),
-    ForceChatEncoder(VisualMask.PLAYER_FORCE_CHAT_MASK),
+    SayEncoder(VisualMask.PLAYER_SAY_MASK),
     PlayerHitsEncoder(),
     PlayerTurnEncoder(),
     PlayerExactMovementEncoder(),
@@ -31,7 +31,7 @@ fun npcVisualEncoders() = castOf<NPCVisuals>(
     NPCColourOverlayEncoder(),
     NPCHitsEncoder(),
     WatchEncoder(VisualMask.NPC_WATCH_MASK),
-    ForceChatEncoder(VisualMask.NPC_FORCE_CHAT_MASK),
+    SayEncoder(VisualMask.NPC_SAY_MASK),
     NPCTimeBarEncoder(),
     NPCSecondaryGraphicEncoder()
 )

--- a/network/src/main/kotlin/world/gregs/voidps/network/login/protocol/visual/VisualMask.kt
+++ b/network/src/main/kotlin/world/gregs/voidps/network/login/protocol/visual/VisualMask.kt
@@ -4,7 +4,7 @@ object VisualMask {
     // Players
     const val PLAYER_WATCH_MASK = 0x1
     const val PLAYER_TIME_BAR_MASK = 0x400
-    const val PLAYER_FORCE_CHAT_MASK = 0x1000
+    const val PLAYER_SAY_MASK = 0x1000
     const val PLAYER_HITS_MASK = 0x4
     const val PLAYER_TURN_MASK = 0x2
     const val PLAYER_EXACT_MOVEMENT_MASK = 0x2000
@@ -25,7 +25,7 @@ object VisualMask {
     const val NPC_COLOUR_OVERLAY_MASK = 0x2000
     const val NPC_HITS_MASK = 0x40
     const val NPC_WATCH_MASK = 0x80
-    const val NPC_FORCE_CHAT_MASK = 0x1
+    const val NPC_SAY_MASK = 0x1
     const val NPC_TIME_BAR_MASK = 0x800
     const val NPC_GRAPHIC_2_MASK = 0x400
 }

--- a/network/src/main/kotlin/world/gregs/voidps/network/login/protocol/visual/Visuals.kt
+++ b/network/src/main/kotlin/world/gregs/voidps/network/login/protocol/visual/Visuals.kt
@@ -19,7 +19,7 @@ abstract class Visuals(index: Int) {
     val timeBar = TimeBar()
     val turn = Turn()
     val watch = Watch()
-    val forceChat = ForceChat()
+    val say = Say()
     val hits = Hits(self = index)
 
     fun flag(mask: Int) {
@@ -42,7 +42,7 @@ abstract class Visuals(index: Int) {
         hits.clear()
         turn.clear()
         watch.clear()
-        forceChat.clear()
+        say.clear()
         timeBar.clear()
         secondaryGraphic.clear()
     }

--- a/network/src/main/kotlin/world/gregs/voidps/network/login/protocol/visual/encode/SayEncoder.kt
+++ b/network/src/main/kotlin/world/gregs/voidps/network/login/protocol/visual/encode/SayEncoder.kt
@@ -4,10 +4,10 @@ import world.gregs.voidps.buffer.write.Writer
 import world.gregs.voidps.network.login.protocol.visual.VisualEncoder
 import world.gregs.voidps.network.login.protocol.visual.Visuals
 
-class ForceChatEncoder(mask: Int) : VisualEncoder<Visuals>(mask) {
+class SayEncoder(mask: Int) : VisualEncoder<Visuals>(mask) {
 
     override fun encode(writer: Writer, visuals: Visuals) {
-        writer.writeString(visuals.forceChat.text)
+        writer.writeString(visuals.say.text)
     }
 
 }

--- a/network/src/main/kotlin/world/gregs/voidps/network/login/protocol/visual/update/Say.kt
+++ b/network/src/main/kotlin/world/gregs/voidps/network/login/protocol/visual/update/Say.kt
@@ -2,7 +2,7 @@ package world.gregs.voidps.network.login.protocol.visual.update
 
 import world.gregs.voidps.network.login.protocol.Visual
 
-data class ForceChat(var text: String = "") : Visual {
+data class Say(var text: String = "") : Visual {
     override fun needsReset(): Boolean {
         return text.isNotEmpty()
     }


### PR DESCRIPTION
- Improve naming for `forceChat` to `say` #580
- Move say and render emote functions into Character
- Make render emote naming consistent
- Move render emote delayed functions into SuspendableContext