### PR TITLE
Fix "I can't reach that." when closing doors from a distance

### DIFF
--- a/engine/src/main/kotlin/world/gregs/voidps/engine/entity/character/mode/interact/Interact.kt
+++ b/engine/src/main/kotlin/world/gregs/voidps/engine/entity/character/mode/interact/Interact.kt
@@ -93,7 +93,10 @@ open class Interact(
         calculate()
         character.walkTrigger()
         val interacted = processInteraction()
-        if (interacted && interactionFinished()) {
+        // A launched interaction that has finished is complete even if it couldn't re-interact
+        // this tick (e.g. the target object was replaced, changing collision so reached() now
+        // fails) - clear it instead of falling through to cantReach().
+        if ((interacted || launched) && interactionFinished()) {
             clear()
             return
         }


### PR DESCRIPTION
Fix for #989 

Summary

Closing an open door from a distance worked, but then incorrectly spammed "I can't reach that." Opening doors from a distance was unaffected.

Root cause

Door open/close uses an operate interaction through arriveDelay(). When the player has just taken the final step, the action resumes on the next tick inside checkDelay, before mode.tick() runs.

Closing swaps the open door for a closed one and updates Collisions.map with a blocking wall, but the Interact mode is not cleared. It then reaches mode.tick() in the same tick and re-checks reachability using the old open-door snapshot against the updated closed-door collision map. That makes reached() return false and falls through to cantReach().

Opening removes collision instead, so the stale interaction still resolves cleanly.

Fix

In Interact.tick(), clear an already-launched interaction once it has completed (suspension == null && !contains("delay")) instead of rechecking reachability against a mutated collision map.

This fixes doors and the broader case where completing an interaction mutates the target's collision.