### PR TITLE
Fix ground items not showing when changing levels

### DIFF
--- a/engine/src/main/kotlin/world/gregs/voidps/engine/client/update/batch/ZoneBatchUpdates.kt
+++ b/engine/src/main/kotlin/world/gregs/voidps/engine/client/update/batch/ZoneBatchUpdates.kt
@@ -49,7 +49,7 @@ class ZoneBatchUpdates : Runnable {
 
     fun run(player: Player) {
         val previousZone: Zone? = player["previous_zone"]
-        val previous = previousZone?.toRectangle(radius = player.viewport!!.localRadius)?.toZones(player.tile.level)?.toSet()
+        val previous = previousZone?.toRectangle(radius = player.viewport!!.localRadius)?.toZones(previousZone.level)?.toSet()
         player["previous_zone"] = player.tile.zone
         for (zone in player.tile.zone.toRectangle(radius = player.viewport!!.localRadius).toZonesReversed(player.tile.level)) {
             val entered = previous == null || !previous.contains(zone)


### PR DESCRIPTION
Fixes #738

Items are now shown to the player when they change floors.