### PR TITLE
fix: support digits in clan chat names + optional default clan chat for new players

### DIFF
--- a/game/src/main/kotlin/content/social/clan/ClanChat.kt
+++ b/game/src/main/kotlin/content/social/clan/ClanChat.kt
@@ -1,5 +1,6 @@
 package content.social.clan
 
+import content.bot.isBot
 import content.social.friend.*
 import world.gregs.voidps.engine.Script
 import world.gregs.voidps.engine.client.instruction.instruction
@@ -7,6 +8,7 @@ import world.gregs.voidps.engine.client.message
 import world.gregs.voidps.engine.client.variable.hasClock
 import world.gregs.voidps.engine.client.variable.remaining
 import world.gregs.voidps.engine.client.variable.start
+import world.gregs.voidps.engine.data.Settings
 import world.gregs.voidps.engine.data.definition.AccountDefinitions
 import world.gregs.voidps.engine.entity.character.player.*
 import world.gregs.voidps.engine.entity.character.player.chat.ChatType
@@ -36,6 +38,11 @@ class ClanChat(
             if (current.isNotEmpty()) {
                 val account = accountDefinitions.getByAccount(current)
                 joinClan(this, account?.displayName ?: "")
+            } else if (contains("new_player") && !isBot) {
+                val default = Settings["world.start.clanChat", ""]
+                if (default.isNotEmpty()) {
+                    joinClan(this, default)
+                }
             }
             val ownClan = accounts.clan(name.lowercase()) ?: return@playerSpawn
             this.ownClan = ownClan

--- a/game/src/main/resources/game.properties
+++ b/game/src/main/resources/game.properties
@@ -89,6 +89,9 @@ world.start.creation=true
 # Give new accounts starting gear
 world.start.gear=true
 
+# Clan chat channel for new accounts to automatically join (the channel owner's display name; blank to disable)
+world.start.clanChat=
+
 #------- NPC Rules -------
 
 # Whether NPCs can be collided with

--- a/game/src/test/kotlin/WorldTest.kt
+++ b/game/src/test/kotlin/WorldTest.kt
@@ -105,7 +105,7 @@ abstract class WorldTest : KoinTest {
         return player to client
     }
 
-    fun createPlayer(tile: Tile = Tile.EMPTY, name: String = "player${Players.size}"): Player {
+    fun createPlayer(tile: Tile = Tile.EMPTY, name: String = "player${Players.size}", setup: (Player) -> Unit = {}): Player {
         if (Players.any { it.accountName == name }) {
             throw IllegalStateException("Player already exists: $name")
         }
@@ -115,6 +115,7 @@ abstract class WorldTest : KoinTest {
         tick()
         player["creation"] = -1
         player["skip_level_up"] = true
+        setup(player)
         accounts.spawn(player, null)
         player.softTimers.clear("restore_stats")
         player.softTimers.clear("restore_hitpoints")

--- a/game/src/test/kotlin/content/social/clan/ClanTest.kt
+++ b/game/src/test/kotlin/content/social/clan/ClanTest.kt
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import world.gregs.voidps.cache.secure.Huffman
+import world.gregs.voidps.engine.data.Settings
 import world.gregs.voidps.engine.entity.character.player.PlayerRights
 import world.gregs.voidps.engine.entity.character.player.chat.ChatType
 import world.gregs.voidps.engine.entity.character.player.chat.clan.ClanRank
@@ -88,6 +89,31 @@ internal class ClanTest : WorldTest() {
         verify {
             client.message("Now talking in clan channel player", ChatType.ClanChat.id)
         }
+    }
+
+    @Test
+    fun `New players automatically join the default clan chat`() = runTest {
+        Settings.load(mapOf("world.start.clanChat" to "player"))
+        val owner = createPlayer(name = "player")
+        owner.ownClan?.name = "clan"
+
+        val newbie = createPlayer(name = "newbie") { it["new_player"] = true }
+
+        assertEquals(owner.ownClan, newbie.clan)
+        assertEquals("player", newbie["clan_chat", ""])
+        assertTrue(owner.ownClan!!.members.contains(newbie))
+    }
+
+    @Test
+    fun `Existing players do not join the default clan chat`() = runTest {
+        Settings.load(mapOf("world.start.clanChat" to "player"))
+        val owner = createPlayer(name = "player")
+        owner.ownClan?.name = "clan"
+
+        val existing = createPlayer(name = "existing")
+
+        assertEquals(null, existing.clan)
+        assertTrue(owner.ownClan!!.members.isEmpty())
     }
 
     @Test

--- a/network/src/main/kotlin/world/gregs/voidps/network/login/protocol/JagExtensions.kt
+++ b/network/src/main/kotlin/world/gregs/voidps/network/login/protocol/JagExtensions.kt
@@ -227,7 +227,7 @@ suspend fun ByteWriteChannel.writeLong(string: String) {
         when (char) {
             in 65..90 -> long += char - 64L
             in 97..122 -> long += char - 96L
-            in 0..9 -> long += char - 21L
+            in 48..57 -> long += char - 21L
         }
     }
     while (long % 37L == 0L && long != 0L) {

--- a/network/src/test/kotlin/world/gregs/voidps/network/login/protocol/JagExtensionsTest.kt
+++ b/network/src/test/kotlin/world/gregs/voidps/network/login/protocol/JagExtensionsTest.kt
@@ -72,6 +72,24 @@ class JagExtensionsTest {
     }
 
     @Test
+    fun `Write string as long includes digits`() = runTest {
+        val channel = ByteChannel(autoFlush = true)
+        channel.writeLong("clan123")
+        channel.close()
+        val packet = ByteReadPacket(channel.readRemaining().readByteArray())
+        assertEquals(8531929449L, packet.readLong())
+    }
+
+    @Test
+    fun `Write all numeric string as long`() = runTest {
+        val channel = ByteChannel(autoFlush = true)
+        channel.writeLong("123")
+        channel.close()
+        val packet = ByteReadPacket(channel.readRemaining().readByteArray())
+        assertEquals(39435L, packet.readLong())
+    }
+
+    @Test
     fun `Read byte inverse`() {
         val data = byteArrayOf(0x01)
         val packet = ByteReadPacket(data)


### PR DESCRIPTION
 Fixes

 Clan names containing digits were broken: writeLong(String) in JagExtensions.kt encoded names as base-37 RS longs but checked digit characters against in 0..9 instead of their ASCII codes (48..57), so digits were silently dropped.

 - Mixed names (e.g. Clan123) displayed without their digits.
 - All-numeric names (e.g. 123) encoded to 0, making the channel impossible to join.

 One-line fix to the character range; the - 21 offset was already correct ('0' → 27 … '9' → 36).

 Features

 Added an optional world.start.clanChat setting (game.properties). When set to a channel owner's display name, brand-new accounts automatically join that clan chat on first login. Detection uses the transient new_player flag set by
 AccountManager.create(), so it is unaffected by script ordering or the world.start.creation setting. Bots are excluded, and the join persists via the existing clan_chat variable (normal auto-rejoin/leave behaviour applies).

 Tests

 - JagExtensionsTest: digit encoding cases (clan123, all-numeric 123).
 - ClanTest: new players auto-join the default channel; existing players don't.
 - WorldTest.createPlayer gained an optional pre-spawn setup lambda for variable injection.
