### PR TITLE
feat: add bonus experience game mechanic

### DIFF
--- a/data/client/client.scripts.toml
+++ b/data/client/client.scripts.toml
@@ -1,6 +1,9 @@
 [model_swapper]
 id = 67
 
+[refresh_bonus_experience]
+id = 776
+
 [is_quest_item]
 id = 927
 

--- a/data/entity/player/modal/toplevel/gameframe.varbits.toml
+++ b/data/entity/player/modal/toplevel/gameframe.varbits.toml
@@ -1,3 +1,12 @@
 [life_points]
 id = 7198
 format = "int"
+
+[bonus_xp_enabled]
+id = 7232
+format = "boolean"
+
+[bonus_xp_time]
+id = 7233
+persist = true
+format = "int"

--- a/data/entity/player/modal/toplevel/gameframe.varps.toml
+++ b/data/entity/player/modal/toplevel/gameframe.varps.toml
@@ -3,6 +3,11 @@ id = 1801
 persist = true
 format = "int"
 
+[bonus_xp_counter]
+id = 1878
+persist = true
+format = "int"
+
 [movement]
 id = 173
 persist = true

--- a/engine/src/main/kotlin/world/gregs/voidps/engine/entity/character/player/skill/exp/Experience.kt
+++ b/engine/src/main/kotlin/world/gregs/voidps/engine/entity/character/player/skill/exp/Experience.kt
@@ -14,6 +14,12 @@ class Experience(
 
     lateinit var player: Player
 
+    /**
+     * Per-player experience multiplier applied on top of the "world.experienceRate" setting.
+     * Not persisted; resets to 1.0 every login.
+     */
+    var multiplier: Double = 1.0
+
     fun direct(skill: Skill): Int = experience[skill.ordinal]
 
     fun get(skill: Skill): Double = experience[skill.ordinal] / 10.0
@@ -40,7 +46,7 @@ class Experience(
         if (experience <= 0.0) {
             return
         }
-        val actual = experience * 10 * Settings["world.experienceRate", DEFAULT_EXPERIENCE_RATE]
+        val actual = experience * 10 * multiplier * Settings["world.experienceRate", DEFAULT_EXPERIENCE_RATE]
         if (blocked.contains(skill)) {
             Skills.blocked(player, skill, actual.toInt())
         } else {

--- a/engine/src/test/kotlin/world/gregs/voidps/engine/entity/character/player/skill/ExperienceTableTest.kt
+++ b/engine/src/test/kotlin/world/gregs/voidps/engine/entity/character/player/skill/ExperienceTableTest.kt
@@ -53,6 +53,16 @@ internal class ExperienceTableTest {
     }
 
     @Test
+    fun `Add experience with bonus multiplier`() {
+        experience.multiplier = 2.7
+        experience.add(Skill.Attack, 10.0)
+        assertEquals(27.0, experience.get(Skill.Attack))
+        experience.multiplier = 1.0
+        experience.add(Skill.Attack, 10.0)
+        assertEquals(37.0, experience.get(Skill.Attack))
+    }
+
+    @Test
     fun `Can't set negative experience`() {
         experience.set(Skill.Attack, -10.0)
         assertEquals(0.0, experience.get(Skill.Attack))

--- a/game/src/main/kotlin/content/entity/player/stat/BonusExperience.kt
+++ b/game/src/main/kotlin/content/entity/player/stat/BonusExperience.kt
@@ -1,0 +1,69 @@
+package content.entity.player.stat
+
+import world.gregs.voidps.engine.Script
+import world.gregs.voidps.engine.client.message
+import world.gregs.voidps.engine.client.sendScript
+import world.gregs.voidps.engine.data.Settings
+import world.gregs.voidps.engine.entity.character.player.Player
+import world.gregs.voidps.engine.timer.Timer
+
+/**
+ * Bonus XP Weekend
+ * Boosts all experience gained while active, the multiplier starts at 2.7x
+ * and decreases for every 30 minutes a player spends online, down to 1.1x.
+ * https://runescape.wiki/w/Bonus_XP_Weekend
+ */
+class BonusExperience : Script {
+
+    init {
+        playerSpawn {
+            if (!Settings["events.bonusExperience.enabled", false]) {
+                reset(this)
+                return@playerSpawn
+            }
+            experience.multiplier = multiplier(get("bonus_xp_time", 0))
+            softTimers.start("bonus_xp")
+            set("bonus_xp_enabled", true)
+            sendScript("refresh_bonus_experience")
+            message("Bonus XP Weekend is now active!")
+        }
+
+        timerStart("bonus_xp") { 100 } // 1 minute
+
+        timerTick("bonus_xp") {
+            val minutes = inc("bonus_xp_time")
+            experience.multiplier = multiplier(minutes)
+            sendScript("refresh_bonus_experience")
+            return@timerTick Timer.CONTINUE
+        }
+
+        experience { _, from, to ->
+            val multiplier = experience.multiplier
+            if (multiplier > 1.0) {
+                val increase = to - from
+                inc("bonus_xp_counter", increase - (increase / multiplier).toInt())
+                sendScript("refresh_bonus_experience")
+            }
+        }
+    }
+
+    fun reset(player: Player) {
+        if (player["bonus_xp_time", 0] > 0 || player["bonus_xp_counter", 0] > 0) {
+            player["bonus_xp_time"] = 0
+            player["bonus_xp_counter"] = 0
+            player.sendScript("refresh_bonus_experience")
+        }
+    }
+
+    companion object {
+        /**
+         * Experience multipliers for each 30 minutes spent online.
+         */
+        private val multipliers = doubleArrayOf(
+            2.7, 2.55, 2.4, 2.25, 2.1, 2.0, 1.9, 1.8, 1.7, 1.6, 1.5,
+            1.45, 1.4, 1.35, 1.3, 1.25, 1.2, 1.175, 1.15, 1.125, 1.1,
+        )
+
+        fun multiplier(minutes: Int): Double = multipliers[((minutes - 1) / 30).coerceIn(0, multipliers.lastIndex)]
+    }
+}

--- a/game/src/main/resources/game.properties
+++ b/game/src/main/resources/game.properties
@@ -183,6 +183,10 @@ slayer.strykewyrmReqTask=true
 # Skip requirements for quests that aren't implemented
 quests.requirements.skipMissing = true
 
+# Whether Bonus XP Weekend is active, boosting experience gained the multiplier
+# starts at 2.7x and decreases every 30 minutes spent online, down to 1.1x
+events.bonusExperience.enabled=false
+
 # Whether hiding penguins appear as an event in the game world
 events.penguinHideAndSeek.enabled=true
 

--- a/game/src/test/kotlin/content/entity/player/stat/BonusExperienceTest.kt
+++ b/game/src/test/kotlin/content/entity/player/stat/BonusExperienceTest.kt
@@ -1,0 +1,28 @@
+package content.entity.player.stat
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+internal class BonusExperienceTest {
+
+    @Test
+    fun `Multiplier starts at maximum`() {
+        assertEquals(2.7, BonusExperience.multiplier(0))
+        assertEquals(2.7, BonusExperience.multiplier(1))
+        assertEquals(2.7, BonusExperience.multiplier(30))
+    }
+
+    @Test
+    fun `Multiplier decreases every 30 minutes`() {
+        assertEquals(2.55, BonusExperience.multiplier(31))
+        assertEquals(2.55, BonusExperience.multiplier(60))
+        assertEquals(2.4, BonusExperience.multiplier(61))
+        assertEquals(2.0, BonusExperience.multiplier(151))
+    }
+
+    @Test
+    fun `Multiplier caps at minimum`() {
+        assertEquals(1.1, BonusExperience.multiplier(601))
+        assertEquals(1.1, BonusExperience.multiplier(10_000))
+    }
+}

--- a/game/src/test/kotlin/content/entity/player/stat/BonusExperienceWorldTest.kt
+++ b/game/src/test/kotlin/content/entity/player/stat/BonusExperienceWorldTest.kt
@@ -1,0 +1,67 @@
+package content.entity.player.stat
+
+import WorldTest
+import containsMessage
+import org.junit.jupiter.api.Test
+import world.gregs.voidps.engine.data.Settings
+import world.gregs.voidps.engine.entity.character.player.skill.Skill
+import world.gregs.voidps.engine.entity.character.player.skill.exp.exp
+import java.util.Properties
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+internal class BonusExperienceWorldTest : WorldTest() {
+
+    private fun enable(enabled: Boolean = true) {
+        val properties = Properties()
+        properties.putAll(settings)
+        properties["events.bonusExperience.enabled"] = enabled.toString()
+        Settings.load(properties)
+    }
+
+    @Test
+    fun `Bonus experience is granted and tracked while active`() {
+        enable()
+        val player = createPlayer()
+
+        assertTrue(player["bonus_xp_enabled", false])
+        assertEquals(2.7, player.experience.multiplier)
+        assertTrue(player.containsMessage("Bonus XP Weekend"))
+
+        player.exp(Skill.Attack, 10.0)
+        assertEquals(270, player.experience.direct(Skill.Attack))
+        assertEquals(170, player["bonus_xp_counter", 0])
+    }
+
+    @Test
+    fun `Multiplier decreases with time spent online`() {
+        enable()
+        val player = createPlayer()
+        player["bonus_xp_time"] = 30
+
+        tick(101)
+
+        assertEquals(31, player["bonus_xp_time", 0])
+        assertEquals(2.55, player.experience.multiplier)
+    }
+
+    @Test
+    fun `Bonus experience progress resets when inactive`() {
+        enable(false)
+        val player = createPlayer()
+        player["bonus_xp_time"] = 60
+        player["bonus_xp_counter"] = 100
+
+        scripts.filterIsInstance<BonusExperience>().first().reset(player)
+
+        assertFalse(player["bonus_xp_enabled", false])
+        assertEquals(1.0, player.experience.multiplier)
+        assertEquals(0, player["bonus_xp_time", 0])
+        assertEquals(0, player["bonus_xp_counter", 0])
+
+        player.exp(Skill.Attack, 10.0)
+        assertEquals(100, player.experience.direct(Skill.Attack))
+        assertEquals(0, player["bonus_xp_counter", 0])
+    }
+}


### PR DESCRIPTION
 ## Description

 Implements Bonus XP Weekend: while active (`events.bonusExperience.enabled`), players earn
 boosted experience starting at 2.7x, decaying every 30 minutes spent online down to 1.1x.
 Progress shows in the XP counter orb hover tooltip (multiplier, time elapsed, bonus xp earned).

 ## Changes

 ### Engine
 - `Experience.multiplier` — per-player multiplier applied on top of `world.experienceRate`;
   not persisted, resets to 1.0 each login. Reusable by other xp-boosting content (auras, pendants).

 ### `BonusExperience.kt`
 - Login while active: enables tooltip (varbit 7232), starts a 1-minute timer, sends welcome message
 - Timer increments time online (varbit 7233, persisted) and recalculates the multiplier — the decay
   table matches the client's own table in clientscript 338 exactly (verified by disassembling the
   cache), including the inclusive ≤30 minute first interval
 - `experience` hook accrues the bonus portion into the bonus xp counter (varp 1878, x10 units,
   persisted) and reruns the orb refresh script (776)
 - While disabled: persisted progress is reset on login

 ### Data & config
 - Varbit/varp definitions in `gameframe.varbits.toml` / `gameframe.varps.toml`
 - `refresh_bonus_experience` (776) mapping in `client.scripts.toml`
 - `events.bonusExperience.enabled` game property, default `false`

 ## Tests
 - `BonusExperienceWorldTest` — activation on login, 2.7x grant + bonus tracking, decay after
   31 minutes online, progress reset when disabled
 - `BonusExperienceTest` — multiplier decay table boundaries
 - `ExperienceTableTest` — engine multiplier applied with/without rate

 ## Known limitation
 The 634 client has no bonus-xp orb art (sprite 5568 absent), so the only display is the XP orb
 hover tooltip. The tooltip box wraps the trailing "xp" of "Multiplier: 2.7xp" onto a second line —
 client-side layout in clientscripts 776/569; fixing it needs a cache edit.
