### PR TITLE
General bug fixes

### DIFF
--- a/data/area/fremennik_province/rellekka/fremennik_dungeon/basilisk/basilisk.drops.toml
+++ b/data/area/fremennik_province/rellekka/fremennik_dungeon/basilisk/basilisk.drops.toml
@@ -16,7 +16,7 @@ drops = [
     { id = "adamant_full_helm", chance = 4 },
     { id = "mithril_kiteshield", chance = 4 },
     { id = "rune_dagger", chance = 4 },
-    { id = "light_mystic_hat" },
+    { id = "mystic_hat_light" },
     { id = "water_rune", amount = 75, chance = 32 },
     { id = "nature_rune", amount = 15, chance = 20 },
     { id = "law_rune", amount = 3, chance = 12 },

--- a/data/area/fremennik_province/rellekka/fremennik_dungeon/cockatrice/cockatrice.drops.toml
+++ b/data/area/fremennik_province/rellekka/fremennik_dungeon/cockatrice/cockatrice.drops.toml
@@ -14,7 +14,7 @@ drops = [
     { id = "iron_boots", chance = 4 },
     { id = "iron_javelin", amount = 5, chance = 4 },
     { id = "steel_longsword", chance = 4 },
-    { id = "light_mystic_boots" },
+    { id = "mystic_boots_light" },
     { id = "nature_rune", amount = 2, chance = 24 },
     { id = "nature_rune", amount = 4, chance = 16 },
     { id = "nature_rune", amount = 6, chance = 8 },

--- a/data/area/misthalin/lumbridge/swamp/caves/lumbridge_swamp_caves.drops.toml
+++ b/data/area/misthalin/lumbridge/swamp/caves/lumbridge_swamp_caves.drops.toml
@@ -46,7 +46,7 @@ drops = [
     { id = "mithril_med_helm", chance = 4 },
     { id = "mithril_full_helm", chance = 4 },
     { id = "adamant_med_helm", chance = 4 },
-    { id = "light_mystic_hat" },
+    { id = "mystic_hat_light" },
     { id = "grimy_guam", chance = 128 },
     { id = "coins", amount = 15, chance = 40 },
     { id = "tinderbox", chance = 84 },

--- a/data/area/misthalin/lumbridge/swamp/lumbridge_swamp.drops.toml
+++ b/data/area/misthalin/lumbridge/swamp/lumbridge_swamp.drops.toml
@@ -1,7 +1,7 @@
 [rockslug_drop_table]
 roll = 512
 drops = [
-    { id = "light_mystic_gloves" },
+    { id = "mystic_gloves_light" },
     { id = "earth_rune", amount = 5, chance = 120 },
     { id = "earth_rune", amount = 42, chance = 16 },
     { id = "chaos_rune", amount = 2, chance = 16 },

--- a/data/area/morytania/slayer_tower/aberrant_spectre/aberrant_spectre.drops.toml
+++ b/data/area/morytania/slayer_tower/aberrant_spectre/aberrant_spectre.drops.toml
@@ -14,7 +14,7 @@ drops = [
   { id = "lava_battlestaff", chance = 4 },
   { id = "adamant_platelegs", chance = 4 },
   { id = "rune_full_helm", chance = 4 },
-  { id = "dark_mystic_robe_bottom" },
+  { id = "mystic_robe_bottom_dark" },
   { table = "rare_seed_drop_table", chance = 76 },
   { id = "coins", amount = 460, chance = 4 },
   { id = "nothing", amount = 0, chance = 72 },

--- a/data/area/morytania/slayer_tower/banshee/banshee.drops.toml
+++ b/data/area/morytania/slayer_tower/banshee/banshee.drops.toml
@@ -12,7 +12,7 @@ drops = [
     { id = "iron_mace", chance = 2 },
     { id = "iron_dagger", chance = 2 },
     { id = "iron_kiteshield" },
-    { id = "dark_mystic_gloves" },
+    { id = "mystic_gloves_dark" },
     { id = "air_rune", amount = 3, chance = 12 },
     { id = "cosmic_rune", amount = 2, chance = 12 },
     { id = "chaos_rune", amount = 3, chance = 8 },

--- a/data/area/morytania/slayer_tower/gargoyle/gargoyle.drops.toml
+++ b/data/area/morytania/slayer_tower/gargoyle/gargoyle.drops.toml
@@ -10,7 +10,7 @@ drops = [
 roll = 512
 drops = [
   { id = "granite_maul", chance = 2 },
-  { id = "dark_mystic_robe_top" },
+  { id = "mystic_robe_top_dark" },
   { id = "adamant_platelegs", chance = 16 },
   { id = "rune_full_helm", chance = 12 },
   { id = "rune_2h_sword", chance = 8 },

--- a/data/area/morytania/slayer_tower/infernal_mage/infernal_mage.drops.toml
+++ b/data/area/morytania/slayer_tower/infernal_mage/infernal_mage.drops.toml
@@ -9,8 +9,8 @@ drops = [
 roll = 1000
 drops = [
   { id = "lava_battlestaff" },
-  { id = "dark_mystic_boots" },
-  { id = "dark_mystic_hat" },
+  { id = "mystic_boots_dark" },
+  { id = "mystic_hat_dark" },
   { id = "staff", chance = 56 },
   { id = "staff_of_fire", chance = 7 },
   { id = "earth_rune", amount = 10, chance = 42 },

--- a/data/entity/npc/monster/kurask/kurask.drops.toml
+++ b/data/entity/npc/monster/kurask/kurask.drops.toml
@@ -14,7 +14,7 @@ drops = [
     { id = "adamant_platebody", chance = 24 },
     { id = "rune_hatchet", chance = 24 },
     { id = "leaf_bladed_sword", chance = 2 },
-    { id = "light_mystic_robe_top", chance = 2 },
+    { id = "mystic_robe_top_light", chance = 2 },
     { id = "leaf_bladed_spear" },
     { id = "nature_rune", amount = 10, chance = 80 },
     { id = "nature_rune", amount = 15, chance = 56 },

--- a/data/entity/npc/monster/reptile/lizard/lizard.drops.toml
+++ b/data/entity/npc/monster/reptile/lizard/lizard.drops.toml
@@ -9,7 +9,7 @@ drops = [
 [lizard_secondary]
 roll = 512
 drops = [
-    { id = "light_mystic_gloves" },
+    { id = "mystic_gloves_light" },
     { id = "fire_rune", amount = 5, chance = 120 },
     { id = "fire_rune", amount = 42, chance = 56 },
     { id = "nature_rune", amount = 5, chance = 16 },

--- a/data/entity/npc/monster/turoth/turoth.drops.toml
+++ b/data/entity/npc/monster/turoth/turoth.drops.toml
@@ -15,7 +15,7 @@ drops = [
     { id = "adamant_full_helm", chance = 4 },
     { id = "rune_dagger", chance = 4 },
     { id = "leaf_bladed_sword" },
-    { id = "light_mystic_robe_bottom" },
+    { id = "mystic_robe_bottom_light" },
     { id = "law_rune", amount = 3, chance = 24 },
     { id = "nature_rune", amount = 15, chance = 20 },
     { id = "nature_rune", amount = 37, chance = 4 },

--- a/data/entity/player/dialogue/dialogue.ifaces.toml
+++ b/data/entity/player/dialogue/dialogue.ifaces.toml
@@ -96,10 +96,10 @@ id = 8
 id = 68
 type = "dialogue_box"
 
-[.head_large]
+[.head]
 id = 1
 
-[.head]
+[.head_large]
 id = 2
 
 [.title]
@@ -115,10 +115,10 @@ id = 5
 id = 69
 type = "dialogue_box"
 
-[.head_large]
+[.head]
 id = 1
 
-[.head]
+[.head_large]
 id = 2
 
 [.title]
@@ -137,10 +137,10 @@ id = 6
 id = 70
 type = "dialogue_box"
 
-[.head_large]
+[.head]
 id = 1
 
-[.head]
+[.head_large]
 id = 2
 
 [.title]
@@ -162,10 +162,10 @@ id = 7
 id = 71
 type = "dialogue_box"
 
-[.head_large]
+[.head]
 id = 1
 
-[.head]
+[.head_large]
 id = 2
 
 [.title]

--- a/data/entity/player/unobtainable.items.toml
+++ b/data/entity/player/unobtainable.items.toml
@@ -440,11 +440,11 @@ id = 10568
 id = 10601
 tradeable = false
 
-[dark_mystic_hat_2]
+[mystic_hat_dark_2]
 id = 10602
 tradeable = false
 
-[light_mystic_hat_3]
+[mystic_hat_light_3]
 id = 10603
 tradeable = false
 

--- a/data/skill/construction/construction.invs.toml
+++ b/data/skill/construction/construction.invs.toml
@@ -395,8 +395,8 @@ defaults = [
 id = 446
 defaults = [
     { id = "mystic_hat_blue_2", amount = 1 },
-    { id = "dark_mystic_hat_2", amount = 1 },
-    { id = "light_mystic_hat_3", amount = 1 },
+    { id = "mystic_hat_dark_2", amount = 1 },
+    { id = "mystic_hat_light_3", amount = 1 },
     { id = "skeletal_helm_2", amount = 1 },
     { id = "infinity_top_2", amount = 1 },
     { id = "splitbark_helm_2", amount = 1 },

--- a/data/skill/herblore/potion.items.toml
+++ b/data/skill/herblore/potion.items.toml
@@ -311,6 +311,7 @@ price = 4364
 weight = 0.03
 excess = "super_ranging_potion_2"
 empty = "vial"
+aka = ["ranging_potion_3", "range_potion_3", "super_range_3", "super_range_potion_3"]
 examine = "3 doses of super ranging potion."
 
 [super_ranging_potion_3_noted]
@@ -322,6 +323,7 @@ price = 2939
 weight = 0.025
 excess = "super_ranging_potion_1"
 empty = "vial"
+aka = ["ranging_potion_2", "range_potion_2", "super_range_2", "super_range_potion_2"]
 examine = "2 doses of super ranging potion."
 
 [super_ranging_potion_2_noted]
@@ -333,6 +335,7 @@ price = 1554
 weight = 0.02
 excess = "vial"
 empty = "vial"
+aka = ["ranging_potion_1", "range_potion_1", "super_range_1", "super_range_potion_1"]
 examine = "1 dose of super ranging potion."
 
 [super_ranging_potion_1_noted]
@@ -552,7 +555,7 @@ id = 2443
 id = 2444
 price = 5861
 weight = 0.035
-aka = ["super_rng", "super_range", "super_ranges"]
+aka = ["super_rng", "super_range", "super_ranging_potion", "super_ranges", "ranging_potion_4"]
 excess = "super_ranging_potion_3"
 empty = "vial"
 examine = "4 doses of super ranging potion."
@@ -822,6 +825,7 @@ price = 6810
 weight = 0.035
 excess = "super_magic_potion_3"
 empty = "vial"
+aka = ["super_magic_potion", "magic_potion", "super_magic_4", "magic_potion_4"]
 examine = "4 doses of super magic potion."
 
 [super_magic_potion_4_noted]
@@ -833,6 +837,7 @@ price = 5257
 weight = 0.03
 excess = "super_magic_potion_2"
 empty = "vial"
+aka = ["magic_potion_3", "super_magic_3"]
 examine = "3 doses of super magic potion."
 
 [super_magic_potion_3_noted]
@@ -844,6 +849,7 @@ price = 3550
 weight = 0.025
 excess = "super_magic_potion_1"
 empty = "vial"
+aka = ["magic_potion_2", "super_magic_3"]
 examine = "2 doses of super magic potion."
 
 [super_magic_potion_2_noted]
@@ -855,6 +861,7 @@ price = 1783
 weight = 0.02
 excess = "vial"
 empty = "vial"
+aka = ["magic_potion_1", "super_magic_1"]
 examine = "1 dose of super magic potion."
 
 [super_magic_potion_1_noted]

--- a/data/skill/magic/robe.items.toml
+++ b/data/skill/magic/robe.items.toml
@@ -736,7 +736,7 @@ examine = "Magical boots."
 [mystic_boots_blue_noted]
 id = 4098
 
-[dark_mystic_hat]
+[mystic_hat_dark]
 id = 4099
 price = 34300
 limit = 100
@@ -745,10 +745,10 @@ slot = "Hat"
 type = "Hair"
 examine = "A dark magical hat."
 
-[dark_mystic_hat_noted]
+[mystic_hat_dark_noted]
 id = 4100
 
-[dark_mystic_robe_top]
+[mystic_robe_top_dark]
 id = 4101
 price = 71900
 limit = 100
@@ -756,10 +756,10 @@ weight = 2.721
 slot = "Chest"
 examine = "The upper half of a dark magical robe."
 
-[dark_mystic_robe_top_noted]
+[mystic_robe_top_dark_noted]
 id = 4102
 
-[dark_mystic_robe_bottom]
+[mystic_robe_bottom_dark]
 id = 4103
 price = 47600
 limit = 100
@@ -767,10 +767,10 @@ weight = 1.814
 slot = "Legs"
 examine = "The lower half of a dark magical robe."
 
-[dark_mystic_robe_bottom_noted]
+[mystic_robe_bottom_dark_noted]
 id = 4104
 
-[dark_mystic_gloves]
+[mystic_gloves_dark]
 id = 4105
 price = 5811
 limit = 100
@@ -778,10 +778,10 @@ weight = 0.453
 slot = "Hands"
 examine = "Dark magical gloves."
 
-[dark_mystic_gloves_noted]
+[mystic_gloves_dark_noted]
 id = 4106
 
-[dark_mystic_boots]
+[mystic_boots_dark]
 id = 4107
 price = 103400
 limit = 100
@@ -789,10 +789,10 @@ weight = 0.453
 slot = "Feet"
 examine = "Dark magical boots."
 
-[dark_mystic_boots_noted]
+[mystic_boots_dark_noted]
 id = 4108
 
-[light_mystic_hat]
+[mystic_hat_light]
 id = 4109
 price = 8845
 limit = 100
@@ -801,10 +801,10 @@ slot = "Hat"
 type = "Hair"
 examine = "A bright magical hat."
 
-[light_mystic_hat_noted]
+[mystic_hat_light_noted]
 id = 4110
 
-[light_mystic_robe_top]
+[mystic_robe_top_light]
 id = 4111
 price = 74900
 limit = 100
@@ -812,10 +812,10 @@ weight = 2.721
 slot = "Chest"
 examine = "The upper half of a bright magical robe."
 
-[light_mystic_robe_top_noted]
+[mystic_robe_top_light_noted]
 id = 4112
 
-[light_mystic_robe_bottom]
+[mystic_robe_bottom_light]
 id = 4113
 price = 47300
 limit = 100
@@ -823,10 +823,10 @@ weight = 1.814
 slot = "Legs"
 examine = "The lower half of a bright magical robe."
 
-[light_mystic_robe_bottom_noted]
+[mystic_robe_bottom_light_noted]
 id = 4114
 
-[light_mystic_gloves]
+[mystic_gloves_light]
 id = 4115
 price = 274000
 limit = 100
@@ -834,10 +834,10 @@ weight = 0.453
 slot = "Hands"
 examine = "Bright magical gloves."
 
-[light_mystic_gloves_noted]
+[mystic_gloves_light_noted]
 id = 4116
 
-[light_mystic_boots]
+[mystic_boots_light]
 id = 4117
 price = 12300
 limit = 100
@@ -845,5 +845,5 @@ weight = 0.453
 slot = "Feet"
 examine = "Bright magical boots."
 
-[light_mystic_boots_noted]
+[mystic_boots_light_noted]
 id = 4118

--- a/data/skill/magic/robe.items.toml
+++ b/data/skill/magic/robe.items.toml
@@ -83,6 +83,7 @@ limit = 100
 weight = 0.453
 slot = "Hat"
 type = "HairLow"
+aka = ["blue_wizard_hat"]
 examine = "A silly pointed hat."
 kept = "Wilderness"
 
@@ -369,6 +370,7 @@ limit = 100
 weight = 0.453
 slot = "Hat"
 type = "HairLow"
+aka = ["wizard_hat_black"]
 examine = "A silly pointed hat."
 
 [black_wizard_hat_noted]

--- a/data/skill/skill.ifaces.toml
+++ b/data/skill/skill.ifaces.toml
@@ -171,5 +171,5 @@ id = "10-24"
 
 [skill_level_details]
 id = 741
-type = "main_screen"
+type = "wide_screen"
 

--- a/data/social/trade/exchange/grand_exchange.items.toml
+++ b/data/social/trade/exchange/grand_exchange.items.toml
@@ -368,7 +368,7 @@ id = 11960
 price = 446500
 limit = 100
 weight = 2.267
-items = ["light_mystic_hat", "light_mystic_robe_top", "light_mystic_robe_bottom", "light_mystic_gloves", "light_mystic_boots"]
+items = ["mystic_hat_light", "mystic_robe_top_light", "mystic_robe_bottom_light", "mystic_gloves_light", "mystic_boots_light"]
 examine = "Grand Exchange set containing a hat, top, bottoms, gloves and boots."
 
 [light_mystic_robes_set_noted]
@@ -379,7 +379,7 @@ id = 11962
 price = 285600
 limit = 100
 weight = 2.267
-items = ["dark_mystic_hat", "dark_mystic_robe_top", "dark_mystic_robe_bottom", "dark_mystic_gloves", "dark_mystic_boots"]
+items = ["mystic_hat_dark", "mystic_robe_top_dark", "mystic_robe_bottom_dark", "mystic_gloves_dark", "mystic_boots_dark"]
 examine = "Grand Exchange set containing a hat, top, bottoms, gloves and boots."
 
 [dark_mystic_robes_set_noted]

--- a/data/social/trade/lend/lent.items.toml
+++ b/data/social/trade/lend/lent.items.toml
@@ -274,34 +274,34 @@ id = 13511
 [mystic_boots_blue_lent]
 id = 13512
 
-[dark_mystic_hat_lent]
+[mystic_hat_dark_lent]
 id = 13513
 
-[dark_mystic_robe_top_lent]
+[mystic_robe_top_dark_lent]
 id = 13514
 
-[dark_mystic_robe_bottom_lent]
+[mystic_robe_bottom_dark_lent]
 id = 13515
 
-[dark_mystic_gloves_lent]
+[mystic_gloves_dark_lent]
 id = 13516
 
-[dark_mystic_boots_lent]
+[mystic_boots_dark_lent]
 id = 13517
 
-[light_mystic_hat_lent]
+[mystic_hat_light_lent]
 id = 13518
 
-[light_mystic_robe_top_lent]
+[mystic_robe_top_light_lent]
 id = 13519
 
-[light_mystic_robe_bottom_lent]
+[mystic_robe_bottom_light_lent]
 id = 13520
 
-[light_mystic_gloves_lent]
+[mystic_gloves_light_lent]
 id = 13521
 
-[light_mystic_boots_lent]
+[mystic_boots_light_lent]
 id = 13522
 
 [maple_longbow_lent]

--- a/game/src/main/kotlin/content/entity/Examines.kt
+++ b/game/src/main/kotlin/content/entity/Examines.kt
@@ -19,6 +19,7 @@ class Examines : Script {
         interfaceOption("Examine", "inventory:inventory", ::examineItem)
         interfaceOption("Examine", "worn_equipment:item", ::examineItem)
         interfaceOption("Examine", "bank:inventory", ::examineItem)
+        interfaceOption("Examine", "bank_side:inventory", ::examineItem)
         interfaceOption("Examine", "price_checker:items", ::examineItem)
         interfaceOption("Examine", "equipment_bonuses:inventory", ::examineItem)
         interfaceOption("Examine", "trade_main:offer_options", ::examineItem)

--- a/game/src/main/kotlin/content/entity/player/dialogue/type/NPCDialogue.kt
+++ b/game/src/main/kotlin/content/entity/player/dialogue/type/NPCDialogue.kt
@@ -31,6 +31,9 @@ suspend fun Player.npc(expression: String, text: String, largeHead: Boolean? = n
     val id = target["transform_id", get("dialogue_def") ?: target.id]
     if (target.def["interacts", true]) {
         target.mode = Face(target, this, target.def["interact_range", 1])
+        if (target.tile.within(tile, 10)) {
+            face(target)
+        }
     }
     npc(id, expression, text, largeHead, clickToContinue, title)
 }

--- a/game/src/main/kotlin/content/skill/dungeoneering/DungeonWorldMap.kt
+++ b/game/src/main/kotlin/content/skill/dungeoneering/DungeonWorldMap.kt
@@ -46,7 +46,8 @@ class DungeonWorldMap : Script {
                 SOUTH or EAST or NORTH -> 2801
                 SOUTH or EAST or WEST -> 2802
                 SOUTH or EAST or WEST or NORTH -> 2803
-                WEST or EAST -> 2804
+                NORTH or SOUTH -> 2804
+                WEST or EAST -> 2805
                 else -> return
             }
         } else {

--- a/game/src/main/kotlin/content/skill/melee/Block.kt
+++ b/game/src/main/kotlin/content/skill/melee/Block.kt
@@ -10,6 +10,7 @@ import world.gregs.voidps.engine.data.definition.WeaponAnimationDefinitions
 import world.gregs.voidps.engine.data.definition.WeaponStyleDefinitions
 import world.gregs.voidps.engine.entity.character.Character
 import world.gregs.voidps.engine.entity.character.mode.combat.CombatAttack
+import world.gregs.voidps.engine.entity.character.mode.combat.CombatDamage
 import world.gregs.voidps.engine.entity.character.npc.NPC
 import world.gregs.voidps.engine.entity.character.player.Player
 import world.gregs.voidps.engine.entity.character.player.equip.equipped
@@ -25,16 +26,17 @@ class Block(
 ) : Script {
 
     init {
-        combatAttack(handler = ::attack)
-        npcCombatAttack(handler = ::attack)
+        combatAttack(handler = ::anims)
+        npcCombatAttack(handler = ::anims)
+
+        combatDamage(handler = ::sounds)
+        npcCombatDamage(handler = ::sounds)
     }
 
-    fun attack(source: Character, attack: CombatAttack) {
+    fun anims(source: Character, attack: CombatAttack) {
         val target = attack.target
         val delay = attack.delay
         if (target is Player) {
-            source.sound(calculateHitSound(target), delay)
-            target.sound(calculateHitSound(target), delay)
             val shield = target.equipped(EquipSlot.Shield).id
             if (shield.endsWith("shield")) {
                 target.anim("shield_block", delay)
@@ -58,7 +60,19 @@ class Block(
             val def = NPCDefinitions.get(id)
             val combat = combatDefinitions.get(def["combat_def", id])
             target.anim(combat.defendAnim, delay)
-            source.sound(combat.defendSound?.id ?: return, delay)
+        }
+    }
+
+    fun sounds(target: Character, damage: CombatDamage) {
+        val source = damage.source
+        if (target is Player) {
+            source.sound(calculateHitSound(target))
+            target.sound(calculateHitSound(target))
+        } else if (target is NPC) {
+            val id = if (source is Player) target.def(source).stringId else target.id
+            val def = NPCDefinitions.get(id)
+            val combat = combatDefinitions.get(def["combat_def", id])
+            source.sound(combat.defendSound?.id ?: return)
         }
     }
 

--- a/game/src/main/kotlin/content/skill/melee/CombatStyles.kt
+++ b/game/src/main/kotlin/content/skill/melee/CombatStyles.kt
@@ -15,6 +15,9 @@ class CombatStyles(val styles: WeaponStyleDefinitions) : Script {
         }
 
         interfaceOpened("combat_styles") {
+            sendVariable("attack_style_index")
+            sendVariable("special_attack_energy")
+            sendVariable("auto_retaliate")
             refreshStyle(this)
         }
 

--- a/game/src/test/kotlin/content/quest/free/cooks_assistant/CooksAssistantTest.kt
+++ b/game/src/test/kotlin/content/quest/free/cooks_assistant/CooksAssistantTest.kt
@@ -2,28 +2,25 @@ package content.quest.free.cooks_assistant
 
 import WorldTest
 import content.quest.quest
-import dialogueContinue
 import dialogueOption
 import itemOnObject
 import npcOption
 import objectOption
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertNotNull
+import skipDialogues
 import world.gregs.voidps.engine.client.instruction.handle.interactFloorItem
 import world.gregs.voidps.engine.client.instruction.handle.interactObject
 import world.gregs.voidps.engine.client.ui.dialogue
 import world.gregs.voidps.engine.data.Settings
 import world.gregs.voidps.engine.entity.character.move.tele
 import world.gregs.voidps.engine.entity.character.npc.NPCs
-import world.gregs.voidps.engine.entity.character.player.Player
 import world.gregs.voidps.engine.entity.item.floor.FloorItems
 import world.gregs.voidps.engine.entity.item.floor.loadItemSpawns
 import world.gregs.voidps.engine.entity.obj.GameObjects
 import world.gregs.voidps.engine.get
 import world.gregs.voidps.engine.inv.add
 import world.gregs.voidps.engine.inv.inventory
-import world.gregs.voidps.engine.suspend.Suspension
 import world.gregs.voidps.type.Tile
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
@@ -46,11 +43,11 @@ class CooksAssistantTest : WorldTest() {
         player.tele(3208, 3215, 0)
         player.npcOption(cook, "Talk-to")
         tick()
-        player.fastForwardDialogue()
-        player.selectDialogueOption(1) // What's wrong?
-        player.fastForwardDialogue()
-        player.selectDialogueOption(1) // Yes, I'll help
-        player.fastForwardDialogue()
+        player.skipDialogues()
+        player.dialogueOption(1) // What's wrong?
+        player.skipDialogues()
+        player.dialogueOption(1) // Yes, I'll help
+        player.skipDialogues()
         assertNull(player.dialogue)
         assertEquals("started", player.quest("cooks_assistant"))
 
@@ -87,10 +84,10 @@ class CooksAssistantTest : WorldTest() {
         val millie = NPCs.find(Tile(3169, 3306), "millie_miller")
         player.npcOption(millie, "Talk-to")
         tick()
-        player.fastForwardDialogue()
-        player.selectDialogueOption(1) // Extra fine flour
-        player.fastForwardDialogue()
-        player.selectDialogueOption(2) // I'm fine, thanks
+        player.skipDialogues()
+        player.dialogueOption(1) // Extra fine flour
+        player.skipDialogues()
+        player.dialogueOption(2) // I'm fine, thanks
 
         player.tele(3165, 3307, 2)
         val hopper = GameObjects.find(Tile(3166, 3307, 2), "hopper")
@@ -115,25 +112,11 @@ class CooksAssistantTest : WorldTest() {
         player.tele(3208, 3215, 0)
         player.npcOption(cook, "Talk-to")
         tick()
-        player.fastForwardDialogue()
+        player.skipDialogues()
 
         assertNull(player.dialogue)
         assertEquals("completed", player.quest("cooks_assistant"))
         assertTrue(player.inventory.contains("sardine_noted", 20))
         assertTrue(player.inventory.contains("coins", 500))
-    }
-
-    private fun Player.fastForwardDialogue() {
-        assertNotNull(dialogue)
-        require(suspension is Suspension.Continue)
-        while (suspension is Suspension.Continue) {
-            dialogueContinue()
-        }
-    }
-
-    private fun Player.selectDialogueOption(option: Int) {
-        assertNotNull(dialogue)
-        require(suspension is Suspension.IntEntry)
-        dialogueOption("line$option")
     }
 }

--- a/game/src/test/kotlin/content/quest/free/dorics_quest/DoricsQuestTest.kt
+++ b/game/src/test/kotlin/content/quest/free/dorics_quest/DoricsQuestTest.kt
@@ -2,19 +2,16 @@ package content.quest.free.dorics_quest
 
 import WorldTest
 import content.quest.quest
-import dialogueContinue
 import dialogueOption
 import npcOption
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertNotNull
+import skipDialogues
 import world.gregs.voidps.engine.client.ui.dialogue
 import world.gregs.voidps.engine.entity.character.move.tele
 import world.gregs.voidps.engine.entity.character.npc.NPCs
-import world.gregs.voidps.engine.entity.character.player.Player
 import world.gregs.voidps.engine.entity.character.player.skill.Skill
 import world.gregs.voidps.engine.inv.add
 import world.gregs.voidps.engine.inv.inventory
-import world.gregs.voidps.engine.suspend.Suspension
 import world.gregs.voidps.type.Tile
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
@@ -33,13 +30,13 @@ class DoricsQuestTest : WorldTest() {
         val doric = NPCs.find(player.tile.regionLevel, "doric")
         player.npcOption(doric, "Talk-to")
         tick()
-        player.fastForwardDialogue()
+        player.skipDialogues()
         // start quest with option 2
-        player.selectDialogueOption(2)
-        player.fastForwardDialogue()
+        player.dialogueOption(2)
+        player.skipDialogues()
         // accept quest
-        player.selectDialogueOption(1)
-        player.fastForwardDialogue()
+        player.dialogueOption(1)
+        player.skipDialogues()
 
         assertNull(player.dialogue)
         assertEquals("started", player.quest("dorics_quest"))
@@ -56,13 +53,13 @@ class DoricsQuestTest : WorldTest() {
         val doric = NPCs.find(player.tile.regionLevel, "doric")
         player.npcOption(doric, "Talk-to")
         tick()
-        player.fastForwardDialogue()
+        player.skipDialogues()
         // start quest with option 1
-        player.selectDialogueOption(1)
-        player.fastForwardDialogue()
+        player.dialogueOption(1)
+        player.skipDialogues()
         // accept quest
-        player.selectDialogueOption(1)
-        player.fastForwardDialogue()
+        player.dialogueOption(1)
+        player.skipDialogues()
 
         assertNull(player.dialogue)
         assertEquals("started", player.quest("dorics_quest"))
@@ -75,23 +72,9 @@ class DoricsQuestTest : WorldTest() {
         // give items to doric and complete quest
         player.npcOption(doric, "Talk-to")
         tick()
-        player.fastForwardDialogue()
+        player.skipDialogues()
 
         tick(1)
         assertEquals("completed", player.quest("dorics_quest"))
-    }
-
-    private fun Player.fastForwardDialogue() {
-        assertNotNull(dialogue)
-        require(suspension is Suspension.Continue)
-        while (suspension is Suspension.Continue) {
-            dialogueContinue()
-        }
-    }
-
-    private fun Player.selectDialogueOption(option: Int) {
-        assertNotNull(dialogue)
-        require(suspension is Suspension.IntEntry)
-        dialogueOption("line$option")
     }
 }

--- a/game/src/test/kotlin/content/quest/free/gunnars_ground/GunnarsGroundTest.kt
+++ b/game/src/test/kotlin/content/quest/free/gunnars_ground/GunnarsGroundTest.kt
@@ -2,21 +2,19 @@ package content.quest.free.gunnars_ground
 
 import WorldTest
 import content.quest.quest
-import dialogueContinue
 import dialogueOption
 import itemOnItem
 import npcOption
-import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
+import skipDialogues
 import world.gregs.voidps.engine.client.ui.dialogue
 import world.gregs.voidps.engine.entity.character.move.tele
 import world.gregs.voidps.engine.entity.character.npc.NPCs
-import world.gregs.voidps.engine.entity.character.player.Player
 import world.gregs.voidps.engine.entity.character.player.skill.Skill
 import world.gregs.voidps.engine.entity.character.player.skill.level.Level
 import world.gregs.voidps.engine.inv.clear
 import world.gregs.voidps.engine.inv.inventory
-import world.gregs.voidps.engine.suspend.Suspension
 import world.gregs.voidps.type.Tile
 import kotlin.test.assertNull
 
@@ -31,22 +29,22 @@ class GunnarsGroundTest : WorldTest() {
 
         player.npcOption(dororan, "Talk-to")
         tick()
-        player.fastForwardDialogue()
-        player.selectDialogueOption(1)
+        player.skipDialogues()
+        player.dialogueOption(1)
 
-        player.fastForwardDialogue()
-        player.selectDialogueOption(2)
+        player.skipDialogues()
+        player.dialogueOption(2)
 
-        player.fastForwardDialogue()
-        player.selectDialogueOption(1)
+        player.skipDialogues()
+        player.dialogueOption(1)
 
-        player.fastForwardDialogue()
-        player.selectDialogueOption(2)
+        player.skipDialogues()
+        player.dialogueOption(2)
 
-        player.fastForwardDialogue()
-        player.selectDialogueOption(1)
+        player.skipDialogues()
+        player.dialogueOption(1)
 
-        player.fastForwardDialogue()
+        player.skipDialogues()
 
         assertNull(player.dialogue)
         assertEquals("unstarted", player.quest("gunnars_ground"))
@@ -68,24 +66,24 @@ class GunnarsGroundTest : WorldTest() {
         // start quest
         player.npcOption(dororan, "Talk-to")
         tick()
-        player.fastForwardDialogue()
-        player.selectDialogueOption(1)
-        player.fastForwardDialogue()
-        player.selectDialogueOption(2)
-        player.fastForwardDialogue()
-        player.selectDialogueOption(1)
-        player.fastForwardDialogue()
-        player.selectDialogueOption(2)
-        player.fastForwardDialogue()
-        player.selectDialogueOption(1)
-        player.fastForwardDialogue()
-        player.selectDialogueOption(1)
+        player.skipDialogues()
+        player.dialogueOption(1)
+        player.skipDialogues()
+        player.dialogueOption(2)
+        player.skipDialogues()
+        player.dialogueOption(1)
+        player.skipDialogues()
+        player.dialogueOption(2)
+        player.skipDialogues()
+        player.dialogueOption(1)
+        player.skipDialogues()
+        player.dialogueOption(1)
 
         assertEquals("started", player.quest("gunnars_ground"))
 
-        player.fastForwardDialogue()
-        player.selectDialogueOption(2)
-        player.fastForwardDialogue()
+        player.skipDialogues()
+        player.dialogueOption(2)
+        player.skipDialogues()
 
         assertNull(player.dialogue)
         assertEquals(1, player.inventory.count("love_poem"))
@@ -96,17 +94,17 @@ class GunnarsGroundTest : WorldTest() {
         val jeffery = NPCs.find(player.tile.regionLevel, "jeffery")
         player.npcOption(jeffery, "Talk-to")
         tick(2)
-        player.fastForwardDialogue()
-        player.selectDialogueOption(1)
-        player.fastForwardDialogue()
-        player.selectDialogueOption(1)
-        player.fastForwardDialogue()
-        player.selectDialogueOption(1)
-        player.fastForwardDialogue()
-        player.selectDialogueOption(1)
-        player.fastForwardDialogue()
-        player.selectDialogueOption(1)
-        player.fastForwardDialogue()
+        player.skipDialogues()
+        player.dialogueOption(1)
+        player.skipDialogues()
+        player.dialogueOption(1)
+        player.skipDialogues()
+        player.dialogueOption(1)
+        player.skipDialogues()
+        player.dialogueOption(1)
+        player.skipDialogues()
+        player.dialogueOption(1)
+        player.skipDialogues()
 
         // check if jeffery_ring / love_poem
         assertNull(player.dialogue)
@@ -117,15 +115,15 @@ class GunnarsGroundTest : WorldTest() {
         player.tele(3099, 3422)
         player.npcOption(dororan, "Talk-to")
         tick()
-        player.fastForwardDialogue()
-        player.selectDialogueOption(1)
-        player.fastForwardDialogue()
-        player.selectDialogueOption(2)
-        player.fastForwardDialogue()
-        player.selectDialogueOption(1)
-        player.fastForwardDialogue()
-        player.selectDialogueOption(2)
-        player.fastForwardDialogue()
+        player.skipDialogues()
+        player.dialogueOption(1)
+        player.skipDialogues()
+        player.dialogueOption(2)
+        player.skipDialogues()
+        player.dialogueOption(1)
+        player.skipDialogues()
+        player.dialogueOption(2)
+        player.skipDialogues()
 
         assertNull(player.dialogue)
         assertEquals(1, player.inventory.count("chisel"))
@@ -133,7 +131,7 @@ class GunnarsGroundTest : WorldTest() {
 
         player.itemOnItem(1, 0)
         tick()
-        player.fastForwardDialogue()
+        player.skipDialogues()
 
         // player should get 125 exp for engraving
         assertEquals(playerCraftingExp + 125, player.experience.get(Skill.Crafting))
@@ -147,15 +145,15 @@ class GunnarsGroundTest : WorldTest() {
         player.npcOption(dororan, "Talk-to")
         tick()
 
-        player.fastForwardDialogue()
-        player.selectDialogueOption(1)
-        player.fastForwardDialogue()
-        player.selectDialogueOption(1)
-        player.fastForwardDialogue()
-        player.selectDialogueOption(1)
-        player.fastForwardDialogue()
-        player.selectDialogueOption(2)
-        player.fastForwardDialogue()
+        player.skipDialogues()
+        player.dialogueOption(1)
+        player.skipDialogues()
+        player.dialogueOption(1)
+        player.skipDialogues()
+        player.dialogueOption(1)
+        player.skipDialogues()
+        player.dialogueOption(2)
+        player.skipDialogues()
 
         assertNull(player.dialogue)
         assertEquals("show_gudrun", player.quest("gunnars_ground"))
@@ -166,17 +164,17 @@ class GunnarsGroundTest : WorldTest() {
         player.npcOption(gudrun, "Talk-to")
         tick(4)
 
-        player.fastForwardDialogue()
-        player.selectDialogueOption(1)
-        player.fastForwardDialogue()
-        player.selectDialogueOption(1)
-        player.fastForwardDialogue()
-        player.selectDialogueOption(1)
-        player.fastForwardDialogue()
-        player.selectDialogueOption(1)
-        player.fastForwardDialogue()
-        player.selectDialogueOption(2)
-        player.fastForwardDialogue()
+        player.skipDialogues()
+        player.dialogueOption(1)
+        player.skipDialogues()
+        player.dialogueOption(1)
+        player.skipDialogues()
+        player.dialogueOption(1)
+        player.skipDialogues()
+        player.dialogueOption(1)
+        player.skipDialogues()
+        player.dialogueOption(2)
+        player.skipDialogues()
 
         assertNull(player.dialogue)
         assertEquals("meet_chieftain", player.quest("gunnars_ground"))
@@ -187,17 +185,17 @@ class GunnarsGroundTest : WorldTest() {
         player.npcOption(chieftain, "Talk-to")
         tick()
 
-        player.fastForwardDialogue()
-        player.selectDialogueOption(1)
-        player.fastForwardDialogue()
-        player.selectDialogueOption(1)
-        player.fastForwardDialogue()
-        player.selectDialogueOption(1)
-        player.fastForwardDialogue()
-        player.selectDialogueOption(1)
-        player.fastForwardDialogue()
-        player.selectDialogueOption(1)
-        player.fastForwardDialogue()
+        player.skipDialogues()
+        player.dialogueOption(1)
+        player.skipDialogues()
+        player.dialogueOption(1)
+        player.skipDialogues()
+        player.dialogueOption(1)
+        player.skipDialogues()
+        player.dialogueOption(1)
+        player.skipDialogues()
+        player.dialogueOption(1)
+        player.skipDialogues()
 
         assertNull(player.dialogue)
         assertEquals("tell_gudrun", player.quest("gunnars_ground"))
@@ -207,9 +205,9 @@ class GunnarsGroundTest : WorldTest() {
         player.npcOption(gudrun, "Talk-to")
         tick()
 
-        player.fastForwardDialogue()
-        player.selectDialogueOption(2)
-        player.fastForwardDialogue()
+        player.skipDialogues()
+        player.dialogueOption(2)
+        player.skipDialogues()
 
         assertNull(player.dialogue)
         assertEquals("tell_dororan", player.quest("gunnars_ground"))
@@ -219,32 +217,32 @@ class GunnarsGroundTest : WorldTest() {
         player.npcOption(dororan, "Talk-to")
         tick()
 
-        player.fastForwardDialogue()
-        player.selectDialogueOption(1)
-        player.fastForwardDialogue()
-        player.selectDialogueOption(2)
-        player.fastForwardDialogue()
+        player.skipDialogues()
+        player.dialogueOption(1)
+        player.skipDialogues()
+        player.dialogueOption(2)
+        player.skipDialogues()
         tick(6)
-        player.fastForwardDialogue()
-        player.selectDialogueOption(1)
-        player.fastForwardDialogue()
-        player.selectDialogueOption(1)
-        player.fastForwardDialogue()
-        player.selectDialogueOption(5)
-        player.selectDialogueOption(3)
-        player.fastForwardDialogue()
-        player.selectDialogueOption(1)
-        player.fastForwardDialogue()
-        player.selectDialogueOption(5)
-        player.selectDialogueOption(2)
-        player.fastForwardDialogue()
-        player.selectDialogueOption(1)
-        player.fastForwardDialogue()
-        player.selectDialogueOption(5)
-        player.selectDialogueOption(3)
-        player.fastForwardDialogue()
-        player.selectDialogueOption(1)
-        player.fastForwardDialogue()
+        player.skipDialogues()
+        player.dialogueOption(1)
+        player.skipDialogues()
+        player.dialogueOption(1)
+        player.skipDialogues()
+        player.dialogueOption(5)
+        player.dialogueOption(3)
+        player.skipDialogues()
+        player.dialogueOption(1)
+        player.skipDialogues()
+        player.dialogueOption(5)
+        player.dialogueOption(2)
+        player.skipDialogues()
+        player.dialogueOption(1)
+        player.skipDialogues()
+        player.dialogueOption(5)
+        player.dialogueOption(3)
+        player.skipDialogues()
+        player.dialogueOption(1)
+        player.skipDialogues()
 
         assertNull(player.dialogue)
         assertEquals("poem", player.quest("gunnars_ground"))
@@ -253,35 +251,35 @@ class GunnarsGroundTest : WorldTest() {
         player.npcOption(gudrun, "Talk-to")
         tick(4)
 
-        player.fastForwardDialogue()
+        player.skipDialogues()
 
         tick(6)
 
-        player.fastForwardDialogue()
-        player.selectDialogueOption(1)
-        player.fastForwardDialogue()
-        player.selectDialogueOption(2)
-        player.fastForwardDialogue()
-        player.selectDialogueOption(2)
-        player.fastForwardDialogue()
-        player.selectDialogueOption(2)
-        player.fastForwardDialogue()
-        player.selectDialogueOption(1)
-        player.fastForwardDialogue()
+        player.skipDialogues()
+        player.dialogueOption(1)
+        player.skipDialogues()
+        player.dialogueOption(2)
+        player.skipDialogues()
+        player.dialogueOption(2)
+        player.skipDialogues()
+        player.dialogueOption(2)
+        player.skipDialogues()
+        player.dialogueOption(1)
+        player.skipDialogues()
 
         tick(6)
 
-        player.fastForwardDialogue()
+        player.skipDialogues()
 
         tick(4)
 
-        player.fastForwardDialogue()
+        player.skipDialogues()
 
         tick(9)
 
-        player.fastForwardDialogue()
-        player.selectDialogueOption(1)
-        player.fastForwardDialogue()
+        player.skipDialogues()
+        player.dialogueOption(1)
+        player.skipDialogues()
 
         tick(4)
 
@@ -290,19 +288,5 @@ class GunnarsGroundTest : WorldTest() {
         assertEquals(1, player.inventory.count("swanky_boots"))
         assertEquals(1, player.inventory.count("antique_lamp_gunnars_ground"))
         assertEquals(playerCraftingExp + 300, player.experience.get(Skill.Crafting))
-    }
-
-    private fun Player.fastForwardDialogue() {
-        assertNotNull(dialogue)
-        require(suspension is Suspension.Continue)
-        while (suspension is Suspension.Continue) {
-            dialogueContinue()
-        }
-    }
-
-    private fun Player.selectDialogueOption(option: Int) {
-        assertNotNull(dialogue)
-        require(suspension is Suspension.IntEntry)
-        dialogueOption("line$option")
     }
 }

--- a/game/src/test/kotlin/content/quest/free/restless_ghost/RestlessGhostQuest.kt
+++ b/game/src/test/kotlin/content/quest/free/restless_ghost/RestlessGhostQuest.kt
@@ -3,22 +3,19 @@ package content.quest.free.restless_ghost
 import WorldTest
 import content.entity.player.dialogue.continueDialogue
 import content.quest.quest
-import dialogueContinue
 import dialogueOption
 import equipItem
 import interfaceOption
 import npcOption
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertNotNull
+import skipDialogues
 import world.gregs.voidps.engine.client.instruction.handle.interactObject
 import world.gregs.voidps.engine.client.ui.dialogue
 import world.gregs.voidps.engine.entity.character.move.tele
 import world.gregs.voidps.engine.entity.character.npc.NPCs
-import world.gregs.voidps.engine.entity.character.player.Player
 import world.gregs.voidps.engine.entity.character.player.skill.Skill
 import world.gregs.voidps.engine.entity.obj.GameObjects
 import world.gregs.voidps.engine.inv.inventory
-import world.gregs.voidps.engine.suspend.Suspension
 import world.gregs.voidps.type.Tile
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
@@ -34,13 +31,13 @@ class RestlessGhostQuest : WorldTest() {
         val fatherAereck = NPCs.find(player.tile.regionLevel, "father_aereck")
         player.npcOption(fatherAereck, "Talk-to")
         tick()
-        player.fastForwardDialogue()
-        player.selectDialogueOption(3) // I'm looking for a quest!
-        player.fastForwardDialogue()
+        player.skipDialogues()
+        player.dialogueOption(3) // I'm looking for a quest!
+        player.skipDialogues()
         tick(2)
         // quest overview interface
         player.interfaceOption("quest_intro", "startyes_layer", "Yes")
-        player.fastForwardDialogue()
+        player.skipDialogues()
 
         assertNull(player.dialogue)
         assertEquals("started", player.quest("the_restless_ghost"))
@@ -50,11 +47,11 @@ class RestlessGhostQuest : WorldTest() {
         val fatherUrhney = NPCs.find(player.tile.regionLevel, "father_urhney")
         player.npcOption(fatherUrhney, "Talk-to")
         tick()
-        player.fastForwardDialogue()
-        player.selectDialogueOption(2) // Father Aereck sent me to talk to you.
-        player.fastForwardDialogue()
-        player.selectDialogueOption(1) // A ghost is haunting his graveyard.
-        player.fastForwardDialogue()
+        player.skipDialogues()
+        player.dialogueOption(2) // Father Aereck sent me to talk to you.
+        player.skipDialogues()
+        player.dialogueOption(1) // A ghost is haunting his graveyard.
+        player.skipDialogues()
 
         assertNull(player.dialogue)
         assertEquals("ghost", player.quest("the_restless_ghost"))
@@ -72,9 +69,9 @@ class RestlessGhostQuest : WorldTest() {
         val restlessGhost = NPCs.find(Tile(3250, 3195), "restless_ghost")
         player.npcOption(restlessGhost, "Talk-to")
         tick(2)
-        player.fastForwardDialogue()
-        player.selectDialogueOption(1) // Yep. Now, tell me what the problem is.
-        player.fastForwardDialogue()
+        player.skipDialogues()
+        player.dialogueOption(1) // Yep. Now, tell me what the problem is.
+        player.skipDialogues()
 
         assertNull(player.dialogue)
         assertEquals("mining_spot", player.quest("the_restless_ghost"))
@@ -99,19 +96,5 @@ class RestlessGhostQuest : WorldTest() {
 
         assertEquals("completed", player.quest("the_restless_ghost"))
         assertEquals(1125.0, player.experience.get(Skill.Prayer))
-    }
-
-    private fun Player.fastForwardDialogue() {
-        assertNotNull(dialogue)
-        require(suspension is Suspension.Continue)
-        while (suspension is Suspension.Continue) {
-            dialogueContinue()
-        }
-    }
-
-    private fun Player.selectDialogueOption(option: Int) {
-        assertNotNull(dialogue)
-        require(suspension is Suspension.IntEntry)
-        dialogueOption("line$option")
     }
 }

--- a/game/src/test/kotlin/content/quest/free/the_knights_sword/TheKnightsSwordTest.kt
+++ b/game/src/test/kotlin/content/quest/free/the_knights_sword/TheKnightsSwordTest.kt
@@ -3,23 +3,22 @@ package content.quest.free.the_knights_sword
 import FakeRandom
 import WorldTest
 import content.quest.quest
-import dialogueContinue
 import dialogueOption
 import npcOption
-import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Test
+import skipDialogues
 import world.gregs.voidps.engine.client.instruction.handle.interactObject
 import world.gregs.voidps.engine.client.ui.dialogue
 import world.gregs.voidps.engine.entity.character.move.tele
 import world.gregs.voidps.engine.entity.character.npc.NPCs
-import world.gregs.voidps.engine.entity.character.player.Player
 import world.gregs.voidps.engine.entity.character.player.skill.Skill
 import world.gregs.voidps.engine.entity.character.player.skill.level.Level
 import world.gregs.voidps.engine.entity.obj.GameObjects
 import world.gregs.voidps.engine.inv.add
 import world.gregs.voidps.engine.inv.clear
 import world.gregs.voidps.engine.inv.inventory
-import world.gregs.voidps.engine.suspend.Suspension
 import world.gregs.voidps.type.Tile
 import world.gregs.voidps.type.setRandom
 
@@ -44,15 +43,15 @@ class TheKnightsSwordTest : WorldTest() {
         val squireAsrol = NPCs.find(player.tile.regionLevel, "squire_asrol")
         player.npcOption(squireAsrol, "Talk-to")
         tick(2)
-        player.fastForwardDialogue()
-        player.selectDialogueOption(1)
-        player.fastForwardDialogue()
-        player.selectDialogueOption(2)
-        player.fastForwardDialogue()
-        player.selectDialogueOption(1)
-        player.fastForwardDialogue()
-        player.selectDialogueOption(1)
-        player.fastForwardDialogue()
+        player.skipDialogues()
+        player.dialogueOption(1)
+        player.skipDialogues()
+        player.dialogueOption(2)
+        player.skipDialogues()
+        player.dialogueOption(1)
+        player.skipDialogues()
+        player.dialogueOption(1)
+        player.skipDialogues()
 
         assertNull(player.dialogue)
         assertEquals("started", player.quest("the_knights_sword"))
@@ -62,9 +61,9 @@ class TheKnightsSwordTest : WorldTest() {
         val reldo = NPCs.find(player.tile.regionLevel, "reldo")
         player.npcOption(reldo, "Talk-to")
         tick(4)
-        player.fastForwardDialogue()
-        player.selectDialogueOption(3)
-        player.fastForwardDialogue()
+        player.skipDialogues()
+        player.dialogueOption(3)
+        player.skipDialogues()
 
         assertNull(player.dialogue)
         assertEquals("find_thurgo", player.quest("the_knights_sword"))
@@ -74,8 +73,8 @@ class TheKnightsSwordTest : WorldTest() {
         val thurgo = NPCs.find(player.tile.regionLevel, "thurgo")
         player.npcOption(thurgo, "Talk-to")
         tick(5)
-        player.selectDialogueOption(2)
-        player.fastForwardDialogue()
+        player.dialogueOption(2)
+        player.skipDialogues()
 
         assertNull(player.dialogue)
         assertEquals(0, player.inventory.count("redberry_pie"))
@@ -84,8 +83,8 @@ class TheKnightsSwordTest : WorldTest() {
         // talk to thurgo again after pie
         player.npcOption(thurgo, "Talk-to")
         tick(5)
-        player.selectDialogueOption(1)
-        player.fastForwardDialogue()
+        player.dialogueOption(1)
+        player.skipDialogues()
 
         assertNull(player.dialogue)
         assertEquals("picture", player.quest("the_knights_sword"))
@@ -94,7 +93,7 @@ class TheKnightsSwordTest : WorldTest() {
         player.tele(2973, 3344, 0)
         player.npcOption(squireAsrol, "Talk-to")
         tick(2)
-        player.fastForwardDialogue()
+        player.skipDialogues()
 
         assertNull(player.dialogue)
         assertEquals("cupboard", player.quest("the_knights_sword"))
@@ -113,7 +112,7 @@ class TheKnightsSwordTest : WorldTest() {
         val cupboardOpen = GameObjects.find(Tile(2984, 3336, 2), "cupboard_the_knights_sword_opened")
         player.interactObject(cupboardOpen, "Search")
         tick()
-        player.fastForwardDialogue()
+        player.skipDialogues()
 
         assertNull(player.dialogue)
         assertEquals(1, player.inventory.count("portrait"))
@@ -123,8 +122,8 @@ class TheKnightsSwordTest : WorldTest() {
         player.tele(3000, 3144, 0)
         player.npcOption(thurgo, "Talk-to")
         tick(5)
-        player.selectDialogueOption(1)
-        player.fastForwardDialogue()
+        player.dialogueOption(1)
+        player.skipDialogues()
 
         assertNull(player.dialogue)
         assertEquals(0, player.inventory.count("portrait"))
@@ -148,8 +147,8 @@ class TheKnightsSwordTest : WorldTest() {
         player.tele(3000, 3144, 0)
         player.npcOption(thurgo, "Talk-to")
         tick(5)
-        player.selectDialogueOption(1)
-        player.fastForwardDialogue()
+        player.dialogueOption(1)
+        player.skipDialogues()
 
         assertNull(player.dialogue)
         assertEquals(0, player.inventory.count("iron_bar"))
@@ -161,25 +160,11 @@ class TheKnightsSwordTest : WorldTest() {
         player.tele(2973, 3344, 0)
         player.npcOption(squireAsrol, "Talk-to")
         tick(2)
-        player.fastForwardDialogue()
+        player.skipDialogues()
 
         assertNull(player.dialogue)
         assertEquals(0, player.inventory.count("blurite_sword"))
         assertEquals("completed", player.quest("the_knights_sword"))
         assertEquals(12725.0, player.experience.get(Skill.Smithing))
-    }
-
-    private fun Player.fastForwardDialogue() {
-        assertNotNull(dialogue)
-        require(suspension is Suspension.Continue)
-        while (suspension is Suspension.Continue) {
-            dialogueContinue()
-        }
-    }
-
-    private fun Player.selectDialogueOption(option: Int) {
-        assertNotNull(dialogue)
-        require(suspension is Suspension.IntEntry)
-        dialogueOption("line$option")
     }
 }

--- a/game/src/test/kotlin/content/quest/member/rune_mysteries/RuneMysteriesTest.kt
+++ b/game/src/test/kotlin/content/quest/member/rune_mysteries/RuneMysteriesTest.kt
@@ -2,17 +2,14 @@ package content.quest.member.rune_mysteries
 
 import WorldTest
 import content.quest.quest
-import dialogueContinue
 import dialogueOption
 import npcOption
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertNotNull
+import skipDialogues
 import world.gregs.voidps.engine.client.ui.dialogue
 import world.gregs.voidps.engine.entity.character.move.tele
 import world.gregs.voidps.engine.entity.character.npc.NPCs
-import world.gregs.voidps.engine.entity.character.player.Player
 import world.gregs.voidps.engine.inv.inventory
-import world.gregs.voidps.engine.suspend.Suspension
 import world.gregs.voidps.type.Tile
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
@@ -28,11 +25,11 @@ class RuneMysteriesTest : WorldTest() {
         val dukeHoracio = NPCs.find(player.tile.regionLevel, "duke_horacio")
         player.npcOption(dukeHoracio, "Talk-to")
         tick(5)
-        player.fastForwardDialogue()
-        player.selectDialogueOption(1)
-        player.fastForwardDialogue()
-        player.selectDialogueOption(1)
-        player.fastForwardDialogue()
+        player.skipDialogues()
+        player.dialogueOption(1)
+        player.skipDialogues()
+        player.dialogueOption(1)
+        player.skipDialogues()
 
         assertNull(player.dialogue)
         assertEquals(1, player.inventory.count("talisman_rune_mysteries"))
@@ -43,13 +40,13 @@ class RuneMysteriesTest : WorldTest() {
         val sedridor = NPCs.find(player.tile.regionLevel, "sedridor")
         player.npcOption(sedridor, "Talk-to")
         tick()
-        player.fastForwardDialogue()
-        player.selectDialogueOption(1)
-        player.fastForwardDialogue()
-        player.selectDialogueOption(1)
-        player.fastForwardDialogue()
-        player.selectDialogueOption(1)
-        player.fastForwardDialogue()
+        player.skipDialogues()
+        player.dialogueOption(1)
+        player.skipDialogues()
+        player.dialogueOption(1)
+        player.skipDialogues()
+        player.dialogueOption(1)
+        player.skipDialogues()
 
         assertEquals(1, player.inventory.count("research_package_rune_mysteries"))
         assertNull(player.dialogue)
@@ -60,9 +57,9 @@ class RuneMysteriesTest : WorldTest() {
         val aubury = NPCs.find(player.tile.regionLevel, "aubury")
         player.npcOption(aubury, "Talk-to")
         tick()
-        player.fastForwardDialogue()
-        player.selectDialogueOption(3)
-        player.fastForwardDialogue()
+        player.skipDialogues()
+        player.dialogueOption(3)
+        player.skipDialogues()
 
         assertEquals(1, player.inventory.count("research_notes_rune_mysteries"))
         assertNull(player.dialogue)
@@ -72,24 +69,10 @@ class RuneMysteriesTest : WorldTest() {
         player.tele(3103, 9570, 0)
         player.npcOption(sedridor, "Talk-to")
         tick()
-        player.fastForwardDialogue()
+        player.skipDialogues()
 
         assertNull(player.dialogue)
         assertEquals("completed", player.quest("rune_mysteries"))
         assertEquals(1, player.inventory.count("air_talisman"))
-    }
-
-    private fun Player.fastForwardDialogue() {
-        assertNotNull(dialogue)
-        require(suspension is Suspension.Continue)
-        while (suspension is Suspension.Continue) {
-            dialogueContinue()
-        }
-    }
-
-    private fun Player.selectDialogueOption(option: Int) {
-        assertNotNull(dialogue)
-        require(suspension is Suspension.IntEntry)
-        dialogueOption("line$option")
     }
 }


### PR DESCRIPTION
- Fix bank item examines
- Fix special attack and auto retaliate appearing in wrong state on login
- Players face npcs on chat box dialogue
- Fix continue-less player dialogue head size
- Fix hit sounds not playing on damage
- Fix level up skill details interface not using full resizable screen
- Fix dungeoneering map room rotation
- Rename mystic items to be more consistent
- Replace fastForwardDialogue with skipDialogues in quest tests