### PR TITLE
fix: bind row id collision between spells and spell_projectiles

### DIFF
--- a/data/skill/magic/spell_projectiles.tables.toml
+++ b/data/skill/magic/spell_projectiles.tables.toml
@@ -8,7 +8,7 @@ end_height_default = -1
 [.ice_barrage]
 end_height = 0
 
-[.bind]
+[.bind_projectile]
 gfx = "bind"
 end_height = 0
 

--- a/data/skill/magic/spells.tables.toml
+++ b/data/skill/magic/spells.tables.toml
@@ -149,7 +149,7 @@ freeze_ticks = 8
 graphic = "bind_cast"
 animation = "bind"
 animation_staff = "bind_staff"
-projectiles = ["spell_projectiles.bind"]
+projectiles = ["spell_projectiles.bind_projectile"]
 
 [.snare]
 clone = "bind"


### PR DESCRIPTION
<html><head></head><body><h1>fix: <code>bind</code> row id collision between <code>spells</code> and <code>spell_projectiles</code></h1>
<h2>Bug</h2>
<p>After #964, both tables declare a <code>[.bind]</code> row:</p>

File | Columns
-- | --
spell_projectiles.tables.toml | 4
spells.tables.toml | 17


<p><code>clone = "bind"</code> in <code>spells</code> matches by <code>rowId</code> only. <code>spell_projectiles</code> loads first, so the 4-column projectile row gets cloned into the 17-column spell row, throwing <code>ArrayIndexOutOfBoundsException</code> at <code>clone[4]</code>. This crashes <code>Main.preload</code> via Koin.</p>
<h2>Fix</h2>
<p>Rename the projectile row to <code>bind_projectile</code> and update its one reference.</p>
<pre><code class="language-diff"> # spell_projectiles.tables.toml
-[.bind]
+[.bind_projectile]
</code></pre>
<pre><code class="language-diff"> # spells.tables.toml
-projectiles = ["spell_projectiles.bind"]
+projectiles = ["spell_projectiles.bind_projectile"]
</code></pre>
<h2>Note</h2>
<p><code>[.ice_barrage]</code> also collides but isn't cloned, so it's harmless for now.</p></body></html>