### PR TITLE
fix: max roll for general_seeds table

### DIFF
--- a/game/src/main/kotlin/content/entity/death/NPCDeath.kt
+++ b/game/src/main/kotlin/content/entity/death/NPCDeath.kt
@@ -92,11 +92,7 @@ class NPCDeath(
 
     fun dropLoot(npc: NPC, killer: Character?, tile: Tile) {
         val table = tables.get("${npc.def["drop_table", npc.id]}_drop_table") ?: return
-        val combatLevel = when (killer) {
-            is Player -> killer.combatLevel
-            is NPC -> killer.def.combat
-            else -> -1
-        }
+        val combatLevel = npc.def.combat
         val drops = table.roll(maximumRoll = if (combatLevel > 0) combatLevel * 10 else -1, player = killer as? Player)
             .filterNot { it.id == "nothing" }
             .reversed()


### PR DESCRIPTION
The current code was checking the combat level of the killer when passing a maximum roll to the loot method. This should be based off the npcs combat level instead.

Source: https://oldschool.runescape.wiki/w/Drop_table#General%20seed%20drop%20table