### PR TITLE
Fixed bugs with the Delrith encounter in Demon Slayer

### DIFF
--- a/data/entity/npc/monster/demon/demons.npcs.toml
+++ b/data/entity/npc/monster/demon/demons.npcs.toml
@@ -6,6 +6,7 @@ str = 10
 def = 5
 combat_def = "delrith"
 categories = ["demons"]
+hunt_mode = "aggressive"
 examine = "A freshly summoned demon."
 
 [delrith_weakened]

--- a/game/src/main/kotlin/content/area/misthalin/varrock/Delrith.kt
+++ b/game/src/main/kotlin/content/area/misthalin/varrock/Delrith.kt
@@ -17,9 +17,11 @@ import content.quest.startCutscene
 import world.gregs.voidps.engine.Script
 import world.gregs.voidps.engine.client.clearCamera
 import world.gregs.voidps.engine.client.instruction.handle.interactNpc
+import world.gregs.voidps.engine.client.instruction.handle.interactPlayer
 import world.gregs.voidps.engine.client.moveCamera
 import world.gregs.voidps.engine.client.shakeCamera
 import world.gregs.voidps.engine.client.turnCamera
+import world.gregs.voidps.engine.client.ui.closeInterfaces
 import world.gregs.voidps.engine.client.variable.hasClock
 import world.gregs.voidps.engine.client.variable.start
 import world.gregs.voidps.engine.data.definition.Areas
@@ -77,6 +79,12 @@ class Delrith : Script {
         }
 
         playerDespawn {
+            if (get("logged_out", false)) {
+                if (contains("demon_slayer_cutscene")) {
+                    tele(defaultTile)
+                }
+            }
+
             val cutscene: Cutscene = remove("demon_slayer_cutscene") ?: return@playerDespawn
             cutscene.destroy()
         }
@@ -109,10 +117,13 @@ class Delrith : Script {
                     val expected = DemonSlayerSpell.getWord(player, index + 1)
                     if (selected != expected) {
                         correct = false
-                        target.anim("delrith_continue")
-                        delay(2)
+                        player.closeInterfaces()
+                        val delrith = NPCs.add("delrith", target.tile, Direction.SOUTH)
                         NPCs.remove(target)
+                        delrith.anim("delrith_continue")
+                        delrith.interactPlayer(player, "Attack")
                         delay(1)
+                        return@weakQueue
                     } else {
                         delay(3)
                     }

--- a/game/src/main/kotlin/content/area/misthalin/varrock/Delrith.kt
+++ b/game/src/main/kotlin/content/area/misthalin/varrock/Delrith.kt
@@ -92,7 +92,7 @@ class Delrith : Script {
             }
         }
 
-        npcOperate("Banish", "delrith") { (target) ->
+        npcOperate("Banish", "delrith_weakened") { (target) ->
             if (target.transform != "delrith_weakened") {
                 return@npcOperate
             }


### PR DESCRIPTION
While completing the Demon Slayer quests I found few bugs that
would be confusing for players.

1. If you give the wrong word for the incantation Delrith just
   disappears and doesn't come back. You could work around this by
   walking out of the area which brings you out of the instance and then
   re-entering the instance. This is a bit annoying and not what happens
   normally. The change here was to reset Delrith back to full strength
   and have him attack the player again.
2. If the player logs out while in the instance, when they log back in
   they'll be floating in an empty instance. The only way out is to
   teleport somewhere which could require the player to wait a while if
   the only teleport they have is the base Lumbridge one and they used
   it recently. The fix here was just to catch the logout event and
   teleport them to safety before tearing the instance down.
3. I noticed that when you got to actually fighting Delrith, after slaying him
   if you clicked the Banish option you would get a "Nothing interesting
   happens" message. Looks like the expected target was set to full strength
   Delrith on accident. This had no workaround for players and needed a fix.