### PR TITLE
Separate movement and area checks into queue

### DIFF
--- a/engine/src/main/kotlin/world/gregs/voidps/engine/client/instruction/InstructionHandlers.kt
+++ b/engine/src/main/kotlin/world/gregs/voidps/engine/client/instruction/InstructionHandlers.kt
@@ -112,7 +112,7 @@ class InstructionHandlers(
 
 @Suppress("UNCHECKED_CAST")
 @JvmName("onEventDispatcher")
-inline fun <reified I : Instruction> onInstruction(noinline handler: I.(Player) -> Unit) {
+inline fun <reified I : Instruction> instruction(noinline handler: I.(Player) -> Unit) {
     when (I::class) {
         FinishRegionLoad::class -> get<InstructionHandlers>().finishRegionLoad = handler as FinishRegionLoad.(Player) -> Unit
         ChangeDisplayMode::class -> get<InstructionHandlers>().changeDisplayMode = handler as ChangeDisplayMode.(Player) -> Unit

--- a/engine/src/main/kotlin/world/gregs/voidps/engine/client/ui/Interfaces.kt
+++ b/engine/src/main/kotlin/world/gregs/voidps/engine/client/ui/Interfaces.kt
@@ -98,7 +98,7 @@ class Interfaces(
 
     private fun sendIfOpened(id: String): Boolean {
         val type = getType(id)
-        if (!interfaces.contains(type)) {
+        if (interfaces[type] != id) {
             interfaces[type] = id
             sendOpen(id)
             events.emit(InterfaceOpened(id))

--- a/engine/src/main/kotlin/world/gregs/voidps/engine/client/ui/Interfaces.kt
+++ b/engine/src/main/kotlin/world/gregs/voidps/engine/client/ui/Interfaces.kt
@@ -1,6 +1,6 @@
 package world.gregs.voidps.engine.client.ui
 
-import it.unimi.dsi.fastutil.objects.ObjectOpenHashSet
+import it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap
 import world.gregs.voidps.cache.definition.data.InterfaceDefinition
 import world.gregs.voidps.engine.client.playMusicTrack
 import world.gregs.voidps.engine.client.sendScript
@@ -27,7 +27,7 @@ class Interfaces(
     private val events: EventDispatcher,
     internal var client: Client? = null,
     internal val definitions: InterfaceDefinitions,
-    private val openInterfaces: MutableSet<String> = ObjectOpenHashSet()
+    private val interfaces: MutableMap<String, String> = Object2ObjectOpenHashMap()
 ) {
     var displayMode = 0
 
@@ -67,7 +67,7 @@ class Interfaces(
     }
 
     fun remove(id: String): Boolean {
-        if (openInterfaces.remove(id)) {
+        if (interfaces.remove(getType(id), id)) {
             sendClose(id)
             events.emit(InterfaceClosed(id))
             (events as? Player)?.queue?.clearWeak()
@@ -77,15 +77,15 @@ class Interfaces(
     }
 
     fun get(type: String): String? {
-        return openInterfaces.firstOrNull { getType(it) == type }
+        return interfaces[type]
     }
 
     fun contains(id: String): Boolean {
-        return openInterfaces.contains(id)
+        return interfaces[getType(id)] == id
     }
 
     fun refresh() {
-        openInterfaces.forEach { id ->
+        for (id in interfaces.values) {
             sendOpen(id)
             notifyRefresh(id)
         }
@@ -97,7 +97,9 @@ class Interfaces(
     }
 
     private fun sendIfOpened(id: String): Boolean {
-        if (openInterfaces.add(id)) {
+        val type = getType(id)
+        if (!interfaces.contains(type)) {
+            interfaces[type] = id
             sendOpen(id)
             events.emit(InterfaceOpened(id))
             notifyRefresh(id)
@@ -108,10 +110,10 @@ class Interfaces(
     }
 
     private fun closeChildrenOf(parent: String) {
-        val it = openInterfaces.iterator()
+        val it = interfaces.iterator()
         val children = mutableListOf<String>()
         while (it.hasNext()) {
-            val id = it.next()
+            val (_, id) = it.next()
             if (getParent(id) == parent) {
                 it.remove()
                 sendClose(id)

--- a/engine/src/main/kotlin/world/gregs/voidps/engine/client/update/PlayerTask.kt
+++ b/engine/src/main/kotlin/world/gregs/voidps/engine/client/update/PlayerTask.kt
@@ -16,6 +16,7 @@ class PlayerTask(
             character.timers.run()
         }
         character.softTimers.run()
+        character.area.tick()
         character.mode.tick()
         checkTileFacing(character)
     }

--- a/engine/src/main/kotlin/world/gregs/voidps/engine/client/update/npc/NPCResetTask.kt
+++ b/engine/src/main/kotlin/world/gregs/voidps/engine/client/update/npc/NPCResetTask.kt
@@ -2,8 +2,6 @@ package world.gregs.voidps.engine.client.update.npc
 
 import world.gregs.voidps.engine.client.update.CharacterTask
 import world.gregs.voidps.engine.client.update.iterator.TaskIterator
-import world.gregs.voidps.engine.entity.character.move.followTile
-import world.gregs.voidps.engine.entity.character.move.previousTile
 import world.gregs.voidps.engine.entity.character.npc.NPC
 import world.gregs.voidps.engine.entity.character.npc.NPCs
 
@@ -18,7 +16,7 @@ class NPCResetTask(
     @Suppress("PARAMETER_NAME_CHANGED_ON_OVERRIDE")
     override fun run(npc: NPC) {
         npc.visuals.reset()
-        npc.followTile = npc.previousTile
+        npc.steps.follow = npc.steps.previous
     }
 
 }

--- a/engine/src/main/kotlin/world/gregs/voidps/engine/client/update/player/PlayerResetTask.kt
+++ b/engine/src/main/kotlin/world/gregs/voidps/engine/client/update/player/PlayerResetTask.kt
@@ -3,8 +3,6 @@ package world.gregs.voidps.engine.client.update.player
 import world.gregs.voidps.engine.client.update.CharacterTask
 import world.gregs.voidps.engine.client.update.batch.ZoneBatchUpdates
 import world.gregs.voidps.engine.client.update.iterator.TaskIterator
-import world.gregs.voidps.engine.entity.character.move.followTile
-import world.gregs.voidps.engine.entity.character.move.previousTile
 import world.gregs.voidps.engine.entity.character.player.Player
 import world.gregs.voidps.engine.entity.character.player.Players
 import world.gregs.voidps.type.random
@@ -30,7 +28,7 @@ class PlayerResetTask(
     @Suppress("PARAMETER_NAME_CHANGED_ON_OVERRIDE")
     override fun run(player: Player) {
         player.visuals.reset()
-        player.followTile = player.previousTile
+        player.steps.follow = player.steps.previous
     }
 
     companion object {

--- a/engine/src/main/kotlin/world/gregs/voidps/engine/data/AccountManager.kt
+++ b/engine/src/main/kotlin/world/gregs/voidps/engine/data/AccountManager.kt
@@ -12,7 +12,6 @@ import world.gregs.voidps.engine.entity.Spawn
 import world.gregs.voidps.engine.entity.World
 import world.gregs.voidps.engine.entity.character.mode.move.AreaEntered
 import world.gregs.voidps.engine.entity.character.mode.move.AreaExited
-import world.gregs.voidps.engine.entity.character.move.previousTile
 import world.gregs.voidps.engine.entity.character.player.Player
 import world.gregs.voidps.engine.entity.character.player.Players
 import world.gregs.voidps.engine.entity.character.player.appearance
@@ -65,7 +64,7 @@ class AccountManager(
         player.inventories.normalStack = ItemDependentStack(itemDefinitions)
         player.inventories.events = player
         player.inventories.start()
-        player.previousTile = player.tile.add(Direction.WEST.delta)
+        player.steps.previous = player.tile.add(Direction.WEST.delta)
         player.experience.events = player
         player.levels.link(player, PlayerLevels(player.experience))
         player.body.link(player.equipment)

--- a/engine/src/main/kotlin/world/gregs/voidps/engine/data/AccountManager.kt
+++ b/engine/src/main/kotlin/world/gregs/voidps/engine/data/AccountManager.kt
@@ -58,6 +58,7 @@ class AccountManager(
         player.interfaces = Interfaces(player, player.client, interfaceDefinitions)
         player.interfaceOptions = InterfaceOptions(player, interfaceDefinitions, inventoryDefinitions)
         (player.variables as PlayerVariables).definitions = variableDefinitions
+        player.area.areaDefinitions = areaDefinitions
         player.inventories.definitions = inventoryDefinitions
         player.inventories.itemDefinitions = itemDefinitions
         player.inventories.validItemRule = validItems

--- a/engine/src/main/kotlin/world/gregs/voidps/engine/entity/character/mode/interact/Interaction.kt
+++ b/engine/src/main/kotlin/world/gregs/voidps/engine/entity/character/mode/interact/Interaction.kt
@@ -1,6 +1,6 @@
 package world.gregs.voidps.engine.entity.character.mode.interact
 
-import world.gregs.voidps.engine.client.variable.remaining
+import world.gregs.voidps.engine.GameLoop
 import world.gregs.voidps.engine.entity.character.Character
 import world.gregs.voidps.engine.event.CancellableEvent
 import world.gregs.voidps.engine.event.SuspendableEvent
@@ -28,8 +28,8 @@ abstract class Interaction<C : Character> : CancellableEvent(), SuspendableEvent
      * Movement delay, typically operating/interacting with an object or floor item that performs an animation or exact movement
      */
     suspend fun arriveDelay() {
-        val delay = character.remaining("last_movement")
-        if (delay == -1) {
+        val delay = character.steps.last - GameLoop.tick
+        if (delay <= 0) {
             return
         }
         delay(delay)

--- a/engine/src/main/kotlin/world/gregs/voidps/engine/entity/character/mode/move/AreaEntered.kt
+++ b/engine/src/main/kotlin/world/gregs/voidps/engine/entity/character/mode/move/AreaEntered.kt
@@ -1,7 +1,5 @@
 package world.gregs.voidps.engine.entity.character.mode.move
 
-import world.gregs.voidps.engine.entity.character.Character
-import world.gregs.voidps.engine.entity.character.npc.NPC
 import world.gregs.voidps.engine.entity.character.player.Player
 import world.gregs.voidps.engine.event.EventDispatcher
 import world.gregs.voidps.engine.event.Events
@@ -10,45 +8,29 @@ import world.gregs.voidps.engine.suspend.SuspendableContext
 import world.gregs.voidps.engine.suspend.Suspension
 import world.gregs.voidps.type.Area
 
-data class AreaEntered<C : Character>(
-    override val character: C,
+data class AreaEntered(
+    override val character: Player,
     val name: String,
     val tags: Set<String>,
     val area: Area
-) : SuspendableEvent, SuspendableContext<C> {
+) : SuspendableEvent, SuspendableContext<Player> {
 
-    override val size = 5
+    override val size = 3
 
     override suspend fun pause(ticks: Int) {
         Suspension.start(character, ticks)
     }
 
     override fun parameter(dispatcher: EventDispatcher, index: Int): Any? = when (index) {
-        0 -> "${dispatcher.key}_enter"
+        0 -> "area_enter"
         1 -> name
-        2 -> dispatcher.identifier
-        3 -> tags
-        4 -> area
+        2 -> tags
         else -> null
     }
 }
 
-fun enterArea(area: String = "*", tag: String = "*", handler: suspend AreaEntered<Player>.() -> Unit) {
-    Events.handle<Player, AreaEntered<Player>>("player_enter", area, "player", tag, "*") {
+fun enterArea(area: String = "*", tag: String = "*", handler: suspend AreaEntered.() -> Unit) {
+    Events.handle<Player, AreaEntered>("area_enter", area, tag) {
         handler.invoke(this)
     }
-}
-
-fun npcEnterArea(npc: String = "*", area: String = "*", tag: String = "*", handler: suspend AreaEntered<NPC>.() -> Unit) {
-    Events.handle<NPC, AreaEntered<NPC>>("npc_enter", area, npc, tag, "*") {
-        handler.invoke(this)
-    }
-}
-
-fun characterEnterArea(area: String = "*", tag: String = "*", handler: suspend AreaEntered<Character>.() -> Unit) {
-    val block: suspend AreaEntered<Character>.(EventDispatcher) -> Unit = {
-        handler.invoke(this)
-    }
-    Events.handle("player_enter", area, "player", tag, "*", handler = block)
-    Events.handle("npc_enter", area, "*", tag, "*", handler = block)
 }

--- a/engine/src/main/kotlin/world/gregs/voidps/engine/entity/character/mode/move/AreaExited.kt
+++ b/engine/src/main/kotlin/world/gregs/voidps/engine/entity/character/mode/move/AreaExited.kt
@@ -1,7 +1,5 @@
 package world.gregs.voidps.engine.entity.character.mode.move
 
-import world.gregs.voidps.engine.entity.character.Character
-import world.gregs.voidps.engine.entity.character.npc.NPC
 import world.gregs.voidps.engine.entity.character.player.Player
 import world.gregs.voidps.engine.event.EventDispatcher
 import world.gregs.voidps.engine.event.Events
@@ -10,45 +8,29 @@ import world.gregs.voidps.engine.suspend.SuspendableContext
 import world.gregs.voidps.engine.suspend.Suspension
 import world.gregs.voidps.type.Area
 
-data class AreaExited<C : Character>(
-    override val character: C,
+data class AreaExited(
+    override val character: Player,
     val name: String,
     val tags: Set<String>,
     val area: Area
-) : SuspendableEvent, SuspendableContext<C> {
+) : SuspendableEvent, SuspendableContext<Player> {
 
-    override val size = 5
+    override val size = 3
 
     override suspend fun pause(ticks: Int) {
         Suspension.start(character, ticks)
     }
 
     override fun parameter(dispatcher: EventDispatcher, index: Int): Any? = when (index) {
-        0 -> "${dispatcher.key}_exit"
+        0 -> "area_exit"
         1 -> name
-        2 -> dispatcher.identifier
-        3 -> tags
-        4 -> area
+        2 -> tags
         else -> null
     }
 }
 
-fun exitArea(area: String = "*", tag: String = "*", handler: suspend AreaExited<Player>.() -> Unit) {
-    Events.handle<Player, AreaExited<Player>>("player_exit", area, "player", tag, "*") {
+fun exitArea(area: String = "*", tag: String = "*", handler: suspend AreaExited.() -> Unit) {
+    Events.handle<Player, AreaExited>("area_exit", area, tag) {
         handler.invoke(this)
     }
-}
-
-fun npcExitArea(npc: String = "*", area: String = "*", tag: String = "*", handler: suspend AreaExited<NPC>.() -> Unit) {
-    Events.handle<NPC, AreaExited<NPC>>("npc_exit", area, npc, tag, "*") {
-        handler.invoke(this)
-    }
-}
-
-fun characterExitArea(area: String = "*", tag: String = "*", handler: suspend AreaExited<Character>.() -> Unit) {
-    val block: suspend AreaExited<Character>.(EventDispatcher) -> Unit = {
-        handler.invoke(this)
-    }
-    Events.handle("player_exit", area, "player", tag, "*", handler = block)
-    Events.handle("npc_exit", area, "*", tag, "*", handler = block)
 }

--- a/engine/src/main/kotlin/world/gregs/voidps/engine/entity/character/mode/move/AreaQueue.kt
+++ b/engine/src/main/kotlin/world/gregs/voidps/engine/entity/character/mode/move/AreaQueue.kt
@@ -1,0 +1,38 @@
+package world.gregs.voidps.engine.entity.character.mode.move
+
+import world.gregs.voidps.engine.data.definition.AreaDefinitions
+import world.gregs.voidps.engine.entity.character.player.Player
+import world.gregs.voidps.type.Tile
+
+/**
+ * In osrs this is called an EngineQueue and also handles stat changes/level up:
+ * it would check if the zone entered or exited contains a script and add them to this queue
+ * to fire on the next cycle.
+ *
+ * However, this is simplified and looks up the areas directly and sends an event if one has changed
+ */
+class AreaQueue(
+    private val player: Player
+) {
+    lateinit var areaDefinitions: AreaDefinitions
+
+    fun tick() {
+        if (player.steps.movedFrom.id == 0) {
+            return
+        }
+        val from = player.steps.movedFrom
+        player.steps.movedFrom = Tile.EMPTY
+        player.emit(Moved(player, from, player.tile))
+        val to = player.tile
+        for (def in areaDefinitions.get(from.zone)) {
+            if (from in def.area && to !in def.area) {
+                player.emit(AreaExited(player, def.name, def.tags, def.area))
+            }
+        }
+        for (def in areaDefinitions.get(to.zone)) {
+            if (to in def.area && from !in def.area) {
+                player.emit(AreaEntered(player, def.name, def.tags, def.area))
+            }
+        }
+    }
+}

--- a/engine/src/main/kotlin/world/gregs/voidps/engine/entity/character/mode/move/Movement.kt
+++ b/engine/src/main/kotlin/world/gregs/voidps/engine/entity/character/mode/move/Movement.kt
@@ -11,7 +11,6 @@ import world.gregs.voidps.engine.entity.character.Character
 import world.gregs.voidps.engine.entity.character.mode.EmptyMode
 import world.gregs.voidps.engine.entity.character.mode.Mode
 import world.gregs.voidps.engine.entity.character.mode.move.target.TargetStrategy
-import world.gregs.voidps.engine.entity.character.move.previousTile
 import world.gregs.voidps.engine.entity.character.move.running
 import world.gregs.voidps.engine.entity.character.npc.NPC
 import world.gregs.voidps.engine.entity.character.player.Player
@@ -109,7 +108,7 @@ open class Movement(
         } else {
             character.visuals.walkStep = clockwise(direction)
         }
-        character.previousTile = character.tile
+        character.steps.previous = character.tile
         move(character, direction.delta)
         character.face(direction, false)
         return true

--- a/engine/src/main/kotlin/world/gregs/voidps/engine/entity/character/mode/move/Steps.kt
+++ b/engine/src/main/kotlin/world/gregs/voidps/engine/entity/character/mode/move/Steps.kt
@@ -11,6 +11,8 @@ class Steps(
 ) : List<Step> by steps {
     var destination: Tile = Tile.EMPTY
         private set
+    var previous: Tile = Tile.EMPTY
+    var follow: Tile = Tile.EMPTY
 
     fun peek(): Step? = steps.peek()
 

--- a/engine/src/main/kotlin/world/gregs/voidps/engine/entity/character/mode/move/Steps.kt
+++ b/engine/src/main/kotlin/world/gregs/voidps/engine/entity/character/mode/move/Steps.kt
@@ -13,6 +13,8 @@ class Steps(
         private set
     var previous: Tile = Tile.EMPTY
     var follow: Tile = Tile.EMPTY
+    var movedFrom: Tile = Tile.EMPTY
+    var last = 0
 
     fun peek(): Step? = steps.peek()
 

--- a/engine/src/main/kotlin/world/gregs/voidps/engine/entity/character/mode/move/target/FollowTargetStrategy.kt
+++ b/engine/src/main/kotlin/world/gregs/voidps/engine/entity/character/mode/move/target/FollowTargetStrategy.kt
@@ -1,7 +1,6 @@
 package world.gregs.voidps.engine.entity.character.mode.move.target
 
 import world.gregs.voidps.engine.entity.character.Character
-import world.gregs.voidps.engine.entity.character.move.followTile
 import world.gregs.voidps.type.Tile
 
 data class FollowTargetStrategy(
@@ -9,7 +8,7 @@ data class FollowTargetStrategy(
 ) : TargetStrategy {
     override val bitMask = 0
     override val tile: Tile
-        get() = character.followTile
+        get() = character.steps.follow
     override val width: Int
         get() = character.size
     override val height: Int

--- a/engine/src/main/kotlin/world/gregs/voidps/engine/entity/character/move/Move.kt
+++ b/engine/src/main/kotlin/world/gregs/voidps/engine/entity/character/move/Move.kt
@@ -2,15 +2,6 @@ package world.gregs.voidps.engine.entity.character.move
 
 import world.gregs.voidps.engine.entity.character.Character
 import world.gregs.voidps.engine.entity.character.player.Player
-import world.gregs.voidps.type.Tile
-
-var Character.followTile: Tile
-    get() = get("follow_tile", tile)
-    set(value) = set("follow_tile", value)
-
-var Character.previousTile: Tile
-    get() = get("previous_tile", tile)
-    set(value) = set("previous_tile", value)
 
 var Character.running: Boolean
     get() = if (this is Player) get("movement", "walk") == "run" else get("running", false)

--- a/engine/src/main/kotlin/world/gregs/voidps/engine/entity/character/move/Teleport.kt
+++ b/engine/src/main/kotlin/world/gregs/voidps/engine/entity/character/move/Teleport.kt
@@ -32,6 +32,6 @@ fun Character.tele(delta: Delta, clearMode: Boolean = true, clearInterfaces: Boo
         movementType = MoveType.Teleport
     }
     steps.clear()
-    previousTile = tile.add(delta).add(Direction.WEST)
+    steps.previous = tile.add(delta).add(Direction.WEST)
     Movement.move(this, delta)
 }

--- a/engine/src/main/kotlin/world/gregs/voidps/engine/entity/character/npc/NPCs.kt
+++ b/engine/src/main/kotlin/world/gregs/voidps/engine/entity/character/npc/NPCs.kt
@@ -161,11 +161,6 @@ data class NPCs(
             npc["respawn_direction"] = npc.direction
         }
         npc.emit(Spawn)
-        for (def in areaDefinitions.get(npc.tile.zone)) {
-            if (npc.tile in def.area) {
-                npc.emit(AreaEntered(npc, def.name, def.tags, def.area))
-            }
-        }
         return true
     }
 

--- a/engine/src/main/kotlin/world/gregs/voidps/engine/entity/character/player/Player.kt
+++ b/engine/src/main/kotlin/world/gregs/voidps/engine/entity/character/player/Player.kt
@@ -11,6 +11,7 @@ import world.gregs.voidps.engine.client.variable.Variables
 import world.gregs.voidps.engine.entity.character.Character
 import world.gregs.voidps.engine.entity.character.mode.EmptyMode
 import world.gregs.voidps.engine.entity.character.mode.Mode
+import world.gregs.voidps.engine.entity.character.mode.move.AreaQueue
 import world.gregs.voidps.engine.entity.character.mode.move.Steps
 import world.gregs.voidps.engine.entity.character.player.chat.clan.ClanRank
 import world.gregs.voidps.engine.entity.character.player.equip.BodyParts
@@ -69,6 +70,7 @@ class Player(
     lateinit var interfaces: Interfaces
     lateinit var interfaceOptions: InterfaceOptions
     override lateinit var collision: CollisionStrategy
+    val area: AreaQueue = AreaQueue(this)
 
     val networked: Boolean
         get() = client != null && viewport != null

--- a/engine/src/main/kotlin/world/gregs/voidps/engine/entity/item/floor/FloorItems.kt
+++ b/engine/src/main/kotlin/world/gregs/voidps/engine/entity/item/floor/FloorItems.kt
@@ -45,6 +45,7 @@ class FloorItems(
         }
         removeQueue.clear()
         for (floorItem in addQueue) {
+            add(floorItem)
             floorItem.emit(Spawn)
         }
         addQueue.clear()
@@ -57,11 +58,11 @@ class FloorItems(
             logger.warn { "Invalid floor item id: '$id' at $tile" }
         }
         val item = FloorItem(tile, id, amount, revealTicks, disappearTicks, charges, if (revealTicks == 0) null else owner)
-        add(item)
+        display(item)
         return item
     }
 
-    internal fun add(floorItem: FloorItem) {
+    private fun display(floorItem: FloorItem) {
         val list = data.getOrPut(floorItem.tile.zone.id) { zonePool.borrow() }.getOrPut(floorItem.tile.id) { tilePool.borrow() }
         if (combined(list, floorItem)) {
             return
@@ -69,10 +70,12 @@ class FloorItems(
         if (full(list, floorItem)) {
             return
         }
-        if (list.add(floorItem)) {
-            batches.add(floorItem.tile.zone, FloorItemAddition(floorItem.tile.id, floorItem.def.id, floorItem.amount, floorItem.owner))
-            addQueue.add(floorItem)
-        }
+        addQueue.add(floorItem)
+        batches.add(floorItem.tile.zone, FloorItemAddition(floorItem.tile.id, floorItem.def.id, floorItem.amount, floorItem.owner))
+    }
+
+    private fun add(floorItem: FloorItem) {
+        data.getOrPut(floorItem.tile.zone.id) { zonePool.borrow() }.getOrPut(floorItem.tile.id) { tilePool.borrow() }.add(floorItem)
     }
 
     /**

--- a/engine/src/test/kotlin/world/gregs/voidps/engine/client/ui/GameFrameTest.kt
+++ b/engine/src/test/kotlin/world/gregs/voidps/engine/client/ui/GameFrameTest.kt
@@ -15,8 +15,8 @@ internal class GameFrameTest : InterfaceTest() {
         super.setup()
         interfaces = Interfaces(events, client, definitions, open)
         every { definitions.getOrNull("") } returns InterfaceDefinition()
-        every { definitions.getOrNull("toplevel_full") } returns InterfaceDefinition(id = -1)
-        every { definitions.getOrNull("toplevel") } returns InterfaceDefinition()
+        every { definitions.getOrNull("toplevel_full") } returns InterfaceDefinition(id = -1, type = "root")
+        every { definitions.getOrNull("toplevel") } returns InterfaceDefinition(type = "root")
     }
 
     @Test
@@ -32,14 +32,14 @@ internal class GameFrameTest : InterfaceTest() {
     @Test
     fun `Size set top level if full open`() {
         interfaces.resizable = true
-        open.add("toplevel_full")
+        open["root"] = "toplevel_full"
         assertTrue(interfaces.setDisplayMode(Interfaces.FIXED_SCREEN))
         assertEquals(false, interfaces.resizable)
     }
 
     @Test
     fun `Size set full if top level open`() {
-        open.add("toplevel")
+        open["root"] = "toplevel"
         assertTrue(interfaces.setDisplayMode(Interfaces.RESIZABLE_SCREEN))
         assertEquals(true, interfaces.resizable)
     }

--- a/engine/src/test/kotlin/world/gregs/voidps/engine/client/ui/InterfaceTest.kt
+++ b/engine/src/test/kotlin/world/gregs/voidps/engine/client/ui/InterfaceTest.kt
@@ -15,7 +15,7 @@ abstract class InterfaceTest : KoinMock() {
     internal lateinit var client: Client
     internal lateinit var events: EventDispatcher
     internal lateinit var interfaces: Interfaces
-    internal lateinit var open: MutableSet<String>
+    internal lateinit var open: MutableMap<String, String>
     internal lateinit var definitions: InterfaceDefinitions
 
     @BeforeEach
@@ -23,7 +23,7 @@ abstract class InterfaceTest : KoinMock() {
         client = mockk(relaxed = true)
         events = mockk(relaxed = true)
         definitions = declare { mockk(relaxed = true) }
-        open = mutableSetOf()
+        open = mutableMapOf()
         interfaces = spyk(Interfaces(events, client, definitions, open))
         mockkStatic("world.gregs.voidps.network.login.protocol.encode.InterfaceEncodersKt")
         mockkStatic("world.gregs.voidps.engine.client.ui.InterfacesKt")

--- a/engine/src/test/kotlin/world/gregs/voidps/engine/client/ui/InterfacesMultipleTest.kt
+++ b/engine/src/test/kotlin/world/gregs/voidps/engine/client/ui/InterfacesMultipleTest.kt
@@ -25,9 +25,9 @@ internal class InterfacesMultipleTest : InterfaceTest() {
     override fun setup() {
         super.setup()
         every { definitions.get(any<Int>()) } returns InterfaceDefinition(-1)
-        val zero = InterfaceDefinition(id = 0, stringId = "zero", permanent = false, fixed = InterfaceDefinition.pack(1, 0))
-        val one = InterfaceDefinition(id = 1, stringId = "one", permanent = false, fixed = InterfaceDefinition.pack(2, 0))
-        val two = InterfaceDefinition(id = 2, stringId = "two", permanent = false)
+        val zero = InterfaceDefinition(id = 0, stringId = "zero", type = "0", permanent = false, fixed = InterfaceDefinition.pack(1, 0))
+        val one = InterfaceDefinition(id = 1, stringId = "one", type = "1", permanent = false, fixed = InterfaceDefinition.pack(2, 0))
+        val two = InterfaceDefinition(id = 2, stringId = "two", type = "2", permanent = false)
         every { definitions.getOrNull(zeroId) } returns zero
         every { definitions.getOrNull(oneId) } returns one
         every { definitions.getOrNull(twoId) } returns two

--- a/engine/src/test/kotlin/world/gregs/voidps/engine/client/ui/InterfacesSingleTest.kt
+++ b/engine/src/test/kotlin/world/gregs/voidps/engine/client/ui/InterfacesSingleTest.kt
@@ -32,14 +32,14 @@ internal class InterfacesSingleTest : InterfaceTest() {
 
     @Test
     fun `Opened contains with type`() {
-        open.add(name)
+        open["type"] = name
         assertTrue(interfaces.contains(name))
         assertEquals(name, interfaces.get("type"))
     }
 
     @Test
     fun `Reopen only refreshes`() {
-        open.add(name)
+        open["type"] = name
 
         assertFalse(interfaces.open(name))
 
@@ -50,8 +50,8 @@ internal class InterfacesSingleTest : InterfaceTest() {
 
     @Test
     fun `Close no longer contains`() {
-        every { definitions.getOrNull("zero")?.parent(any()) } returns 2
-        open.add(name)
+        every { definitions.getOrNull(name) } returns InterfaceDefinition(id = 1, stringId = "1", type = "type", resizable = 2, fixed = 2)
+        open["type"] = name
 
         assertTrue(interfaces.close(name))
         assertFalse(interfaces.contains(name))

--- a/engine/src/test/kotlin/world/gregs/voidps/engine/entity/character/mode/move/MovementTest.kt
+++ b/engine/src/test/kotlin/world/gregs/voidps/engine/entity/character/mode/move/MovementTest.kt
@@ -15,7 +15,6 @@ import world.gregs.voidps.engine.client.variable.start
 import world.gregs.voidps.engine.data.definition.AreaDefinitions
 import world.gregs.voidps.engine.entity.character.mode.move.target.TargetStrategy
 import world.gregs.voidps.engine.entity.character.mode.move.target.TileTargetStrategy
-import world.gregs.voidps.engine.entity.character.move.previousTile
 import world.gregs.voidps.engine.entity.character.move.running
 import world.gregs.voidps.engine.entity.character.npc.NPC
 import world.gregs.voidps.engine.entity.character.player.Player
@@ -111,7 +110,7 @@ internal class MovementTest : KoinMock() {
         assertEquals(MoveType.Walk, player.temporaryMoveType)
 
         assertEquals(Direction.NORTH_EAST, player.direction)
-        assertEquals(Tile(5, 5), player.previousTile)
+        assertEquals(Tile(5, 5), player.steps.previous)
         assertEquals(Tile(6, 6), player.tile)
     }
 
@@ -126,7 +125,7 @@ internal class MovementTest : KoinMock() {
         assertEquals(1, player.visuals.runStep)
 
         assertEquals(Direction.NORTH_EAST, player.direction)
-        assertEquals(Tile(6, 6), player.previousTile)
+        assertEquals(Tile(6, 6), player.steps.previous)
         assertEquals(Tile(7, 7), player.tile)
         assertFalse(player.steps.isEmpty())
     }

--- a/engine/src/test/kotlin/world/gregs/voidps/engine/entity/item/floor/FloorItemTrackingTest.kt
+++ b/engine/src/test/kotlin/world/gregs/voidps/engine/entity/item/floor/FloorItemTrackingTest.kt
@@ -36,8 +36,8 @@ class FloorItemTrackingTest {
 
     @Test
     fun `Private items are revealed after timer`() {
-        val item = FloorItem(Tile.EMPTY, "item", revealTicks = 10, owner = "player")
-        items.add(item)
+        val item = items.add(Tile.EMPTY, "item", revealTicks = 10, owner = "player")
+        items.run()
 
         repeat(10) {
             assertEquals("player", item.owner)
@@ -51,8 +51,8 @@ class FloorItemTrackingTest {
 
     @Test
     fun `Public items are removed after timer`() {
-        val item = FloorItem(Tile.EMPTY, "item", disappearTicks = 10, owner = null)
-        items.add(item)
+        val item = items.add(Tile.EMPTY, "item", disappearTicks = 10)
+        items.run()
 
         repeat(10) {
             tracking.run()
@@ -63,8 +63,8 @@ class FloorItemTrackingTest {
 
     @Test
     fun `Public items revealed and removed after timers`() {
-        val item = FloorItem(Tile.EMPTY, "item", revealTicks = 10, disappearTicks = 10, owner = "player")
-        items.add(item)
+        val item = items.add(Tile.EMPTY, "item", revealTicks = 10, disappearTicks = 10, owner = "player")
+        items.run()
 
         repeat(10) {
             tracking.run()

--- a/engine/src/test/kotlin/world/gregs/voidps/engine/entity/item/floor/FloorItemsTest.kt
+++ b/engine/src/test/kotlin/world/gregs/voidps/engine/entity/item/floor/FloorItemsTest.kt
@@ -47,10 +47,8 @@ class FloorItemsTest {
 
     @Test
     fun `Add floor items`() {
-        val first = floorItem("item", Tile.EMPTY)
-        items.add(first)
-        val second = floorItem("item", Tile(10, 10, 1), owner = "player")
-        items.add(second)
+        val first = items.add(Tile.EMPTY, "item")
+        val second = items.add(Tile(10, 10, 1), "item", owner = "player")
         items.run()
 
         assertEquals(items[Tile.EMPTY].first(), first)
@@ -64,10 +62,8 @@ class FloorItemsTest {
 
     @Test
     fun `Add floor items in order`() {
-        val first = floorItem("item1", Tile.EMPTY)
-        items.add(first)
-        val second = floorItem("item2", Tile.EMPTY)
-        items.add(second)
+        val first = items.add(Tile.EMPTY, "item1")
+        val second = items.add(Tile.EMPTY, "item2")
         items.run()
 
         val items = items[Tile.EMPTY]
@@ -77,10 +73,9 @@ class FloorItemsTest {
 
     @Test
     fun `Adding two private stackable items combines them`() {
-        val first = floorItem("stackable", Tile.EMPTY, owner = "player", disappear = 5, reveal = 5)
-        items.add(first)
-        val second = floorItem("stackable", Tile.EMPTY, owner = "player", disappear = 10, reveal = 10)
-        items.add(second)
+        items.add(Tile.EMPTY, "stackable", owner = "player", disappearTicks = 5, revealTicks = 5)
+        items.run()
+        items.add(Tile.EMPTY, "stackable", owner = "player", disappearTicks = 10, revealTicks = 10)
         items.run()
 
         val floorItem = items[Tile.EMPTY].first()
@@ -102,10 +97,8 @@ class FloorItemsTest {
 
     @Test
     fun `Don't combine non-stackable items`() {
-        val first = floorItem("item", Tile.EMPTY, owner = "player")
-        items.add(first)
-        val second = floorItem("item", Tile.EMPTY, owner = "player")
-        items.add(second)
+        val first = items.add(Tile.EMPTY, "item", owner = "player")
+        val second = items.add(Tile.EMPTY, "item", owner = "player")
         items.run()
         val items = items[Tile.EMPTY]
         assertEquals(first, items[0])
@@ -114,10 +107,8 @@ class FloorItemsTest {
 
     @Test
     fun `Don't combine two overflowing two private stacks`() {
-        val first = floorItem("item", Tile.EMPTY, Int.MAX_VALUE - 10, owner = "player")
-        items.add(first)
-        val second = floorItem("item", Tile.EMPTY, 20, owner = "player")
-        items.add(second)
+        val first = items.add(Tile.EMPTY, "item", Int.MAX_VALUE - 10, owner = "player")
+        val second = items.add(Tile.EMPTY, "item", 20, owner = "player")
         items.run()
 
         val items = items[Tile.EMPTY]
@@ -127,10 +118,8 @@ class FloorItemsTest {
 
     @Test
     fun `Public items aren't combined`() {
-        val first = floorItem("item", Tile.EMPTY, owner = null, disappear = 5, reveal = -1)
-        items.add(first)
-        val second = floorItem("item", Tile.EMPTY, owner = "player", disappear = 10, reveal = 10)
-        items.add(second)
+        val first = items.add(Tile.EMPTY, "item", disappearTicks = 5, revealTicks = -1)
+        val second = items.add(Tile.EMPTY, "item", owner = "player", disappearTicks = 10, revealTicks = 10)
         items.run()
 
         val items = items[Tile.EMPTY]
@@ -140,10 +129,9 @@ class FloorItemsTest {
 
     @Test
     fun `Remove floor item`() {
-        val first = floorItem("item1", Tile.EMPTY)
-        items.add(first)
-        val second = floorItem("item1", Tile.EMPTY)
-        items.add(second)
+        val first = items.add(Tile.EMPTY, "item1")
+        val second = items.add(Tile.EMPTY, "item1")
+        items.run()
 
         assertTrue(items.remove(first))
         items.run()
@@ -158,12 +146,11 @@ class FloorItemsTest {
     @Test
     fun `Remove lowest value item when limit exceeded`() {
         repeat(128) {
-            val item = floorItem(if (it == 25) "cheap_item" else "item", Tile.EMPTY)
-            items.add(item)
+            items.add(Tile.EMPTY, if (it == 25) "cheap_item" else "item")
         }
+        items.run()
 
-        val item = floorItem("item", Tile.EMPTY, owner = "player")
-        items.add(item)
+        val item = items.add(Tile.EMPTY, "item", owner = "player")
         items.run()
 
         val items = items[Tile.EMPTY]
@@ -174,8 +161,7 @@ class FloorItemsTest {
     @Test
     fun `Equal value items are unstacked when limit exceeded`() {
         repeat(128 * 2) {
-            val item = floorItem(if (it >= 128) "equal_item" else "item", Tile.EMPTY)
-            items.add(item)
+            items.add(Tile.EMPTY, if (it >= 128) "equal_item" else "item")
         }
 
         val items = items[Tile.EMPTY]
@@ -184,8 +170,8 @@ class FloorItemsTest {
 
     @Test
     fun `Clear sends batch update`() {
-        val first = floorItem("item", Tile.EMPTY)
-        items.add(first)
+        items.add(Tile.EMPTY, "item")
+        items.run()
 
         items.clear()
         items.run()
@@ -195,10 +181,6 @@ class FloorItemsTest {
         verify {
             batches.add(Zone.EMPTY, FloorItemRemoval(tile = 0, id = 1, owner = null))
         }
-    }
-
-    private fun floorItem(id: String, tile: Tile, amount: Int = 1, disappear: Int = -1, reveal: Int = -1, charges: Int = 0, owner: String? = null): FloorItem {
-        return FloorItem(tile, id, amount, disappear, reveal, charges, owner)
     }
 
     @AfterEach

--- a/game/src/main/kotlin/content/area/misthalin/edgeville/MultiCombat.kts
+++ b/game/src/main/kotlin/content/area/misthalin/edgeville/MultiCombat.kts
@@ -1,15 +1,29 @@
 package content.area.misthalin.edgeville
 
 import world.gregs.voidps.engine.client.variable.variableSet
-import world.gregs.voidps.engine.entity.character.mode.move.characterEnterArea
-import world.gregs.voidps.engine.entity.character.mode.move.characterExitArea
+import world.gregs.voidps.engine.data.definition.AreaDefinitions
+import world.gregs.voidps.engine.entity.character.mode.move.*
+import world.gregs.voidps.engine.entity.npcSpawn
+import world.gregs.voidps.engine.inject
 
-characterEnterArea(tag = "multi_combat") {
-    character["in_multi_combat"] = true
+
+val areaDefinitions: AreaDefinitions by inject()
+
+npcSpawn { npc ->
+    for (def in areaDefinitions.get(npc.tile.zone)) {
+        if (def.tags.contains("multi_combat")) {
+            npc["in_multi_combat"] = true
+            break
+        }
+    }
 }
 
-characterExitArea(tag = "multi_combat") {
-    character.clear("in_multi_combat")
+enterArea(tag = "multi_combat") {
+    player["in_multi_combat"] = true
+}
+
+exitArea(tag = "multi_combat") {
+    player.clear("in_multi_combat")
 }
 
 variableSet("in_multi_combat", to = true) { player ->

--- a/game/src/main/kotlin/content/entity/Examines.kts
+++ b/game/src/main/kotlin/content/entity/Examines.kts
@@ -9,7 +9,7 @@ import content.entity.player.inv.inventoryOption
 import world.gregs.voidps.engine.data.definition.ItemDefinitions
 import world.gregs.voidps.engine.data.definition.NPCDefinitions
 import world.gregs.voidps.engine.data.definition.ObjectDefinitions
-import world.gregs.voidps.engine.client.instruction.onInstruction
+import world.gregs.voidps.engine.client.instruction.instruction
 import world.gregs.voidps.engine.inject
 import world.gregs.voidps.network.client.instruction.ExamineItem
 import world.gregs.voidps.network.client.instruction.ExamineNpc
@@ -35,21 +35,21 @@ val itemDefinitions: ItemDefinitions by inject()
 val npcDefinitions: NPCDefinitions by inject()
 val objectDefinitions: ObjectDefinitions by inject()
 
-onInstruction<ExamineItem> { player ->
+instruction<ExamineItem> { player ->
     val definition = itemDefinitions.get(itemId)
     if (definition.contains("examine")) {
         player.message(definition["examine"], ChatType.Game)
     }
 }
 
-onInstruction<ExamineNpc> { player ->
+instruction<ExamineNpc> { player ->
     val definition = npcDefinitions.get(npcId)
     if (definition.contains("examine")) {
         player.message(definition["examine"], ChatType.Game)
     }
 }
 
-onInstruction<ExamineObject> { player ->
+instruction<ExamineObject> { player ->
     val definition = objectDefinitions.get(objectId)
     if (definition.contains("examine")) {
         player.message(definition["examine"], ChatType.Game)

--- a/game/src/main/kotlin/content/entity/Movement.kts
+++ b/game/src/main/kotlin/content/entity/Movement.kts
@@ -15,16 +15,16 @@ import world.gregs.voidps.type.Tile
 import content.entity.combat.dead
 import content.entity.death.npcDeath
 import world.gregs.voidps.engine.client.ui.closeInterfaces
-import world.gregs.voidps.engine.client.instruction.onInstruction
+import world.gregs.voidps.engine.client.instruction.instruction
 import world.gregs.voidps.network.client.instruction.Walk
 
 val collisions: Collisions by inject()
 val npcs: NPCs by inject()
 val players: Players by inject()
 
-onInstruction<Walk> { player ->
+instruction<Walk> { player ->
     if (player.contains("delay")) {
-        return@onInstruction
+        return@instruction
     }
     player.closeInterfaces()
     player.clearWatch()

--- a/game/src/main/kotlin/content/entity/npc/shop/stock/Restock.kts
+++ b/game/src/main/kotlin/content/entity/npc/shop/stock/Restock.kts
@@ -33,7 +33,6 @@ timerStart("shop_restock") {
 }
 
 timerTick("shop_restock") { player ->
-    logger.debug { "Restocking shops." }
     for ((name, inventory) in player.inventories.instances) {
         val def = inventoryDefinitions.get(name)
         if (!def["shop", false]) {

--- a/game/src/main/kotlin/content/entity/player/command/admin/AdminCommands.kts
+++ b/game/src/main/kotlin/content/entity/player/command/admin/AdminCommands.kts
@@ -103,6 +103,8 @@ adminCommand("tele (x) (y) [level]", "teleport to given coordinates or area name
             else -> player.tele(int, parts[1].toInt(), if (parts.size > 2) parts[2].toInt() else 0)
         }
     }
+    player["world_map_centre"] = player.tile.id
+    player["world_map_marker_player"] = player.tile.id
 }
 
 adminCommand("teleto (player-name)", "teleport to another player") {

--- a/game/src/main/kotlin/content/entity/player/dialogue/DialogueInput.kts
+++ b/game/src/main/kotlin/content/entity/player/dialogue/DialogueInput.kts
@@ -1,7 +1,7 @@
 package content.entity.player.dialogue
 
 import world.gregs.voidps.engine.client.ui.dialogue.continueDialogue
-import world.gregs.voidps.engine.client.instruction.onInstruction
+import world.gregs.voidps.engine.client.instruction.instruction
 import world.gregs.voidps.engine.suspend.IntSuspension
 import world.gregs.voidps.engine.suspend.StringSuspension
 import world.gregs.voidps.network.client.instruction.EnterInt
@@ -36,11 +36,11 @@ continueDialogue("dialogue_multi*", "line*") { player ->
     (player.dialogueSuspension as? IntSuspension)?.resume(choice)
 }
 
-onInstruction<EnterInt> { player ->
+instruction<EnterInt> { player ->
     (player.dialogueSuspension as? IntSuspension)?.resume(value)
 }
 
-onInstruction<EnterString> { player ->
+instruction<EnterString> { player ->
     (player.dialogueSuspension as? StringSuspension)?.resume(value)
 }
 

--- a/game/src/main/kotlin/content/entity/player/modal/GameFrame.kts
+++ b/game/src/main/kotlin/content/entity/player/modal/GameFrame.kts
@@ -7,7 +7,7 @@ import world.gregs.voidps.engine.client.ui.event.interfaceRefresh
 import world.gregs.voidps.engine.client.ui.hasOpen
 import world.gregs.voidps.engine.client.ui.interfaceOption
 import world.gregs.voidps.engine.client.ui.open
-import world.gregs.voidps.engine.client.instruction.onInstruction
+import world.gregs.voidps.engine.client.instruction.instruction
 import world.gregs.voidps.engine.entity.character.player.Player
 import world.gregs.voidps.engine.queue.weakQueue
 import world.gregs.voidps.network.client.instruction.ChangeDisplayMode
@@ -47,9 +47,9 @@ Tab.entries.forEach { tab ->
     }
 }
 
-onInstruction<ChangeDisplayMode> { player ->
+instruction<ChangeDisplayMode> { player ->
     if (player.interfaces.displayMode == displayMode || !player.hasOpen("graphics_options")) {
-        return@onInstruction
+        return@instruction
     }
     player.interfaces.setDisplayMode(displayMode)
 }

--- a/game/src/main/kotlin/content/entity/player/modal/map/WorldMap.kts
+++ b/game/src/main/kotlin/content/entity/player/modal/map/WorldMap.kts
@@ -12,7 +12,7 @@ import world.gregs.voidps.network.login.protocol.encode.updateInterface
 import content.entity.effect.frozen
 import world.gregs.voidps.engine.client.variable.hasClock
 import world.gregs.voidps.engine.client.variable.start
-import world.gregs.voidps.engine.client.instruction.onInstruction
+import world.gregs.voidps.engine.client.instruction.instruction
 import world.gregs.voidps.network.client.instruction.WorldMapClick
 
 val definitions: InterfaceDefinitions by inject()
@@ -74,7 +74,7 @@ fun updateMap(player: Player) {
     player["world_map_marker_player"] = tile
 }
 
-onInstruction<WorldMapClick> { player ->
+instruction<WorldMapClick> { player ->
     if (player.hasClock("world_map_double_click") && player["previous_world_map_click", 0] == tile) {
         player["world_map_marker_custom"] = tile
     }

--- a/game/src/main/kotlin/content/entity/world/RegionLoading.kts
+++ b/game/src/main/kotlin/content/entity/world/RegionLoading.kts
@@ -9,7 +9,7 @@ import world.gregs.voidps.engine.entity.character.player.Player
 import world.gregs.voidps.engine.entity.character.player.Players
 import world.gregs.voidps.engine.entity.playerDespawn
 import world.gregs.voidps.engine.event.onEvent
-import world.gregs.voidps.engine.client.instruction.onInstruction
+import world.gregs.voidps.engine.client.instruction.instruction
 import world.gregs.voidps.engine.inject
 import world.gregs.voidps.engine.map.region.RegionRetry
 import world.gregs.voidps.engine.map.zone.ClearRegion
@@ -35,7 +35,7 @@ val playerRegions = IntArray(MAX_PLAYERS - 1)
 
 private val blankXtea = IntArray(4)
 
-onInstruction<FinishRegionLoad> { player ->
+instruction<FinishRegionLoad> { player ->
     if (player["debug", false]) {
         println("Finished region load. $player ${player.viewport}")
     }

--- a/game/src/main/kotlin/content/social/chat/Chat.kts
+++ b/game/src/main/kotlin/content/social/chat/Chat.kts
@@ -20,7 +20,7 @@ import world.gregs.voidps.network.login.protocol.encode.publicChat
 import content.social.clan.chatType
 import content.social.clan.clan
 import content.social.ignore.ignores
-import world.gregs.voidps.engine.client.instruction.onInstruction
+import world.gregs.voidps.engine.client.instruction.instruction
 import world.gregs.voidps.network.client.instruction.ChatPrivate
 import world.gregs.voidps.network.client.instruction.ChatPublic
 import world.gregs.voidps.network.client.instruction.ChatTypeChange
@@ -32,11 +32,11 @@ onEvent<Player, PublicChatMessage> { player ->
     player.client?.publicChat(source.index, effects, source.rights.ordinal, compressed)
 }
 
-onInstruction<ChatPrivate> { player ->
+instruction<ChatPrivate> { player ->
     val target = players.get(friend)
     if (target == null || target.ignores(player)) {
         player.message("Unable to send message - player unavailable.")
-        return@onInstruction
+        return@instruction
     }
     val message = PrivateChatMessage(player, message, huffman)
     player.client?.privateChatTo(target.name, message.compressed)
@@ -47,14 +47,14 @@ onEvent<Player, PrivateChatMessage> { player ->
     player.client?.privateChatFrom(source.name, source.rights.ordinal, compressed)
 }
 
-onInstruction<ChatTypeChange> { player ->
+instruction<ChatTypeChange> { player ->
     player["chat_type"] = when (type) {
         1 -> "clan"
         else -> "public"
     }
 }
 
-onInstruction<ChatPublic> { player ->
+instruction<ChatPublic> { player ->
     when (player.chatType) {
         "public" -> {
             val message = PublicChatMessage(player, effects, text, huffman)
@@ -66,11 +66,11 @@ onInstruction<ChatPublic> { player ->
             val clan = player.clan
             if (clan == null) {
                 player.message("You must be in a clan chat to talk.", ChatType.ClanChat)
-                return@onInstruction
+                return@instruction
             }
             if (!clan.hasRank(player, clan.talkRank) || !clan.members.contains(player)) {
                 player.message("You are not allowed to talk in this clan chat.", ChatType.ClanChat)
-                return@onInstruction
+                return@instruction
             }
             val message = ClanChatMessage(player, effects, text, huffman)
             clan.members.filterNot { it.ignores(player) }.forEach {

--- a/game/src/main/kotlin/content/social/chat/QuickChat.kts
+++ b/game/src/main/kotlin/content/social/chat/QuickChat.kts
@@ -21,7 +21,7 @@ import world.gregs.voidps.network.login.protocol.encode.privateQuickChatTo
 import world.gregs.voidps.network.login.protocol.encode.publicQuickChat
 import content.social.clan.clan
 import content.social.ignore.ignores
-import world.gregs.voidps.engine.client.instruction.onInstruction
+import world.gregs.voidps.engine.client.instruction.instruction
 import world.gregs.voidps.network.client.instruction.QuickChatPrivate
 import world.gregs.voidps.network.client.instruction.QuickChatPublic
 
@@ -31,11 +31,11 @@ val variables: VariableDefinitions by inject()
 val enums: EnumDefinitions by inject()
 val items: ItemDefinitions by inject()
 
-onInstruction<QuickChatPrivate> { player ->
+instruction<QuickChatPrivate> { player ->
     val target = players.get(friend)
     if (target == null || target.ignores(player)) {
         player.message("Unable to send message - player unavailable.")
-        return@onInstruction
+        return@instruction
     }
     val definition = phrases.get(file)
     val data = generateData(player, file, data)
@@ -50,7 +50,7 @@ onEvent<Player, PrivateQuickChatMessage> { player ->
     player.client?.privateQuickChatFrom(source.name, source.rights.ordinal, file, data)
 }
 
-onInstruction<QuickChatPublic> { player ->
+instruction<QuickChatPublic> { player ->
     when (chatType) {
         0 -> {
             val definition = phrases.get(file)
@@ -65,11 +65,11 @@ onInstruction<QuickChatPublic> { player ->
             val clan = player.clan
             if (clan == null) {
                 player.message("You must be in a clan chat to talk.", ChatType.ClanChat)
-                return@onInstruction
+                return@instruction
             }
             if (!clan.hasRank(player, clan.talkRank) || !clan.members.contains(player)) {
                 player.message("You are not allowed to talk in this clan chat channel.", ChatType.ClanChat)
-                return@onInstruction
+                return@instruction
             }
             val definition = phrases.get(file)
             val data = generateData(player, file, data)

--- a/game/src/main/kotlin/content/social/clan/ClanChat.kts
+++ b/game/src/main/kotlin/content/social/clan/ClanChat.kts
@@ -13,7 +13,7 @@ import world.gregs.voidps.engine.entity.character.player.isAdmin
 import world.gregs.voidps.engine.entity.character.player.name
 import world.gregs.voidps.engine.entity.playerDespawn
 import world.gregs.voidps.engine.entity.playerSpawn
-import world.gregs.voidps.engine.client.instruction.onInstruction
+import world.gregs.voidps.engine.client.instruction.instruction
 import world.gregs.voidps.engine.inject
 import world.gregs.voidps.engine.timer.epochSeconds
 import world.gregs.voidps.engine.timer.toTicks
@@ -47,27 +47,27 @@ playerDespawn { player ->
     updateMembers(player, clan, ClanRank.Anyone)
 }
 
-onInstruction<ClanChatKick> { player ->
+instruction<ClanChatKick> { player ->
     val clan = player.clan
     if (clan == null || !clan.hasRank(player, clan.kickRank)) {
         player.message("You are not allowed to kick in this clan chat channel.", ChatType.ClanChat)
-        return@onInstruction
+        return@instruction
     }
 
     if (player.name == name) {
         player.message("You cannot kick or ban yourself.", ChatType.ClanChat)
-        return@onInstruction
+        return@instruction
     }
 
     val target = players.get(name)
     if (target == null) {
         player.message("Could not find player with the username '$name'.")
-        return@onInstruction
+        return@instruction
     }
 
     if (!clan.hasRank(player, clan.getRank(target), inclusive = false) || target.isAdmin()) {
         player.message("You cannot kick this member.", ChatType.ClanChat)
-        return@onInstruction
+        return@instruction
     }
 
     if (clan.members.contains(target)) {
@@ -76,10 +76,10 @@ onInstruction<ClanChatKick> { player ->
     player.message("Your request to kick/ban this user was successful.", ChatType.ClanChat)
 }
 
-onInstruction<ClanChatJoin> { player ->
+instruction<ClanChatJoin> { player ->
     if (name.isBlank()) {
         player.emit(LeaveClanChat(forced = false))
-        return@onInstruction
+        return@instruction
     }
     joinClan(player, name)
 }
@@ -141,16 +141,16 @@ val list = listOf(ClanRank.None, ClanRank.Recruit, ClanRank.Corporeal, ClanRank.
 
 val accountDefinitions: AccountDefinitions by inject()
 
-onInstruction<ClanChatRank> { player ->
-    val clan = player.clan ?: player.ownClan ?: return@onInstruction
+instruction<ClanChatRank> { player ->
+    val clan = player.clan ?: player.ownClan ?: return@instruction
     if (!clan.hasRank(player, ClanRank.Owner)) {
-        return@onInstruction
+        return@instruction
     }
     val rank = list[rank]
-    val account = accountDefinitions.get(name) ?: return@onInstruction
+    val account = accountDefinitions.get(name) ?: return@instruction
     player.friends[account.accountName] = rank
     if (clan.members.any { it.accountName == account.accountName }) {
-        val target = players.get(name) ?: return@onInstruction
+        val target = players.get(name) ?: return@instruction
         updateMembers(target, clan, rank)
     }
 }

--- a/game/src/main/kotlin/content/social/friend/FriendsList.kts
+++ b/game/src/main/kotlin/content/social/friend/FriendsList.kts
@@ -21,7 +21,7 @@ import content.social.clan.ownClan
 import content.social.ignore.ignores
 import world.gregs.voidps.engine.entity.character.player.chat.ChatType
 import world.gregs.voidps.engine.entity.character.player.chat.clan.LeaveClanChat
-import world.gregs.voidps.engine.client.instruction.onInstruction
+import world.gregs.voidps.engine.client.instruction.instruction
 import world.gregs.voidps.network.client.instruction.FriendAdd
 import world.gregs.voidps.network.client.instruction.FriendDelete
 import world.gregs.voidps.network.login.protocol.encode.*
@@ -41,31 +41,31 @@ playerDespawn { player ->
     notifyBefriends(player, online = false)
 }
 
-onInstruction<FriendAdd> { player ->
+instruction<FriendAdd> { player ->
     val account = accounts.get(friendsName)
     if (account == null) {
         player.message("Unable to find player with name '$friendsName'.")
-        return@onInstruction
+        return@instruction
     }
 
     if (player.name == friendsName) {
         player.message("You are already your own best friend!")
-        return@onInstruction
+        return@instruction
     }
 
     if (player.ignores.contains(account.accountName)) {
         player.message("Please remove $friendsName from your ignore list first.")
-        return@onInstruction
+        return@instruction
     }
 
     if (player.friends.size >= maxFriends) {
         player.message("Your friends list is full. Max of 100 for free users, and $maxFriends for members.")
-        return@onInstruction
+        return@instruction
     }
 
     if (player.friends.contains(account.accountName)) {
         player.message("$friendsName is already on your friends list.")
-        return@onInstruction
+        return@instruction
     }
 
     player.friends[account.accountName] = ClanRank.Friend
@@ -73,37 +73,37 @@ onInstruction<FriendAdd> { player ->
         friendsName.updateFriend(player, online = true)
     }
     player.sendFriend(account)
-    val clan = player.clan ?: player.ownClan ?: return@onInstruction
+    val clan = player.clan ?: player.ownClan ?: return@instruction
     if (!clan.hasRank(player, ClanRank.Owner)) {
-        return@onInstruction
+        return@instruction
     }
-    val accountDefinition = accountDefinitions.get(friendsName) ?: return@onInstruction
+    val accountDefinition = accountDefinitions.get(friendsName) ?: return@instruction
     if (clan.members.any { it.accountName == accountDefinition.accountName }) {
-        val target = players.get(friendsName) ?: return@onInstruction
+        val target = players.get(friendsName) ?: return@instruction
         for (member in clan.members) {
             member.client?.appendClanChat(ClanMember.of(target, ClanRank.Friend))
         }
     }
 }
 
-onInstruction<FriendDelete> { player ->
+instruction<FriendDelete> { player ->
     val account = accounts.get(friendsName)
     if (account == null || !player.friends.contains(account.accountName)) {
         player.message("Unable to find player with name '$friendsName'.")
-        return@onInstruction
+        return@instruction
     }
 
     player.friends.remove(account.accountName)
     if (player.privateStatus == "friends") {
         friendsName.updateFriend(player, online = false)
     }
-    val clan = player.clan ?: player.ownClan ?: return@onInstruction
+    val clan = player.clan ?: player.ownClan ?: return@instruction
     if (!clan.hasRank(player, ClanRank.Owner)) {
-        return@onInstruction
+        return@instruction
     }
-    val accountDefinition = accountDefinitions.get(friendsName) ?: return@onInstruction
+    val accountDefinition = accountDefinitions.get(friendsName) ?: return@instruction
     if (clan.members.any { it.accountName == accountDefinition.accountName }) {
-        val target = players.get(friendsName) ?: return@onInstruction
+        val target = players.get(friendsName) ?: return@instruction
         for (member in clan.members) {
             member.client?.appendClanChat(ClanMember.of(target, ClanRank.None))
         }

--- a/game/src/main/kotlin/content/social/ignore/IgnoreList.kts
+++ b/game/src/main/kotlin/content/social/ignore/IgnoreList.kts
@@ -11,7 +11,7 @@ import world.gregs.voidps.engine.data.config.AccountDefinition
 import world.gregs.voidps.engine.data.definition.AccountDefinitions
 import world.gregs.voidps.engine.entity.character.player.*
 import world.gregs.voidps.engine.entity.playerSpawn
-import world.gregs.voidps.engine.client.instruction.onInstruction
+import world.gregs.voidps.engine.client.instruction.instruction
 import world.gregs.voidps.engine.inject
 import world.gregs.voidps.network.client.instruction.IgnoreAdd
 import world.gregs.voidps.network.client.instruction.IgnoreDelete
@@ -27,31 +27,31 @@ playerSpawn { player ->
     player.sendIgnores()
 }
 
-onInstruction<IgnoreAdd> { player ->
+instruction<IgnoreAdd> { player ->
     val account = accounts.get(name)
     if (account == null) {
         player.message("Unable to find player with name '$name'.")
-        return@onInstruction
+        return@instruction
     }
 
     if (player.name == name) {
         player.message("We all get irritated with ourselves sometimes, take a break!")
-        return@onInstruction
+        return@instruction
     }
 
     if (player.friends.contains(account.accountName)) {
         player.message("Please remove $name from your ignores list first.")
-        return@onInstruction
+        return@instruction
     }
 
     if (player.ignores.size >= maxIgnores) {
         player.message("Your ignore list is full. Max of $maxIgnores.")
-        return@onInstruction
+        return@instruction
     }
 
     if (player.ignores.contains(account.accountName)) {
         player.message("$name is already on your ignores list.")
-        return@onInstruction
+        return@instruction
     }
 
     player.ignores.add(account.accountName)
@@ -62,26 +62,26 @@ onInstruction<IgnoreAdd> { player ->
     }
 }
 
-onInstruction<IgnoreDelete> { player ->
+instruction<IgnoreDelete> { player ->
     val accountName = player.ignores.firstOrNull {
         val account = accounts.getByAccount(it) ?: return@firstOrNull false
         name.equals(account.displayName, true) // This packet ignores case for some reason.
     }
     if (accountName == null) {
         player.message("Unable to find player with name '$name'.")
-        return@onInstruction
+        return@instruction
     }
 
     val account = accounts.getByAccount(accountName)
     if (account == null || !player.ignores.contains(account.accountName)) {
         player.message("Unable to find player with name '$name'.")
-        return@onInstruction
+        return@instruction
     }
 
     val name = account.displayName
     player.ignores.remove(account.accountName)
     if(player.privateStatus != "on") {
-        return@onInstruction
+        return@instruction
     }
     val other = players.get(name)
     if (other != null && (other.friend(player) || other.isAdmin())) {

--- a/game/src/test/kotlin/content/achievement/LumbridgeBeginnerTasksTest.kt
+++ b/game/src/test/kotlin/content/achievement/LumbridgeBeginnerTasksTest.kt
@@ -39,7 +39,7 @@ internal class LumbridgeBeginnerTasksTest : WorldTest() {
 
         player.running = true
         player.instructions.send(Walk(emptyTile.x, emptyTile.y + 2))
-        tick()
+        tick(2)
 
         assertTrue(player["on_the_run_task", false])
     }
@@ -738,10 +738,10 @@ internal class LumbridgeBeginnerTasksTest : WorldTest() {
 
     @Test
     fun `Wait, That's Not a Sheep`() {
-        val player = createPlayer("adventurer")
+        val player = createPlayer("adventurer", Tile(3109, 3330))
 
         player.tele(3189, 3275)
-        tick()
+        tick(2)
 
         assertTrue(player["wait_thats_not_a_sheep_task", false])
     }

--- a/game/src/test/kotlin/content/entity/combat/CombatTest.kt
+++ b/game/src/test/kotlin/content/entity/combat/CombatTest.kt
@@ -201,7 +201,7 @@ internal class CombatTest : WorldTest() {
         player.interfaceOption("combat_styles", "style3", "Select")
         player.playerOption(target, "Attack")
         tickIf { target.levels.get(Skill.Constitution) > 0 }
-        tick(6) // player death
+        tick(7) // player death
 
         assertNotEquals(startTile, player.tile)
         assertTrue(player.experience.get(Skill.Attack) > EXPERIENCE)

--- a/game/src/test/kotlin/content/entity/npc/combat/HuntModeTest.kt
+++ b/game/src/test/kotlin/content/entity/npc/combat/HuntModeTest.kt
@@ -61,7 +61,7 @@ internal class HuntModeTest : WorldTest() {
         createObject("15516", emptyTile.addY(2)) // fence
         createFloorItem("ashes", emptyTile.addY(3))
 
-        tick(4)
+        tick(6)
 
         assertEquals(emptyTile.addY(1), npc.tile)
     }
@@ -71,7 +71,7 @@ internal class HuntModeTest : WorldTest() {
         val npc = createNPC("ash_cleaner", emptyTile)
         createFloorItem("ashes", emptyTile.addY(3))
 
-        tick(4)
+        tick(9)
 
         assertEquals(emptyTile.addY(3), npc.tile)
         assertTrue(floorItems[emptyTile.addY(3)].isEmpty())

--- a/game/src/test/kotlin/content/entity/player/inv/DropTest.kt
+++ b/game/src/test/kotlin/content/entity/player/inv/DropTest.kt
@@ -21,6 +21,7 @@ internal class DropTest : WorldTest() {
         player.inventory.add("bronze_sword")
 
         player.interfaceOption("inventory", "inventory", "Drop", 4, Item("bronze_sword"), 0)
+        tick()
 
         assertTrue(player.inventory.isEmpty())
         assertTrue(floorItems[player.tile].any { it.id == "bronze_sword" })
@@ -44,10 +45,12 @@ internal class DropTest : WorldTest() {
     fun `Drop stackable items on one another`() {
         val tile = emptyTile
         val player = createPlayer("player", tile)
-        floorItems.add(tile, "coins", 500, owner = player)
+        floorItems.add(tile, "coins", 500, revealTicks = 100, owner = player)
         player.inventory.add("coins", 500)
+        tick()
 
         player.interfaceOption("inventory", "inventory", "Drop", 4, Item("coins", 500), 0)
+        tick()
 
         assertTrue(player.inventory.isEmpty())
         assertEquals(1, floorItems[tile].count { it.id == "coins" })
@@ -62,6 +65,7 @@ internal class DropTest : WorldTest() {
         player.inventory.add("bronze_sword")
 
         player.interfaceOption("inventory", "inventory", "Drop", 4, Item("bronze_sword"), 0)
+        tick()
 
         assertTrue(player.inventory.isEmpty())
         assertEquals(2, floorItems[tile].count { it.id == "bronze_sword" })
@@ -74,6 +78,7 @@ internal class DropTest : WorldTest() {
         player.inventory.add("bronze_sword")
         val drawers = objects[tile.addX(1), "table_lumbridge"]!!
         player.itemOnObject(drawers, itemSlot = 0)
+        tick()
 
         assertTrue(player.inventory.isEmpty())
         assertTrue(floorItems[tile.addX(1)].any { it.id == "bronze_sword" })
@@ -87,6 +92,7 @@ internal class DropTest : WorldTest() {
         val drawers = objects[tile.addX(1), "table_lumbridge"]!!
 
         player.itemOnObject(drawers, itemSlot = 0)
+        tick()
 
         assertTrue(player.inventory.contains("toolkit"))
         assertFalse(floorItems[tile.addX(1)].any { it.id == "toolkit" })

--- a/game/src/test/kotlin/content/social/assist/RequestAssistTest.kt
+++ b/game/src/test/kotlin/content/social/assist/RequestAssistTest.kt
@@ -42,6 +42,7 @@ internal class RequestAssistTest : WorldTest() {
 
         receiver.walk(emptyTile.addY(22))
         tickIf { receiver.tile != emptyTile.addY(22) }
+        tick()
 
         assertFalse(assistant.hasOpen("assist_xp"))
     }


### PR DESCRIPTION
- Add AreaQueue closes #645 
- General performance improvements for movement
  - Use variables instead of map for hot points
  - Store interfaces by type in a map instead of set for faster type checks
- Rename onInstruction to instruction
- Add gradual world map movement updates #638
- Batch update floor items before applying changes in queue #614
