### PR TITLE
Make npc and object definition cloning explicilty not cross-file

### DIFF
--- a/data/minigame/tzhaar_fight_pits/tzhaar_fight_pit.npcs.toml
+++ b/data/minigame/tzhaar_fight_pits/tzhaar_fight_pit.npcs.toml
@@ -14,7 +14,7 @@ categories = ["tz_haar"]
 examine = "Some kind of bat..."
 
 [tz_kih_fight_pits_2]
-clone = "tz_kih"
+clone = "tz_kih_fight_pits"
 id = 2628
 
 [tz_kek_fight_pits]

--- a/engine/src/main/kotlin/world/gregs/voidps/engine/data/definition/NPCDefinitions.kt
+++ b/engine/src/main/kotlin/world/gregs/voidps/engine/data/definition/NPCDefinitions.kt
@@ -51,7 +51,7 @@ object NPCDefinitions : DefinitionsDecoder<NPCDefinition> {
                                 "clone" -> {
                                     val name = string()
                                     val npc = refs.getInt(name)
-                                    require(npc >= 0) { "Cannot find npc id to clone '$name'. Make sure it's in the same file." }
+                                    require(npc >= 0) { "Cannot find npc to clone with id '$name' in ${path}. Make sure it's in the same file." }
                                     val definition = definitions[npc]
                                     extras.putAll(definition.extras ?: continue)
                                 }

--- a/engine/src/main/kotlin/world/gregs/voidps/engine/data/definition/NPCDefinitions.kt
+++ b/engine/src/main/kotlin/world/gregs/voidps/engine/data/definition/NPCDefinitions.kt
@@ -37,8 +37,10 @@ object NPCDefinitions : DefinitionsDecoder<NPCDefinition> {
     ) {
         timedLoad("npc extra") {
             val ids = Object2IntOpenHashMap<String>()
+            val refs = Object2IntOpenHashMap<String>()
             ids.defaultReturnValue(-1)
             for (path in paths) {
+                refs.clear()
                 Config.fileReader(path, 150) {
                     while (nextSection()) {
                         val stringId = section()
@@ -48,8 +50,8 @@ object NPCDefinitions : DefinitionsDecoder<NPCDefinition> {
                             when (val key = key()) {
                                 "clone" -> {
                                     val name = string()
-                                    val npc = ids.getInt(name)
-                                    require(npc >= 0) { "Cannot find npc id to clone '$name'" }
+                                    val npc = refs.getInt(name)
+                                    require(npc >= 0) { "Cannot find npc id to clone '$name'. Make sure it's in the same file." }
                                     val definition = definitions[npc]
                                     extras.putAll(definition.extras ?: continue)
                                 }
@@ -80,6 +82,7 @@ object NPCDefinitions : DefinitionsDecoder<NPCDefinition> {
                             }
                         }
                         require(!ids.containsKey(stringId)) { "Duplicate npc id found '$stringId' at $path." }
+                        refs[stringId] = id
                         ids[stringId] = id
                         definitions[id].stringId = stringId
                         if (extras.isNotEmpty()) {

--- a/engine/src/main/kotlin/world/gregs/voidps/engine/data/definition/ObjectDefinitions.kt
+++ b/engine/src/main/kotlin/world/gregs/voidps/engine/data/definition/ObjectDefinitions.kt
@@ -35,8 +35,10 @@ object ObjectDefinitions : DefinitionsDecoder<ObjectDefinition> {
     fun load(paths: List<String>): ObjectDefinitions {
         timedLoad("object extra") {
             val ids = Object2IntOpenHashMap<String>()
+            val refs = Object2IntOpenHashMap<String>()
             ids.defaultReturnValue(-1)
             for (path in paths) {
+                refs.clear()
                 Config.fileReader(path) {
                     while (nextSection()) {
                         val stringId = section()
@@ -50,8 +52,8 @@ object ObjectDefinitions : DefinitionsDecoder<ObjectDefinition> {
                                 "mining" -> extras[key] = Rock(this)
                                 "clone" -> {
                                     val name = string()
-                                    val obj = ids.getInt(name)
-                                    require(obj >= 0) { "Cannot find object id to clone '$name'" }
+                                    val obj = refs.getInt(name)
+                                    require(obj >= 0) { "Cannot find object to clone with id '$name' in ${path}. Make sure it's in the same file." }
                                     val definition = definitions[obj]
                                     extras.putAll(definition.extras ?: continue)
                                 }
@@ -67,6 +69,7 @@ object ObjectDefinitions : DefinitionsDecoder<ObjectDefinition> {
                         }
                         require(!ids.containsKey(stringId)) { "Duplicate object id found '$stringId' at $path." }
                         ids[stringId] = id
+                        refs[stringId] = id
                         definitions[id].stringId = stringId
                         if (extras.isNotEmpty()) {
                             definitions[id].extras = extras


### PR DESCRIPTION
- Fix accidental tz_kih cross file reference closes #863