### PR TITLE
Add behavior for Antique Lamp from Gunnars Ground

### DIFF
--- a/game/src/main/kotlin/content/quest/free/gunnars_ground/AntiqueLamp.kt
+++ b/game/src/main/kotlin/content/quest/free/gunnars_ground/AntiqueLamp.kt
@@ -1,0 +1,28 @@
+package content.quest.free.gunnars_ground
+
+import content.entity.player.dialogue.type.skillLamp
+import content.entity.player.dialogue.type.statement
+import world.gregs.voidps.engine.Script
+import world.gregs.voidps.engine.entity.character.player.skill.exp.exp
+import world.gregs.voidps.engine.inv.inventory
+import world.gregs.voidps.engine.inv.remove
+
+class AntiqueLamp : Script {
+
+    init {
+        itemOption("Rub", "antique_lamp_gunnars_ground") { (item, slot) ->
+            val skill = skillLamp()
+
+            if (this.levels.get(skill) < 5) {
+                statement("<red>This skill is not high enough to gain experience from this lamp.")
+
+                return@itemOption
+            }
+
+            if (inventory.remove(slot, item.id)) {
+                exp(skill, 200.0)
+                statement("<blue>Your wish has been granted!<br><black>You have been awarded 200 ${skill.name} experience!")
+            }
+        }
+    }
+}

--- a/game/src/test/kotlin/content/quest/free/gunnars_ground/AntiqueLampTest.kt
+++ b/game/src/test/kotlin/content/quest/free/gunnars_ground/AntiqueLampTest.kt
@@ -1,0 +1,85 @@
+package content.quest.free.gunnars_ground
+
+import WorldTest
+import interfaceOption
+import itemOption
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import world.gregs.voidps.engine.entity.character.player.skill.Skill
+import world.gregs.voidps.engine.inv.add
+import world.gregs.voidps.engine.inv.inventory
+
+class AntiqueLampTest : WorldTest() {
+
+    @Test
+    fun `rub antique lamp with skill over level 5`() {
+        val player = createPlayer()
+        val lampId = "antique_lamp_gunnars_ground"
+
+        player.inventory.add(lampId)
+        player.levels.set(Skill.Attack, 5)
+        player.levels.set(Skill.Defence, 4)
+        player.levels.set(Skill.Magic, 6)
+        val initialExperience = player.experience.get(Skill.Magic)
+
+        player.itemOption("Rub", lampId)
+        player.interfaceOption(
+            "skill_stat_advance",
+            "magic",
+            "Select",
+            optionIndex = 0,
+        )
+        player.interfaceOption("skill_stat_advance", "confirm", "Confirm")
+
+        assertEquals(0, player.inventory.count(lampId))
+        assertEquals(initialExperience + 200.0, player.experience.get(Skill.Magic))
+    }
+
+    @Test
+    fun `rub antique lamp with skill at level 5`() {
+        val player = createPlayer()
+        val lampId = "antique_lamp_gunnars_ground"
+
+        player.inventory.add(lampId)
+        player.levels.set(Skill.Attack, 5)
+        player.levels.set(Skill.Defence, 4)
+        player.levels.set(Skill.Magic, 6)
+        val initialExperience = player.experience.get(Skill.Attack)
+
+        player.itemOption("Rub", lampId)
+        player.interfaceOption(
+            "skill_stat_advance",
+            "attack",
+            "Select",
+            optionIndex = 0,
+        )
+        player.interfaceOption("skill_stat_advance", "confirm", "Confirm")
+
+        assertEquals(0, player.inventory.count(lampId))
+        assertEquals(initialExperience + 200.0, player.experience.get(Skill.Attack))
+    }
+
+    @Test
+    fun `rub antique lamp with skill below level 5`() {
+        val player = createPlayer()
+        val lampId = "antique_lamp_gunnars_ground"
+
+        player.inventory.add(lampId)
+        player.levels.set(Skill.Attack, 5)
+        player.levels.set(Skill.Defence, 4)
+        player.levels.set(Skill.Magic, 6)
+        val initialExperience = player.experience.get(Skill.Defence)
+
+        player.itemOption("Rub", lampId)
+        player.interfaceOption(
+            "skill_stat_advance",
+            "defence",
+            "Select",
+            optionIndex = 0,
+        )
+        player.interfaceOption("skill_stat_advance", "confirm", "Confirm")
+
+        assertEquals(1, player.inventory.count(lampId))
+        assertEquals(initialExperience, player.experience.get(Skill.Defence))
+    }
+}


### PR DESCRIPTION
Currently if you complete the quest you're awarded the lamp but rubbing it does nothing and you can't bank the item. The only option is to destroy it.

The wiki says that the expected behavior is to be able to select a skill of at least level 5 and you'll be granted 200 experience.