### PR TITLE
Fix Equip Requirements

### DIFF
--- a/engine/src/main/kotlin/world/gregs/voidps/engine/entity/character/player/skill/level/Level.kt
+++ b/engine/src/main/kotlin/world/gregs/voidps/engine/entity/character/player/skill/level/Level.kt
@@ -91,7 +91,7 @@ object Level {
         val requirements: Map<Skill, Int>? = item.def.getOrNull("equip_req")
         if (requirements != null) {
             for ((skill, level) in requirements) {
-                if (if (skill == Skill.Prayer) !hasMax(skill, level, message) else !has(skill, level, message)) {
+                if (!hasMax(skill, level, message)) {
                     return false
                 }
             }


### PR DESCRIPTION
Equip should requirements always check max level instead of boostable level, to prevent being able to stat boost to equip items they shouldn't be able to (e.g. Using a defence potion at lvl 1 defence to be able to wear steel armour)