### PR TITLE
Add Rune Mysteries happy path test

### DIFF
--- a/data/quest/members/rune_mysteries/rune_mysteries.items.toml
+++ b/data/quest/members/rune_mysteries/rune_mysteries.items.toml
@@ -18,5 +18,6 @@ kept = "Reclaim"
 id = 15361
 tradeable = false
 weight = 0.015
+destroy = "You can get another one by speaking to Duke Horacio in Lumbridge Castle."
 examine = "A mysterious power emanates from the talisman..."
 kept = "Reclaim"

--- a/game/src/main/kotlin/content/area/misthalin/lumbridge/castle/DukeHoracio.kt
+++ b/game/src/main/kotlin/content/area/misthalin/lumbridge/castle/DukeHoracio.kt
@@ -27,7 +27,7 @@ class DukeHoracio : Script {
     suspend fun Player.started() {
         choice {
             option<Quiz>("What did you want me to do again?") {
-                if (ownsItem("air_talisman")) {
+                if (ownsItem("talisman_rune_mysteries")) {
                     npc<Idle>("Take that talisman I gave you to Sedridor at the Wizards' Tower. You'll find it south west of here, across the bridge from Draynor Village.")
                     player<Happy>("Okay, will do.")
                     return@option
@@ -36,12 +36,12 @@ class DukeHoracio : Script {
                 player<Disheartened>("No, I lost it.")
                 npc<Idle>("Ah, well that explains things. One of my servants found it outside, and it seemed too much of a coincidence that another would suddenly show up.")
                 if (inventory.isFull()) {
-                    item("air_talisman", "The Duke tries to hand you the talisman, but you don't have enough room to take it.")
+                    item("talisman_rune_mysteries", "The Duke tries to hand you the talisman, but you don't have enough room to take it.")
                     return@option
                 }
                 npc<Idle>("Here, take it to the Wizards' Tower, south west of here. Please try not to lose it this time.")
-                inventory.add("air_talisman")
-                item("air_talisman", "The Duke hands you the talisman.")
+                inventory.add("talisman_rune_mysteries")
+                item("talisman_rune_mysteries", "The Duke hands you the talisman.")
             }
             findMoney()
         }
@@ -53,7 +53,7 @@ class DukeHoracio : Script {
                 npc<Confused>("Well, I wouldn't describe it as a quest, but there is something I could use some help with.")
                 player<Quiz>("What is it?")
                 npc<Idle>("We were recently sorting through some of the things stored down in the cellar, and we found this old talisman.")
-                item("air_talisman", "The Duke shows you a talisman.")
+                item("talisman_rune_mysteries", "The Duke shows you a talisman.")
                 npc<Idle>("The Order of Wizards over at the Wizards' Tower have been on the hunt for magical artefacts recently. I wonder if this might be just the kind of thing they're after.")
                 npc<Quiz>("Would you be willing to take it to them for me?")
                 startQuest()
@@ -79,14 +79,14 @@ class DukeHoracio : Script {
         choice("Start the Rune Mysteries quest?") {
             option<Happy>("Sure, no problem.") {
                 if (inventory.isFull()) {
-                    item("air_talisman", "The Duke tries to hand you the talisman, but you don't have enough room to take it.")
+                    item("talisman_rune_mysteries", "The Duke tries to hand you the talisman, but you don't have enough room to take it.")
                     return@option
                 }
                 set("rune_mysteries", "started")
-                inventory.add("air_talisman")
+                inventory.add("talisman_rune_mysteries")
                 npc<Idle>("Thank you very much. You'll find the Wizards' Tower south west of here, across the bridge from Draynor Village. When you arrive, look for Sedridor. He is the Archmage of the wizards there.")
                 refreshQuestJournal()
-                item("air_talisman", "The Duke hands you the talisman.")
+                item("talisman_rune_mysteries", "The Duke hands you the talisman.")
             }
             option<Idle>("Not right now.") {
                 npc<Disheartened>("As you wish. Hopefully I can find someone else to help.")

--- a/game/src/main/kotlin/content/area/misthalin/wizards_tower/Sedridor.kt
+++ b/game/src/main/kotlin/content/area/misthalin/wizards_tower/Sedridor.kt
@@ -77,13 +77,13 @@ class Sedridor : Script {
 
     suspend fun Player.okHere() {
         player<Idle>("Okay, here you are.")
-        if (inventory.contains("air_talisman")) {
+        if (inventory.contains("talisman_rune_mysteries")) {
             set("rune_mysteries", "talisman_delivered")
-            item("air_talisman", "You hand the talisman to Sedridor.")
-            inventory.remove("air_talisman")
+            item("talisman_rune_mysteries", "You hand the talisman to Sedridor.")
+            inventory.remove("talisman_rune_mysteries")
             npc<Confused>("Hmm... Doesn't seem to be anything too special. Just a normal air talisman by the looks of things. Still, looks can be deceiving. Let me take a closer look...")
             sound("enchant_emerald_ring")
-            item("air_talisman", "Sedridor murmurs some sort of incantation and the talisman glows slightly.")
+            item("talisman_rune_mysteries", "Sedridor murmurs some sort of incantation and the talisman glows slightly.")
             npc<Confused>("How interesting... It would appear I spoke too soon. There's more to this talisman than meets the eye. In fact, it may well be the last piece of the puzzle.")
             player<Quiz>("Puzzle?")
             npc<Happy>("Indeed! The lost legacy of the first tower. This talisman may in fact be key to finding the forgotten essence mine!")

--- a/game/src/main/kotlin/content/quest/free/rune_mysteries/RuneMysteries.kt
+++ b/game/src/main/kotlin/content/quest/free/rune_mysteries/RuneMysteries.kt
@@ -41,7 +41,7 @@ class RuneMysteries : Script {
                         "<maroon>Lumbridge, across the bridge from <maroon>Draynor Village.",
                     )
 
-                    if (!carriesItem("air_talisman")) {
+                    if (!carriesItem("talisman_rune_mysteries")) {
                         list.add("<navy>If I lose the <maroon>Strange Talisman<navy> , I'll need to ask <maroon>Duke Horacio<navy> for")
                         list.add("<navy>another.")
                     }
@@ -118,7 +118,7 @@ class RuneMysteries : Script {
                 }
                 else -> listOf(
                     "<navy>I can start this quest by speaking to <maroon>Duke Horacio of",
-                    "<maroon>Lumbridge<navy>upstairs in <maroon>Lumbridge Castle.",
+                    "<maroon>Lumbridge<navy> upstairs in <maroon>Lumbridge Castle.",
                 )
             }
             questJournal("Rune Mysteries", lines)

--- a/game/src/test/kotlin/content/quest/member/rune_mysteries/RuneMysteriesTest.kt
+++ b/game/src/test/kotlin/content/quest/member/rune_mysteries/RuneMysteriesTest.kt
@@ -1,0 +1,95 @@
+package content.quest.member.rune_mysteries
+
+import WorldTest
+import content.quest.quest
+import dialogueContinue
+import dialogueOption
+import npcOption
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertNotNull
+import world.gregs.voidps.engine.client.ui.dialogue
+import world.gregs.voidps.engine.entity.character.move.tele
+import world.gregs.voidps.engine.entity.character.npc.NPCs
+import world.gregs.voidps.engine.entity.character.player.Player
+import world.gregs.voidps.engine.inv.inventory
+import world.gregs.voidps.engine.suspend.Suspension
+import world.gregs.voidps.type.Tile
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class RuneMysteriesTest : WorldTest() {
+    override var loadNpcs: Boolean = true
+
+    @Test
+    fun `Complete the quest`() {
+        val player = createPlayer(Tile(3210, 3223, 1))
+
+        // Start quest at duke
+        val dukeHoracio = NPCs.find(player.tile.regionLevel, "duke_horacio")
+        player.npcOption(dukeHoracio, "Talk-to")
+        tick(5)
+        player.fastForwardDialogue()
+        player.selectDialogueOption(1)
+        player.fastForwardDialogue()
+        player.selectDialogueOption(1)
+        player.fastForwardDialogue()
+
+        assertNull(player.dialogue)
+        assertEquals(1, player.inventory.count("talisman_rune_mysteries"))
+        assertEquals("started", player.quest("rune_mysteries"))
+
+        // get package
+        player.tele(3103, 9570, 0)
+        val sedridor = NPCs.find(player.tile.regionLevel, "sedridor")
+        player.npcOption(sedridor, "Talk-to")
+        tick()
+        player.fastForwardDialogue()
+        player.selectDialogueOption(1)
+        player.fastForwardDialogue()
+        player.selectDialogueOption(1)
+        player.fastForwardDialogue()
+        player.selectDialogueOption(1)
+        player.fastForwardDialogue()
+
+        assertEquals(1, player.inventory.count("research_package_rune_mysteries"))
+        assertNull(player.dialogue)
+        assertEquals("research_package", player.quest("rune_mysteries"))
+
+        // deliever package
+        player.tele(3252, 3401, 0)
+        val aubury = NPCs.find(player.tile.regionLevel, "aubury")
+        player.npcOption(aubury, "Talk-to")
+        tick()
+        player.fastForwardDialogue()
+        player.selectDialogueOption(3)
+        player.fastForwardDialogue()
+
+        assertEquals(1, player.inventory.count("research_notes_rune_mysteries"))
+        assertNull(player.dialogue)
+        assertEquals("research_notes", player.quest("rune_mysteries"))
+
+        // deliver notes and finish quest
+        player.tele(3103, 9570, 0)
+        player.npcOption(sedridor, "Talk-to")
+        tick()
+        player.fastForwardDialogue()
+
+        assertNull(player.dialogue)
+        assertEquals("completed", player.quest("rune_mysteries"))
+        assertEquals(1, player.inventory.count("air_talisman"))
+    }
+
+    private fun Player.fastForwardDialogue() {
+        assertNotNull(dialogue)
+        require(suspension is Suspension.Continue)
+        while (suspension is Suspension.Continue) {
+            dialogueContinue()
+        }
+    }
+
+    private fun Player.selectDialogueOption(option: Int) {
+        assertNotNull(dialogue)
+        require(suspension is Suspension.IntEntry)
+        dialogueOption("line$option")
+    }
+}


### PR DESCRIPTION
This adds a happy path test for Rune Mysteries and resolves one task from #746.

Also changes the talisman given during the quest from the regular version to the quest-specific version, matching the change made in 2009.

Uses dragbone's dialogue helper functions for selecting dialogue options.