### PR TITLE
Scope Tables clone resolution to current table

### DIFF
--- a/engine/src/main/kotlin/world/gregs/voidps/engine/data/definition/Tables.kt
+++ b/engine/src/main/kotlin/world/gregs/voidps/engine/data/definition/Tables.kt
@@ -287,7 +287,7 @@ object Tables {
             val column = builder.readers[index]
             if (column is ColumnReader.ReaderClone) {
                 val rowId = column.read(reader)
-                val clone = rows.firstOrNull { it.rowId == rowId }?.data
+                val clone = ids["$key.$rowId"]?.let { rows[it].data }
                 requireNotNull(clone) { "Row '$rowId' to clone not found in table '$key' at ${reader.exception()}." }
                 for (i in row.indices) {
                     if (row[i] == null) {

--- a/engine/src/test/kotlin/world/gregs/voidps/engine/data/definition/TablesTest.kt
+++ b/engine/src/test/kotlin/world/gregs/voidps/engine/data/definition/TablesTest.kt
@@ -133,6 +133,22 @@ class TablesTest {
         assertEquals("text", Tables.string("header.row_three.string_field"))
     }
 
+    @Test
+    fun `Clone resolves within own table when rowId collides across tables`() {
+        AnimationDefinitions.set(emptyArray(), emptyMap())
+        GraphicDefinitions.set(emptyArray(), emptyMap())
+        ItemDefinitions.set(emptyArray(), emptyMap())
+        ObjectDefinitions.set(emptyArray(), emptyMap())
+        NPCDefinitions.set(emptyArray(), emptyMap())
+        VariableDefinitions.set(emptyMap(), emptyMap(), emptyMap())
+        val other = TablesTest::class.java.getResource("test-table-clone-other.toml")!!
+        val main = TablesTest::class.java.getResource("test-table-clone-main.toml")!!
+        Tables.load(listOf(other.path, main.path))
+
+        assertEquals(1, Tables.int("main.cloned.int_field"))
+        assertEquals("main_text", Tables.string("main.cloned.string_field"))
+    }
+
     private fun assertColumns(expected: List<Field>, definition: TableDefinition) {
         for ((i, field) in expected.withIndex()) {
             assertAnyEquals(field.default, definition.default[i], "$field index $i")

--- a/engine/src/test/resources/world/gregs/voidps/engine/data/definition/test-table-clone-main.toml
+++ b/engine/src/test/resources/world/gregs/voidps/engine/data/definition/test-table-clone-main.toml
@@ -1,0 +1,11 @@
+[main]
+int_field = "int"
+string_field = "string"
+clone = "clone"
+
+[.row]
+int_field = 1
+string_field = "main_text"
+
+[.cloned]
+clone = "row"

--- a/engine/src/test/resources/world/gregs/voidps/engine/data/definition/test-table-clone-other.toml
+++ b/engine/src/test/resources/world/gregs/voidps/engine/data/definition/test-table-clone-other.toml
@@ -1,0 +1,6 @@
+[other]
+int_field = "int"
+clone = "clone"
+
+[.row]
+int_field = 99


### PR DESCRIPTION
  ## Summary
  - `readTableRow` resolved `clone = "rowId"` against a global cross-table list, returning the first match by trailing name. Two tables with a same-named row (e.g. `spells.bind` /     
  `spell_projectiles.bind`) collided; `Files.newDirectoryStream` order picked the winner, so boot succeeded or ArrayIndexOutOfBoundsException depending on the host filesystem.
  - Replaced with an O(1) `ids["$table.$rowId"]` lookup, restoring the intra-table semantics the existing error message already promised.                                               
  - Added a regression test that loads two tables sharing a rowId and verifies the clone resolves within its own table.
                                                                                                                                                                                        
  ## Test plan                            
  - [x] `./gradlew :engine:test` green (existing `Test loading a table` still passes; new `Clone resolves within own table when rowId collides across tables` passes).                  
  - [x] Verified the new test fails with AIOOBE against the old global-scan code, confirming it reproduces the original boot crash.                                                     
  - [x] `./gradlew :game:compileKotlin` clean.  