### PR TITLE
Add lazy loaded CRC keys to cache interface for use in login protocol

### DIFF
--- a/cache/src/main/kotlin/world/gregs/voidps/cache/Cache.kt
+++ b/cache/src/main/kotlin/world/gregs/voidps/cache/Cache.kt
@@ -10,6 +10,8 @@ interface Cache {
 
     fun indices(): IntArray
 
+    fun indexCrcs(): IntArray
+
     fun sector(index: Int, archive: Int): ByteArray?
 
     fun archives(index: Int): IntArray

--- a/cache/src/main/kotlin/world/gregs/voidps/cache/CacheDelegate.kt
+++ b/cache/src/main/kotlin/world/gregs/voidps/cache/CacheDelegate.kt
@@ -2,9 +2,16 @@ package world.gregs.voidps.cache
 
 import com.displee.cache.CacheLibrary
 import com.github.michaelbull.logging.InlineLogger
+import world.gregs.voidps.cache.secure.CRC
 import java.math.BigInteger
 
 class CacheDelegate(private val library: CacheLibrary, exponent: BigInteger? = null, modulus: BigInteger? = null) : Cache {
+    private val indexCrcs by lazy {
+        indices().map {
+            val data = sector(255, it) ?: return@map 0
+            CRC.calculate(data, 0, data.size)
+        }.toIntArray()
+    }
 
     constructor(directory: String, exponent: BigInteger? = null, modulus: BigInteger? = null) : this(timed(directory), exponent, modulus)
 
@@ -15,6 +22,8 @@ class CacheDelegate(private val library: CacheLibrary, exponent: BigInteger? = n
     override fun indexCount() = library.indices().size
 
     override fun indices() = library.indices().map { it.id }.toIntArray()
+
+    override fun indexCrcs() = indexCrcs
 
     override fun sector(index: Int, archive: Int): ByteArray? {
         return if (index == 255) {

--- a/cache/src/main/kotlin/world/gregs/voidps/cache/FileCache.kt
+++ b/cache/src/main/kotlin/world/gregs/voidps/cache/FileCache.kt
@@ -1,6 +1,7 @@
 package world.gregs.voidps.cache
 
 import world.gregs.voidps.cache.compress.DecompressionContext
+import world.gregs.voidps.cache.secure.CRC
 import world.gregs.voidps.cache.secure.VersionTableBuilder
 import world.gregs.voidps.cache.secure.Whirlpool
 import java.io.File
@@ -31,6 +32,14 @@ class FileCache(
     }
     private val length = main.length()
     private val context = DecompressionContext()
+    private val indexCrcs by lazy {
+        indices.map {
+            val data = sector(255, it) ?: return@map 0
+            CRC.calculate(data, 0, data.size)
+        }.toIntArray()
+    }
+
+    override fun indexCrcs() = indexCrcs
 
     override fun sector(index: Int, archive: Int): ByteArray? {
         val indexRaf = if (index == 255) index255 else indexes[index] ?: return null

--- a/cache/src/main/kotlin/world/gregs/voidps/cache/secure/CRC.kt
+++ b/cache/src/main/kotlin/world/gregs/voidps/cache/secure/CRC.kt
@@ -1,6 +1,6 @@
 package world.gregs.voidps.cache.secure
 
-class CRC {
+object CRC {
     private val table = IntArray(256) {
         var crc = it
         for (i in 0..7) {

--- a/cache/src/main/kotlin/world/gregs/voidps/cache/secure/VersionTableBuilder.kt
+++ b/cache/src/main/kotlin/world/gregs/voidps/cache/secure/VersionTableBuilder.kt
@@ -9,7 +9,6 @@ class VersionTableBuilder(
     private val indexCount: Int
 ) {
 
-    private val crc = CRC()
     private val versionTable = ByteArray(positionFor(indexCount) + MAX_RSA_SIZE)
     private var built = false
 
@@ -25,7 +24,7 @@ class VersionTableBuilder(
     }
 
     fun sector(index: Int, sectorData: ByteArray, whirlpool: Whirlpool) {
-        val crc = crc.calculate(sectorData)
+        val crc = CRC.calculate(sectorData)
         crc(index, crc)
         val output = ByteArray(ReadOnlyCache.WHIRLPOOL_SIZE)
         whirlpool.reset()


### PR DESCRIPTION
Feel free to close if it's already implemented somewhere or not planned on being supported, but I didn't see any place where the client's CRCs are validated on login anywhere. Does 667 just not send these values or are they currently just being skipped on the login protocol?