### PR TITLE
Fix music unlocks

### DIFF
--- a/game/src/main/kotlin/content/entity/world/music/MusicTracks.kt
+++ b/game/src/main/kotlin/content/entity/world/music/MusicTracks.kt
@@ -70,7 +70,7 @@ class MusicTracks {
                                         Region(region).toCuboid()
                                     }
                                 }
-                                val track = Track(key, index, area)
+                                val track = Track(stringId, index, area)
                                 for (r in area.toRegions()) {
                                     tracks.getOrPut(r.id) { ObjectArrayList(1) }.add(track)
                                 }


### PR DESCRIPTION
All music tracks were listed with the name `areas` instead of the name of the track. Quick fix to get that working again.