### PR TITLE
feat: scheduled reload of account definitions from storage

### DIFF
--- a/engine/src/main/kotlin/world/gregs/voidps/engine/EngineModules.kt
+++ b/engine/src/main/kotlin/world/gregs/voidps/engine/EngineModules.kt
@@ -34,6 +34,7 @@ fun engineModule(files: ConfigFiles) = module {
         SaveQueue(get(), SafeStorage(File(Settings["storage.players.errors"])))
     }
     single { AccountManager(get(), get(), get(), AppearanceOverrides()) }
+    single { AccountDefinitionsReloader(get(), get(), get()) }
     // IO
     single { PlayerAccountLoader(get(), get(), get(), get(), get(), Contexts.Game) }
     // Map

--- a/engine/src/main/kotlin/world/gregs/voidps/engine/data/AccountDefinitionsReloader.kt
+++ b/engine/src/main/kotlin/world/gregs/voidps/engine/data/AccountDefinitionsReloader.kt
@@ -1,0 +1,61 @@
+package world.gregs.voidps.engine.data
+
+import com.github.michaelbull.logging.InlineLogger
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineExceptionHandler
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import world.gregs.voidps.engine.Contexts
+import world.gregs.voidps.engine.data.definition.AccountDefinitions
+import world.gregs.voidps.engine.entity.character.player.Players
+import java.util.concurrent.atomic.AtomicBoolean
+
+/**
+ * Reloads offline account definitions from [storage] so external changes
+ * (website password resets, imported accounts) apply without a server restart.
+ */
+class AccountDefinitionsReloader(
+    private val storage: Storage,
+    private val definitions: AccountDefinitions,
+    private val saveQueue: SaveQueue,
+    io: CoroutineDispatcher = Dispatchers.IO,
+    private val game: CoroutineDispatcher = Contexts.Game,
+) {
+    private val logger = InlineLogger()
+    private val reloading = AtomicBoolean(false)
+    // SupervisorJob so a failed reload doesn't cancel the scope and kill future reloads
+    private val scope = CoroutineScope(SupervisorJob() + io)
+    private val handler = CoroutineExceptionHandler { _, exception ->
+        logger.error(exception) { "Error reloading account definitions!" }
+        reloading.set(false)
+    }
+
+    /**
+     * Loads account data on the io dispatcher and merges it on the game thread.
+     * Online players and accounts with pending saves are skipped as their
+     * in-memory state may be newer than storage.
+     * @return false if a reload is already in progress
+     */
+    fun reload(onComplete: (Int) -> Unit = {}): Boolean {
+        if (!reloading.compareAndSet(false, true)) {
+            return false
+        }
+        val online = Players.mapTo(HashSet()) { it.accountName.lowercase() }
+        scope.launch(handler) {
+            val names = storage.names()
+            val clans = storage.clans()
+            withContext(game) {
+                val count = definitions.merge(names, clans) { account ->
+                    online.contains(account.lowercase()) || saveQueue.saving(account)
+                }
+                reloading.set(false)
+                logger.info { "Reloaded $count account definitions." }
+                onComplete(count)
+            }
+        }
+        return true
+    }
+}

--- a/engine/src/main/kotlin/world/gregs/voidps/engine/data/definition/AccountDefinitions.kt
+++ b/engine/src/main/kotlin/world/gregs/voidps/engine/data/definition/AccountDefinitions.kt
@@ -1,6 +1,5 @@
 package world.gregs.voidps.engine.data.definition
 
-import it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap
 import world.gregs.voidps.engine.data.Storage
 import world.gregs.voidps.engine.data.config.AccountDefinition
 import world.gregs.voidps.engine.entity.character.player.Player
@@ -10,14 +9,15 @@ import world.gregs.voidps.engine.entity.character.player.name
 import world.gregs.voidps.engine.entity.character.player.previousName
 import world.gregs.voidps.engine.get
 import world.gregs.voidps.engine.timedLoad
+import java.util.concurrent.ConcurrentHashMap
 
 /**
  * Stores data about player accounts whether they're online or offline
  */
 class AccountDefinitions(
-    private val definitions: MutableMap<String, AccountDefinition> = Object2ObjectOpenHashMap(),
-    val displayNames: MutableMap<String, String> = Object2ObjectOpenHashMap(),
-    val clans: MutableMap<String, Clan> = Object2ObjectOpenHashMap(),
+    private val definitions: MutableMap<String, AccountDefinition> = ConcurrentHashMap(),
+    val displayNames: MutableMap<String, String> = ConcurrentHashMap(),
+    val clans: MutableMap<String, Clan> = ConcurrentHashMap(),
 ) {
 
     fun add(player: Player) {
@@ -69,5 +69,58 @@ class AccountDefinitions(
             definitions.size
         }
         return this
+    }
+
+    /**
+     * Merges freshly loaded storage data into the in-memory cache so external
+     * changes (website password resets, imported accounts) apply without a restart.
+     * Entries whose account matches [skip] (online or mid-save) are left untouched
+     * as their in-memory state may be newer than storage.
+     * Add/update only; never removes entries. Must be called on the game thread.
+     * @return number of definitions added or updated
+     */
+    fun merge(
+        names: Map<String, AccountDefinition>,
+        clanUpdates: Map<String, Clan>,
+        skip: (accountName: String) -> Boolean,
+    ): Int {
+        var count = 0
+        for ((name, definition) in names) {
+            if (skip(definition.accountName)) {
+                continue
+            }
+            val existing = definitions[name.lowercase()]
+            if (existing == null) {
+                definitions[name.lowercase()] = definition
+            } else if (existing == definition) {
+                continue
+            } else {
+                existing.displayName = definition.displayName
+                existing.previousName = definition.previousName
+                existing.passwordHash = definition.passwordHash
+            }
+            displayNames[definition.accountName.lowercase()] = definition.displayName
+            count++
+        }
+        for ((name, clan) in clanUpdates) {
+            if (skip(clan.owner)) {
+                continue
+            }
+            val existing = clans[name.lowercase()]
+            if (existing == null) {
+                clans[name.lowercase()] = clan
+            } else {
+                existing.ownerDisplayName = clan.ownerDisplayName
+                existing.name = clan.name
+                existing.friends = clan.friends
+                existing.ignores = clan.ignores
+                existing.joinRank = clan.joinRank
+                existing.talkRank = clan.talkRank
+                existing.kickRank = clan.kickRank
+                existing.lootRank = clan.lootRank
+                existing.coinShare = clan.coinShare
+            }
+        }
+        return count
     }
 }

--- a/engine/src/main/kotlin/world/gregs/voidps/engine/data/file/FileStorage.kt
+++ b/engine/src/main/kotlin/world/gregs/voidps/engine/data/file/FileStorage.kt
@@ -1,5 +1,6 @@
 package world.gregs.voidps.engine.data.file
 
+import com.github.michaelbull.logging.InlineLogger
 import it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap
 import world.gregs.config.*
 import world.gregs.voidps.engine.data.PlayerSave
@@ -17,20 +18,26 @@ class FileStorage(
     private val directory: File,
 ) : Storage {
 
+    private val logger = InlineLogger()
+
     override fun names(): Map<String, AccountDefinition> {
         val files = directory.listFiles { _, b -> b.endsWith(".toml") } ?: return emptyMap()
         val definitions: MutableMap<String, AccountDefinition> = Object2ObjectOpenHashMap()
         for (save in files) {
-            val data = PlayerSave.load(save)
-            val variables = data.variables
-            val accountName = data.name
-            val displayName = variables.getOrDefault("display_name", accountName) as String
-            definitions[accountName.lowercase()] = AccountDefinition(
-                accountName = accountName,
-                displayName = displayName,
-                previousName = (variables.getOrDefault("name_history", emptyList<String>()) as List<String>).lastOrNull() ?: "",
-                passwordHash = data.password,
-            )
+            try {
+                val data = PlayerSave.load(save)
+                val variables = data.variables
+                val accountName = data.name
+                val displayName = variables.getOrDefault("display_name", accountName) as String
+                definitions[accountName.lowercase()] = AccountDefinition(
+                    accountName = accountName,
+                    displayName = displayName,
+                    previousName = (variables.getOrDefault("name_history", emptyList<String>()) as List<String>).lastOrNull() ?: "",
+                    passwordHash = data.password,
+                )
+            } catch (e: Exception) {
+                logger.warn(e) { "Failed to load account file ${save.name}, skipping." }
+            }
         }
         return definitions
     }
@@ -39,22 +46,26 @@ class FileStorage(
         val files = directory.listFiles { _, b -> b.endsWith(".toml") } ?: return emptyMap()
         val clans: MutableMap<String, Clan> = Object2ObjectOpenHashMap()
         for (save in files) {
-            val data = PlayerSave.load(save)
-            val variables = data.variables
-            val accountName = data.name
-            val displayName = variables.getOrDefault("display_name", accountName) as String
-            clans[accountName.lowercase()] = Clan(
-                owner = accountName,
-                ownerDisplayName = displayName,
-                name = variables.getOrDefault("clan_name", "") as String,
-                friends = data.friends,
-                ignores = data.ignores,
-                joinRank = ClanRank.valueOf(variables.getOrDefault("clan_join_rank", "Anyone") as String),
-                talkRank = ClanRank.valueOf(variables.getOrDefault("clan_talk_rank", "Anyone") as String),
-                kickRank = ClanRank.valueOf(variables.getOrDefault("clan_kick_rank", "Corporeal") as String),
-                lootRank = ClanRank.valueOf(variables.getOrDefault("clan_loot_rank", "None") as String),
-                coinShare = variables.getOrDefault("coin_share_setting", false) as Boolean,
-            )
+            try {
+                val data = PlayerSave.load(save)
+                val variables = data.variables
+                val accountName = data.name
+                val displayName = variables.getOrDefault("display_name", accountName) as String
+                clans[accountName.lowercase()] = Clan(
+                    owner = accountName,
+                    ownerDisplayName = displayName,
+                    name = variables.getOrDefault("clan_name", "") as String,
+                    friends = data.friends,
+                    ignores = data.ignores,
+                    joinRank = ClanRank.valueOf(variables.getOrDefault("clan_join_rank", "Anyone") as String),
+                    talkRank = ClanRank.valueOf(variables.getOrDefault("clan_talk_rank", "Anyone") as String),
+                    kickRank = ClanRank.valueOf(variables.getOrDefault("clan_kick_rank", "Corporeal") as String),
+                    lootRank = ClanRank.valueOf(variables.getOrDefault("clan_loot_rank", "None") as String),
+                    coinShare = variables.getOrDefault("coin_share_setting", false) as Boolean,
+                )
+            } catch (e: Exception) {
+                logger.warn(e) { "Failed to load clan from account file ${save.name}, skipping." }
+            }
         }
         return clans
     }

--- a/engine/src/test/kotlin/world/gregs/voidps/engine/data/AccountDefinitionsReloaderTest.kt
+++ b/engine/src/test/kotlin/world/gregs/voidps/engine/data/AccountDefinitionsReloaderTest.kt
@@ -1,0 +1,86 @@
+package world.gregs.voidps.engine.data
+
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.Dispatchers
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import world.gregs.voidps.engine.data.config.AccountDefinition
+import world.gregs.voidps.engine.data.definition.AccountDefinitions
+
+class AccountDefinitionsReloaderTest {
+
+    private lateinit var storage: Storage
+    private lateinit var definitions: AccountDefinitions
+    private lateinit var saveQueue: SaveQueue
+    private lateinit var reloader: AccountDefinitionsReloader
+
+    @BeforeEach
+    fun setUp() {
+        storage = mockk(relaxed = true)
+        definitions = AccountDefinitions()
+        saveQueue = SaveQueue(storage)
+        reloader = AccountDefinitionsReloader(storage, definitions, saveQueue, io = Dispatchers.Unconfined, game = Dispatchers.Unconfined)
+    }
+
+    @Test
+    fun `Reload merges storage data into definitions`() {
+        every { storage.names() } returns mapOf("account" to AccountDefinition("account", "Name", "", "hash"))
+        every { storage.clans() } returns emptyMap()
+        var completed = -1
+
+        val started = reloader.reload { count -> completed = count }
+
+        assertTrue(started)
+        assertEquals(1, completed)
+        assertEquals("hash", definitions.get("account")?.passwordHash)
+    }
+
+    @Test
+    fun `Reload failure keeps old data and allows retry`() {
+        definitions.merge(mapOf("account" to AccountDefinition("account", "Name", "", "old_hash")), emptyMap()) { false }
+        every { storage.names() } throws IllegalStateException("Storage unavailable")
+
+        assertTrue(reloader.reload())
+
+        assertEquals("old_hash", definitions.get("account")?.passwordHash)
+        every { storage.names() } returns mapOf("account" to AccountDefinition("account", "Name", "", "new_hash"))
+        every { storage.clans() } returns emptyMap()
+        assertTrue(reloader.reload())
+        assertEquals("new_hash", definitions.get("account")?.passwordHash)
+    }
+
+    @Test
+    fun `Reload skips accounts with pending saves`() {
+        definitions.merge(mapOf("account" to AccountDefinition("account", "Name", "", "memory_hash")), emptyMap()) { false }
+        every { storage.names() } returns mapOf("account" to AccountDefinition("account", "Name", "", "storage_hash"))
+        every { storage.clans() } returns emptyMap()
+        val pendingQueue = mockk<SaveQueue>()
+        every { pendingQueue.saving("account") } returns true
+        val reloader = AccountDefinitionsReloader(storage, definitions, pendingQueue, io = Dispatchers.Unconfined, game = Dispatchers.Unconfined)
+
+        var completed = -1
+        assertTrue(reloader.reload { count -> completed = count })
+
+        assertEquals(0, completed)
+        assertEquals("memory_hash", definitions.get("account")?.passwordHash)
+    }
+
+    @Test
+    fun `Reload returns false while already in progress`() {
+        val blocked = java.util.concurrent.CountDownLatch(1)
+        every { storage.names() } answers {
+            blocked.await()
+            emptyMap()
+        }
+        every { storage.clans() } returns emptyMap()
+        val reloader = AccountDefinitionsReloader(storage, definitions, saveQueue, io = Dispatchers.IO, game = Dispatchers.Unconfined)
+
+        assertTrue(reloader.reload())
+        assertFalse(reloader.reload())
+        blocked.countDown()
+    }
+}

--- a/engine/src/test/kotlin/world/gregs/voidps/engine/data/definition/AccountDefinitionsTest.kt
+++ b/engine/src/test/kotlin/world/gregs/voidps/engine/data/definition/AccountDefinitionsTest.kt
@@ -1,0 +1,138 @@
+package world.gregs.voidps.engine.data.definition
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertSame
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import world.gregs.voidps.engine.data.config.AccountDefinition
+import world.gregs.voidps.engine.entity.character.player.Player
+import world.gregs.voidps.engine.entity.character.player.chat.clan.Clan
+import world.gregs.voidps.engine.entity.character.player.chat.clan.ClanRank
+
+class AccountDefinitionsTest {
+
+    private lateinit var definitions: AccountDefinitions
+
+    @BeforeEach
+    fun setUp() {
+        definitions = AccountDefinitions()
+    }
+
+    @Test
+    fun `Merge adds new definitions and display names`() {
+        val definition = definition("new_account", "Newbie", hash = "hash")
+
+        val count = definitions.merge(mapOf("new_account" to definition), emptyMap()) { false }
+
+        assertEquals(1, count)
+        assertSame(definition, definitions.get("new_account"))
+        assertEquals("Newbie", definitions.displayNames["new_account"])
+    }
+
+    @Test
+    fun `Merge updates existing definition in place`() {
+        val existing = definition("account", "Old name", hash = "old_hash")
+        definitions.merge(mapOf("account" to existing), emptyMap()) { false }
+
+        val count = definitions.merge(mapOf("account" to definition("account", "New name", hash = "new_hash")), emptyMap()) { false }
+
+        assertEquals(1, count)
+        val updated = definitions.get("account")
+        assertSame(existing, updated)
+        assertEquals("New name", updated?.displayName)
+        assertEquals("new_hash", updated?.passwordHash)
+        assertEquals("New name", definitions.displayNames["account"])
+    }
+
+    @Test
+    fun `Merge skips unchanged definitions`() {
+        definitions.merge(mapOf("account" to definition("account", "Name", hash = "hash")), emptyMap()) { false }
+
+        val count = definitions.merge(mapOf("account" to definition("account", "Name", hash = "hash")), emptyMap()) { false }
+
+        assertEquals(0, count)
+    }
+
+    @Test
+    fun `Merge skips accounts matching predicate`() {
+        val existing = definition("online_account", "Online", hash = "memory_hash")
+        definitions.merge(mapOf("online_account" to existing), emptyMap()) { false }
+
+        val count = definitions.merge(mapOf("online_account" to definition("online_account", "Online", hash = "storage_hash")), emptyMap()) { account ->
+            account == "online_account"
+        }
+
+        assertEquals(0, count)
+        assertEquals("memory_hash", definitions.get("online_account")?.passwordHash)
+    }
+
+    @Test
+    fun `Merge never removes definitions absent from storage`() {
+        definitions.merge(mapOf("account" to definition("account", "Name", hash = "hash")), emptyMap()) { false }
+
+        definitions.merge(emptyMap(), emptyMap()) { false }
+
+        assertEquals("hash", definitions.get("account")?.passwordHash)
+    }
+
+    @Test
+    fun `Merge adds new clans`() {
+        val clan = clan("owner_account", "Owner")
+
+        definitions.merge(emptyMap(), mapOf("owner_account" to clan)) { false }
+
+        assertSame(clan, definitions.clan("owner_account"))
+    }
+
+    @Test
+    fun `Merge updates existing clan in place preserving members`() {
+        val existing = clan("owner_account", "Owner")
+        val member: Player = Player(accountName = "member_account")
+        existing.members.add(member)
+        definitions.merge(emptyMap(), mapOf("owner_account" to existing)) { false }
+
+        val update = clan("owner_account", "Owner", name = "New clan", joinRank = ClanRank.Friend, friends = mapOf("friend" to ClanRank.Recruit))
+        definitions.merge(emptyMap(), mapOf("owner_account" to update)) { false }
+
+        val merged = definitions.clan("owner_account")
+        assertSame(existing, merged)
+        assertEquals("New clan", merged?.name)
+        assertEquals(ClanRank.Friend, merged?.joinRank)
+        assertEquals(mapOf("friend" to ClanRank.Recruit), merged?.friends)
+        assertEquals(listOf(member), merged?.members)
+    }
+
+    @Test
+    fun `Merge skips clans whose owner matches predicate`() {
+        val clan = clan("online_account", "Online")
+
+        definitions.merge(emptyMap(), mapOf("online_account" to clan)) { account ->
+            account == "online_account"
+        }
+
+        assertNull(definitions.clan("online_account"))
+    }
+
+    private fun definition(account: String, display: String, hash: String) = AccountDefinition(
+        accountName = account,
+        displayName = display,
+        previousName = "",
+        passwordHash = hash,
+    )
+
+    private fun clan(
+        owner: String,
+        display: String,
+        name: String = "",
+        joinRank: ClanRank = ClanRank.Anyone,
+        friends: Map<String, ClanRank> = emptyMap(),
+    ) = Clan(
+        owner = owner,
+        ownerDisplayName = display,
+        name = name,
+        friends = friends,
+        ignores = emptyList(),
+        joinRank = joinRank,
+    )
+}

--- a/game/src/main/kotlin/content/entity/player/command/ServerCommands.kt
+++ b/game/src/main/kotlin/content/entity/player/command/ServerCommands.kt
@@ -14,6 +14,7 @@ import world.gregs.voidps.engine.client.command.stringArg
 import world.gregs.voidps.engine.client.message
 import world.gregs.voidps.engine.client.ui.menu
 import world.gregs.voidps.engine.client.ui.open
+import world.gregs.voidps.engine.data.AccountDefinitionsReloader
 import world.gregs.voidps.engine.data.Settings
 import world.gregs.voidps.engine.data.SettingsReload
 import world.gregs.voidps.engine.data.configFiles
@@ -56,7 +57,7 @@ import kotlin.text.isBlank
 import kotlin.text.split
 import kotlin.text.toIntOrNull
 
-class ServerCommands(val accountLoader: PlayerAccountLoader) : Script {
+class ServerCommands(val accountLoader: PlayerAccountLoader, val accountReloader: AccountDefinitionsReloader) : Script {
 
     init {
         adminCommand(
@@ -67,7 +68,7 @@ class ServerCommands(val accountLoader: PlayerAccountLoader) : Script {
         )
         val configs = setOf(
             "books", "teleports", "music_tracks", "fairy_rings", "ships", "objects", "items", "bots", "npcs", "areas", "emotes", "anims", "containers", "graphics",
-            "item_on_item", "sounds", "quests", "midis", "variables", "music", "interfaces", "spells", "patrols", "prayers", "drops", "client_scripts", "settings",
+            "item_on_item", "sounds", "quests", "midis", "variables", "music", "interfaces", "spells", "patrols", "prayers", "drops", "client_scripts", "settings", "accounts",
         )
         adminCommand(
             "reload",
@@ -137,6 +138,11 @@ class ServerCommands(val accountLoader: PlayerAccountLoader) : Script {
             "settings", "setting", "game_setting", "game_settings", "games_settings", "properties", "props" -> {
                 Settings.load()
                 SettingsReload.now()
+            }
+            "accounts", "account", "passwords" -> {
+                if (!accountReloader.reload { count -> player.message("Reloaded $count account definitions.", ChatType.Console) }) {
+                    player.message("Account reload already in progress.", ChatType.Console)
+                }
             }
             "bots" -> get<BotManager>().load(files)
             "tables", "rows", "dbs", "spells" -> Tables.load(files.list(Settings["definitions.tables"]))

--- a/game/src/main/kotlin/content/entity/world/AccountReload.kt
+++ b/game/src/main/kotlin/content/entity/world/AccountReload.kt
@@ -1,0 +1,44 @@
+package content.entity.world
+
+import world.gregs.voidps.engine.Script
+import world.gregs.voidps.engine.data.AccountDefinitionsReloader
+import world.gregs.voidps.engine.data.Settings
+import world.gregs.voidps.engine.entity.World
+import world.gregs.voidps.engine.timer.Timer
+import world.gregs.voidps.engine.timer.toTicks
+import java.util.concurrent.TimeUnit
+
+/**
+ * Periodically reloads offline account definitions from storage so website
+ * password resets and imported accounts take effect without a server restart.
+ */
+class AccountReload(val reloader: AccountDefinitionsReloader) : Script {
+
+    init {
+        worldSpawn {
+            if (minutes() > 0) {
+                World.timers.start("account_reload")
+            }
+        }
+
+        worldTimerStart("account_reload") { TimeUnit.MINUTES.toTicks(minutes()) }
+        worldTimerTick("account_reload") {
+            val minutes = minutes()
+            if (minutes <= 0) {
+                return@worldTimerTick Timer.CANCEL
+            }
+            reloader.reload()
+            TimeUnit.MINUTES.toTicks(minutes)
+        }
+
+        settingsReload {
+            if (minutes() > 0) {
+                World.timers.start("account_reload", restart = true)
+            } else {
+                World.timers.stop("account_reload")
+            }
+        }
+    }
+
+    private fun minutes() = Settings["storage.accounts.reloadMinutes", -1]
+}

--- a/game/src/main/resources/game.properties
+++ b/game/src/main/resources/game.properties
@@ -322,6 +322,11 @@ storage.type=files
 # 0 is recommended to avoid players in instances getting stuck.
 storage.autoSave.minutes=5
 
+# How frequently to reload offline account definitions (password hashes, display
+# names, clans) from storage so website password resets and imported accounts take
+# effect without a restart - -1 to disable.
+storage.accounts.reloadMinutes=-1
+
 # The base directory for all game config data
 storage.data=./data/
 


### PR DESCRIPTION
## Summary 
Website password resets and imported accounts previously required a server restart because AccountDefinitions caches all account metadata (including password hashes) at startup and never refreshes.

- Add AccountDefinitions.merge(): add/update only, mutates existing definitions and clans in place (preserves live Clan.members), skips online players and accounts with pending saves whose in-memory state may be newer than storage.
- Add AccountDefinitionsReloader: loads names/clans on Dispatchers.IO, applies merge on the game thread; SupervisorJob so a failed reload does not cancel future ones.
- Add AccountReload script: world timer driven by new setting storage.accounts.reloadMinutes (-1 default, disabled), reacts to ::reload settings.
- Add ::reload accounts admin command for on-demand refresh.
- FileStorage.names()/clans(): warn and skip corrupt save files instead of crashing, so a partially-written save cannot abort a reload.
- Swap AccountDefinitions maps to ConcurrentHashMap as login threads read while the game thread merges.

Known limitation: a password reset for a currently online player is overwritten at logout; it converges on the next reload after they log out.

## Tests successful
- engine/src/test/kotlin/world/gregs/voidps/engine/data/definition/AccountDefinitionsTest.kt
- engine/src/test/kotlin/world/gregs/voidps/engine/data/AccountDefinitionsReloaderTest.kt

## Manual test
- Successfully reloaded password for a test account via in-game 'reload accounts' command.