### PR TITLE
Bug: Fix bots stuck at east Varrock gate (45851)

### DIFF
--- a/data/area/misthalin/border_guard.areas.toml
+++ b/data/area/misthalin/border_guard.areas.toml
@@ -32,3 +32,8 @@ tags = ["border"]
 x = [3077, 3078]
 y = [3332, 3334]
 tags = ["border"]
+
+[border_guard_varrock_east]
+x = [3272, 3274]
+y = [3428, 3429]
+tags = ["border"]

--- a/data/bot/varrock.nav-edges.toml
+++ b/data/bot/varrock.nav-edges.toml
@@ -16,7 +16,8 @@ edges = [
     { from = { x = 2655, y = 4831 }, to = { x = 2655, y = 4830 } }, # varrock_east_earth_altar_to_exit
     { from = { x = 2655, y = 4830 }, to = { x = 3304, y = 3474 }, cost = 3, actions = [{ object = { option = "Enter", id = "earth_altar_portal", x = 2655, y = 4829, success = { tile = { x = 3304, y = 3474 } } } }] }, # varrock_east_earth_altar_exit_to_ruins
     { from = { x = 3254, y = 3422 }, to = { x = 3265, y = 3428 } }, # varrock_east_bank_to_dirt_crossroad
-    { from = { x = 3265, y = 3428 }, to = { x = 3280, y = 3428 } }, # varrock_east_dirt_crossroad_to_east_crossroad
+    { from = { x = 3265, y = 3428 }, to = { x = 3272, y = 3428 } }, # varrock_east_dirt_crossroad_to_east_gate
+    { from = { x = 3272, y = 3428 }, to = { x = 3280, y = 3428 } }, # varrock_east_gate_to_east_crossroad
     { from = { x = 3280, y = 3428 }, to = { x = 3287, y = 3414 } }, # varrock_east_crossroad_to_east_path_south
     { from = { x = 3287, y = 3414 }, to = { x = 3291, y = 3399 } }, # varrock_east_path_to_south
     { from = { x = 3291, y = 3399 }, to = { x = 3293, y = 3384 } }, # varrock_east_path_south_to_east_border

--- a/data/bot/varrock.nav-edges.toml
+++ b/data/bot/varrock.nav-edges.toml
@@ -16,8 +16,7 @@ edges = [
     { from = { x = 2655, y = 4831 }, to = { x = 2655, y = 4830 } }, # varrock_east_earth_altar_to_exit
     { from = { x = 2655, y = 4830 }, to = { x = 3304, y = 3474 }, cost = 3, actions = [{ object = { option = "Enter", id = "earth_altar_portal", x = 2655, y = 4829, success = { tile = { x = 3304, y = 3474 } } } }] }, # varrock_east_earth_altar_exit_to_ruins
     { from = { x = 3254, y = 3422 }, to = { x = 3265, y = 3428 } }, # varrock_east_bank_to_dirt_crossroad
-    { from = { x = 3265, y = 3428 }, to = { x = 3272, y = 3428 } }, # varrock_east_dirt_crossroad_to_east_gate
-    { from = { x = 3272, y = 3428 }, to = { x = 3280, y = 3428 } }, # varrock_east_gate_to_east_crossroad
+    { from = { x = 3265, y = 3428 }, to = { x = 3280, y = 3428 } }, # varrock_east_dirt_crossroad_to_east_crossroad
     { from = { x = 3280, y = 3428 }, to = { x = 3287, y = 3414 } }, # varrock_east_crossroad_to_east_path_south
     { from = { x = 3287, y = 3414 }, to = { x = 3291, y = 3399 } }, # varrock_east_path_to_south
     { from = { x = 3291, y = 3399 }, to = { x = 3293, y = 3384 } }, # varrock_east_path_south_to_east_border

--- a/game/src/main/kotlin/content/area/misthalin/BorderGuard.kt
+++ b/game/src/main/kotlin/content/area/misthalin/BorderGuard.kt
@@ -20,9 +20,9 @@ class BorderGuard : Script {
 
     val raised = mutableMapOf<GameObject, Boolean>()
 
-    val gates = mutableMapOf<Rectangle, Tile>()
+    val gates = mutableMapOf<Rectangle, List<Tile>>()
 
-    private val gateAutoCloseDelay = 6
+    private val gateAutoCloseDelay = 5
 
     init {
         worldSpawn {
@@ -34,12 +34,12 @@ class BorderGuard : Script {
                         val obj = GameObjects.getLayer(it, ObjectLayer.GROUND)
                         if (obj != null && obj.id.startsWith("border_guard")) obj else null
                     }
-                    for (tile in tiles) {
-                        val obj = GameObjects.getLayer(tile, ObjectLayer.WALL) ?: continue
-                        if (obj.def.isDoor()) {
-                            gates[passage] = obj.tile
-                            break
-                        }
+                    val doors = tiles.mapNotNull {
+                        val obj = GameObjects.getLayer(it, ObjectLayer.WALL)
+                        if (obj != null && obj.def.isDoor()) obj.tile else null
+                    }
+                    if (doors.isNotEmpty()) {
+                        gates[passage] = doors
                     }
                 }
             }
@@ -54,7 +54,6 @@ class BorderGuard : Script {
         entered("border_guard_draynor_falador", ::enter)
         entered("border_guard_varrock_east", ::enterGate)
 
-        exited("border_guard_varrock_east", ::exitGate)
         exited("border_guard_edgeville_varrock", ::exit)
         exited("border_guard_al_kharid_varrock", ::exit)
         exited("border_guard_port_sarim_draynor", ::exit)
@@ -86,20 +85,12 @@ class BorderGuard : Script {
 
     fun enterGate(player: Player, def: AreaDefinition) {
         val border = def.area as Rectangle
-        val gateTile = gates[border]
-        if (gateTile != null) {
-            val gate = GameObjects.getLayer(gateTile, ObjectLayer.WALL)
-            if (gate != null && gate.id.endsWith("_closed")) {
-                // collision = false leaves the map untouched (others stay blocked); the timer closes it behind us
-                Door.openDoor(player, gate, ticks = gateAutoCloseDelay, collision = false)
+        for (gateTile in gates[border] ?: return) {
+            val gate = GameObjects.getLayer(gateTile, ObjectLayer.WALL) ?: continue
+            if (gate.id.endsWith("_closed")) {
+                Door.openDoor(player, gate, ticks = gateAutoCloseDelay, collision = true)
             }
         }
-        val endSide = Border.getOppositeSide(border, border.nearestTo(player.tile))
-        player.walkTo(endSide, noCollision = true, forceWalk = true)
-    }
-
-    fun exitGate(player: Player, def: AreaDefinition) {
-        player.steps.update(noCollision = false, noRun = false)
     }
 
     fun changeGuardState(guards: List<GameObject>, raise: Boolean) {

--- a/game/src/main/kotlin/content/area/misthalin/BorderGuard.kt
+++ b/game/src/main/kotlin/content/area/misthalin/BorderGuard.kt
@@ -1,5 +1,7 @@
 package content.area.misthalin
 
+import content.entity.obj.door.Door
+import content.entity.obj.door.Door.isDoor
 import world.gregs.voidps.engine.Script
 import world.gregs.voidps.engine.data.definition.AreaDefinition
 import world.gregs.voidps.engine.data.definition.Areas
@@ -8,6 +10,7 @@ import world.gregs.voidps.engine.entity.obj.GameObject
 import world.gregs.voidps.engine.entity.obj.GameObjects
 import world.gregs.voidps.engine.entity.obj.ObjectLayer
 import world.gregs.voidps.type.Distance.nearestTo
+import world.gregs.voidps.type.Tile
 import world.gregs.voidps.type.area.Rectangle
 import kotlin.collections.set
 
@@ -17,14 +20,26 @@ class BorderGuard : Script {
 
     val raised = mutableMapOf<GameObject, Boolean>()
 
+    val gates = mutableMapOf<Rectangle, Tile>()
+
+    private val gateAutoCloseDelay = 6
+
     init {
         worldSpawn {
             for (border in Areas.tagged("border")) {
                 val passage = border.area as Rectangle
                 for (zone in passage.toZones()) {
-                    guards[passage] = zone.toRectangle().mapNotNull {
+                    val tiles = zone.toRectangle()
+                    guards[passage] = tiles.mapNotNull {
                         val obj = GameObjects.getLayer(it, ObjectLayer.GROUND)
                         if (obj != null && obj.id.startsWith("border_guard")) obj else null
+                    }
+                    for (tile in tiles) {
+                        val obj = GameObjects.getLayer(tile, ObjectLayer.WALL) ?: continue
+                        if (obj.def.isDoor()) {
+                            gates[passage] = obj.tile
+                            break
+                        }
                     }
                 }
             }
@@ -37,7 +52,9 @@ class BorderGuard : Script {
         entered("border_guard_varrock_south", ::enter)
         entered("border_guard_draynor_barbarian_village", ::enter)
         entered("border_guard_draynor_falador", ::enter)
+        entered("border_guard_varrock_east", ::enterGate)
 
+        exited("border_guard_varrock_east", ::exitGate)
         exited("border_guard_edgeville_varrock", ::exit)
         exited("border_guard_al_kharid_varrock", ::exit)
         exited("border_guard_port_sarim_draynor", ::exit)
@@ -65,6 +82,24 @@ class BorderGuard : Script {
         val guards = guards[border] ?: return
         player.steps.update(noCollision = false, noRun = false)
         changeGuardState(guards, false)
+    }
+
+    fun enterGate(player: Player, def: AreaDefinition) {
+        val border = def.area as Rectangle
+        val gateTile = gates[border]
+        if (gateTile != null) {
+            val gate = GameObjects.getLayer(gateTile, ObjectLayer.WALL)
+            if (gate != null && gate.id.endsWith("_closed")) {
+                // collision = false leaves the map untouched (others stay blocked); the timer closes it behind us
+                Door.openDoor(player, gate, ticks = gateAutoCloseDelay, collision = false)
+            }
+        }
+        val endSide = Border.getOppositeSide(border, border.nearestTo(player.tile))
+        player.walkTo(endSide, noCollision = true, forceWalk = true)
+    }
+
+    fun exitGate(player: Player, def: AreaDefinition) {
+        player.steps.update(noCollision = false, noRun = false)
     }
 
     fun changeGuardState(guards: List<GameObject>, raise: Boolean) {

--- a/game/src/test/kotlin/content/area/misthalin/BorderGuardTest.kt
+++ b/game/src/test/kotlin/content/area/misthalin/BorderGuardTest.kt
@@ -64,25 +64,25 @@ internal class BorderGuardTest : WorldTest() {
 
     @Test
     fun `Guards open the east Varrock gate walking east`() {
-        val player = createPlayer(Tile(3271, 3429))
+        // The full bot route (varrock_east_dirt_crossroad -> east_crossroad) through closed gate 45851.
+        // Pathfinding truncates at the gate; entering the border opens it and movement re-paths across.
+        val player = createPlayer(Tile(3265, 3428))
         tick()
 
-        handler.walk(Walk(3275, 3429), player)
-        tick(8)
+        handler.walk(Walk(3280, 3428), player)
+        tick(20)
 
-        // Carried through the closed gate to the far (east) side
-        assertEquals(Tile(3275, 3429), player.tile)
+        assertEquals(Tile(3280, 3428), player.tile)
     }
 
     @Test
     fun `Guards open the east Varrock gate walking west`() {
-        val player = createPlayer(Tile(3275, 3429))
+        val player = createPlayer(Tile(3280, 3428))
         tick()
 
-        handler.walk(Walk(3271, 3429), player)
-        tick(8)
+        handler.walk(Walk(3265, 3428), player)
+        tick(20)
 
-        // Carried through the closed gate to the far (west) side
-        assertEquals(Tile(3271, 3429), player.tile)
+        assertEquals(Tile(3265, 3428), player.tile)
     }
 }

--- a/game/src/test/kotlin/content/area/misthalin/BorderGuardTest.kt
+++ b/game/src/test/kotlin/content/area/misthalin/BorderGuardTest.kt
@@ -61,4 +61,28 @@ internal class BorderGuardTest : WorldTest() {
 
         assertEquals(Tile(3292, 3387), player.tile)
     }
+
+    @Test
+    fun `Guards open the east Varrock gate walking east`() {
+        val player = createPlayer(Tile(3271, 3429))
+        tick()
+
+        handler.walk(Walk(3275, 3429), player)
+        tick(8)
+
+        // Carried through the closed gate to the far (east) side
+        assertEquals(Tile(3275, 3429), player.tile)
+    }
+
+    @Test
+    fun `Guards open the east Varrock gate walking west`() {
+        val player = createPlayer(Tile(3275, 3429))
+        tick()
+
+        handler.walk(Walk(3271, 3429), player)
+        tick(8)
+
+        // Carried through the closed gate to the far (west) side
+        assertEquals(Tile(3271, 3429), player.tile)
+    }
 }


### PR DESCRIPTION
 ## Summary
 Players currently must manually click the gate (generic Doors.kt Open/Close). The fix makes the
 guards auto-open it on approach, carry the walker through, and close it behind for both players and
 bots.
 
 ## Testing Complete
 Manually verified that gate automatically opens for players/bots and closes behind them as player exits.
 
 ## Linked Issue
 https://github.com/GregHib/void/issues/1035
