### PR TITLE
Map burnt cod to `burnt_trout`

### DIFF
--- a/data/skill/fishing/fish.items.toml
+++ b/data/skill/fishing/fish.items.toml
@@ -144,7 +144,7 @@ price = 21
 limit = 20000
 weight = 0.45
 fishing = { level = 23, xp = 45.0, chance_min = 4, chance_max = 55 }
-cooking = { level = 18, xp = 75.0, chances = { fire = "83-422", range = "88-432", cooks_range = "93-442" }, cooked = "cod", cooked_message = "You successfully cook a cod.", burnt_message = "You accidentally burn the cod." }
+cooking = { level = 18, xp = 75.0, chances = { fire = "83-422", range = "88-432", cooks_range = "93-442" }, cooked = "cod", burnt = "burnt_trout", cooked_message = "You successfully cook a cod.", burnt_message = "You accidentally burn the cod." }
 examine = "I should try cooking this."
 
 [raw_cod_noted]


### PR DESCRIPTION
When cooking cod when it's burnt intially it shows the inventory slot that contained the fish is now empty but when the inventory refreshes (say after opening the bank) the spot fills with dwarf remains. Dwarf remains is item ID 0 which indicated to me to that the item didn't have a proper mapping.

Sure enough, cod is treated like trout so it should using the `burnt_trout` item. Mackeral is treated the same way with herring. Adding this mapping fixed burning cod.