### PR TITLE
Add shop definition for Nurmofs Pickaxe Shop

### DIFF
--- a/data/area/asgarnia/dwarven_mines/dwarven_mine.npcs.toml
+++ b/data/area/asgarnia/dwarven_mines/dwarven_mine.npcs.toml
@@ -36,6 +36,7 @@ examine = "I wonder if he wants to buy my junk?"
 
 [nurmof]
 id = 594
+shop = "nurmofs_pickaxe_shop"
 examine = "He runs a pickaxe store."
 
 [boot_dwarven_mine]

--- a/data/area/asgarnia/dwarven_mines/dwarven_mine.shops.toml
+++ b/data/area/asgarnia/dwarven_mines/dwarven_mine.shops.toml
@@ -24,6 +24,17 @@ defaults = [
     { id = "hammer", amount = 10 },
 ]
 
+[nurmofs_pickaxe_shop]
+id = 68
+defaults = [
+    { id = "bronze_pickaxe", amount = 6 },
+    { id = "iron_pickaxe", amount = 5 },
+    { id = "steel_pickaxe", amount = 4 },
+    { id = "mithril_pickaxe", amount = 3 },
+    { id = "adamant_pickaxe", amount = 2 },
+    { id = "rune_pickaxe", amount = 1 },
+]
+
 [nulodions_multicannon_parts]
 id = 79
 defaults = [


### PR DESCRIPTION
The ID of the shop was pulled from this thread: https://rune-server.org/threads/all-2011-shops.693716/
The stock of items was pulled from this wiki page: https://oldschool.runescape.wiki/w/Nurmof

Tested in a private server.