### PR TITLE
Make interface handlers suspendable

### DIFF
--- a/engine/src/main/kotlin/world/gregs/voidps/engine/client/instruction/InterfaceHandler.kt
+++ b/engine/src/main/kotlin/world/gregs/voidps/engine/client/instruction/InterfaceHandler.kt
@@ -12,6 +12,7 @@ import world.gregs.voidps.engine.entity.character.player.Player
 import world.gregs.voidps.engine.entity.item.Item
 import world.gregs.voidps.engine.inv.equipment
 import world.gregs.voidps.engine.entity.character.Character
+import world.gregs.voidps.engine.suspend.Suspension
 
 class InterfaceHandler(
     private val inventoryDefinitions: InventoryDefinitions,
@@ -125,7 +126,9 @@ fun <C: Character> C.protectedAccess(block: suspend C.() -> Unit): Boolean {
     if (contains("delay") && (this is Player && hasMenuOpen())) {
         return false
     }
-    if (suspension != null) {
+    // Check suspension type to avoid breaking interfaces with selection options and custom suspension usage
+    // like quest start modal using StringEntry or grand exchange using Continue
+    if (suspension != null && suspension is Suspension.Delay) {
         return false
     }
     Script.launch {

--- a/engine/src/main/kotlin/world/gregs/voidps/engine/client/instruction/InterfaceHandler.kt
+++ b/engine/src/main/kotlin/world/gregs/voidps/engine/client/instruction/InterfaceHandler.kt
@@ -2,6 +2,8 @@ package world.gregs.voidps.engine.client.instruction
 
 import com.github.michaelbull.logging.InlineLogger
 import world.gregs.voidps.cache.definition.data.InterfaceComponentDefinition
+import world.gregs.voidps.engine.Script
+import world.gregs.voidps.engine.client.ui.hasMenuOpen
 import world.gregs.voidps.engine.data.definition.EnumDefinitions
 import world.gregs.voidps.engine.data.definition.InterfaceDefinitions
 import world.gregs.voidps.engine.data.definition.InventoryDefinitions
@@ -9,6 +11,7 @@ import world.gregs.voidps.engine.data.definition.ItemDefinitions
 import world.gregs.voidps.engine.entity.character.player.Player
 import world.gregs.voidps.engine.entity.item.Item
 import world.gregs.voidps.engine.inv.equipment
+import world.gregs.voidps.engine.entity.character.Character
 
 class InterfaceHandler(
     private val inventoryDefinitions: InventoryDefinitions,
@@ -116,6 +119,19 @@ class InterfaceHandler(
             return inventory
         }
     }
+}
+
+fun <C: Character> C.protectedAccess(block: suspend C.() -> Unit): Boolean {
+    if (contains("delay") && (this is Player && hasMenuOpen())) {
+        return false
+    }
+    if (suspension != null) {
+        return false
+    }
+    Script.launch {
+        block.invoke(this@protectedAccess)
+    }
+    return true
 }
 
 data class InterfaceData(

--- a/engine/src/main/kotlin/world/gregs/voidps/engine/client/instruction/handle/InterfaceOnInterfaceOptionHandler.kt
+++ b/engine/src/main/kotlin/world/gregs/voidps/engine/client/instruction/handle/InterfaceOnInterfaceOptionHandler.kt
@@ -2,6 +2,7 @@ package world.gregs.voidps.engine.client.instruction.handle
 
 import world.gregs.voidps.engine.client.instruction.InstructionHandler
 import world.gregs.voidps.engine.client.instruction.InterfaceHandler
+import world.gregs.voidps.engine.client.instruction.protectedAccess
 import world.gregs.voidps.engine.client.ui.closeInterfaces
 import world.gregs.voidps.engine.client.ui.InterfaceApi
 import world.gregs.voidps.engine.entity.character.player.Player
@@ -20,10 +21,12 @@ class InterfaceOnInterfaceOptionHandler(
         player.closeInterfaces()
         player.queue.clearWeak()
         player.suspension = null
-        if (fromItem.isEmpty()) {
-            InterfaceApi.onItem(player, "$fromId:$fromComponent", toItem)
-        } else {
-            InterfaceApi.itemOnItem(player, fromItem, toItem, fromSlot, toSlot)
+        player.protectedAccess {
+            if (fromItem.isEmpty()) {
+                InterfaceApi.onItem(player, "$fromId:$fromComponent", toItem)
+            } else {
+                InterfaceApi.itemOnItem(player, fromItem, toItem, fromSlot, toSlot)
+            }
         }
         return true
     }

--- a/engine/src/main/kotlin/world/gregs/voidps/engine/client/instruction/handle/InterfaceOptionHandler.kt
+++ b/engine/src/main/kotlin/world/gregs/voidps/engine/client/instruction/handle/InterfaceOptionHandler.kt
@@ -1,9 +1,9 @@
 package world.gregs.voidps.engine.client.instruction.handle
 
 import com.github.michaelbull.logging.InlineLogger
-import world.gregs.voidps.engine.Script
 import world.gregs.voidps.engine.client.instruction.InstructionHandler
 import world.gregs.voidps.engine.client.instruction.InterfaceHandler
+import world.gregs.voidps.engine.client.instruction.protectedAccess
 import world.gregs.voidps.engine.client.ui.InterfaceOption
 import world.gregs.voidps.engine.data.definition.InterfaceDefinitions
 import world.gregs.voidps.engine.client.ui.InterfaceApi
@@ -38,7 +38,7 @@ class InterfaceOptionHandler(
             item = item,
             itemSlot = itemSlot,
         )
-        Script.launch {
+        player.protectedAccess {
             InterfaceApi.option(player, event)
         }
         return true

--- a/engine/src/main/kotlin/world/gregs/voidps/engine/client/ui/InterfaceApi.kt
+++ b/engine/src/main/kotlin/world/gregs/voidps/engine/client/ui/InterfaceApi.kt
@@ -11,7 +11,7 @@ import world.gregs.voidps.engine.event.Wildcards
 
 interface InterfaceApi {
 
-    fun onItem(id: String, item: String = "*", handler: Player.(item: Item, id: String) -> Unit) {
+    fun onItem(id: String, item: String = "*", handler: suspend Player.(item: Item, id: String) -> Unit) {
         Script.checkLoading()
         Wildcards.find(id, Wildcard.Component) { i ->
             Wildcards.find(item, Wildcard.Item) { itm ->
@@ -20,20 +20,20 @@ interface InterfaceApi {
         }
     }
 
-    fun itemOnItem(fromItem: String = "*", toItem: String = "*", bidirectional: Boolean = true, handler: Player.(fromItem: Item, toItem: Item, fromSlot: Int, toSlot: Int) -> Unit) {
+    fun itemOnItem(fromItem: String = "*", toItem: String = "*", bidirectional: Boolean = true, handler: suspend Player.(fromItem: Item, toItem: Item, fromSlot: Int, toSlot: Int) -> Unit) {
         Script.checkLoading()
-        val biHandler: Player.(Item, Item, Int, Int) -> Unit = { from, to, fromSlot, toSlot ->
+        val biHandler: suspend Player.(Item, Item, Int, Int) -> Unit = { from, to, fromSlot, toSlot ->
             handler(this, to, from, toSlot, fromSlot)
         }
         append(fromItem, toItem, bidirectional, biHandler, handler)
     }
 
-    fun itemOnItem(fromItem: String = "*", toItem: String = "*", bidirectional: Boolean = true, handler: Player.(fromItem: Item, toItem: Item) -> Unit) {
+    fun itemOnItem(fromItem: String = "*", toItem: String = "*", bidirectional: Boolean = true, handler: suspend Player.(fromItem: Item, toItem: Item) -> Unit) {
         Script.checkLoading()
-        val single: Player.(Item, Item, Int, Int) -> Unit = { from, to, _, _ ->
+        val single: suspend Player.(Item, Item, Int, Int) -> Unit = { from, to, _, _ ->
             handler(this, from, to)
         }
-        val biHandler: Player.(Item, Item, Int, Int) -> Unit = { from, to, _, _ ->
+        val biHandler: suspend Player.(Item, Item, Int, Int) -> Unit = { from, to, _, _ ->
             handler(this, to, from)
         }
         append(fromItem, toItem, bidirectional, biHandler, single)
@@ -43,8 +43,8 @@ interface InterfaceApi {
         fromItem: String,
         toItem: String,
         bidirectional: Boolean,
-        biHandler: Player.(Item, Item, Int, Int) -> Unit,
-        handler: Player.(from: Item, to: Item, fromSlot: Int, toSlot: Int) -> Unit,
+        biHandler: suspend Player.(Item, Item, Int, Int) -> Unit,
+        handler: suspend Player.(from: Item, to: Item, fromSlot: Int, toSlot: Int) -> Unit,
     ) {
         Script.checkLoading()
         Wildcards.find(fromItem, Wildcard.Item) { from ->
@@ -128,8 +128,8 @@ interface InterfaceApi {
         private val closed = Object2ObjectOpenHashMap<String, MutableList<Player.(String) -> Unit>>(75)
         private val refreshed = Object2ObjectOpenHashMap<String, MutableList<Player.(String) -> Unit>>(25)
         private val swapped = Object2ObjectOpenHashMap<String, MutableList<Player.(String, String, Int, Int) -> Unit>>(10)
-        private val onItem = Object2ObjectOpenHashMap<String, MutableList<Player.(Item, String) -> Unit>>(2)
-        private val itemOnItem = Object2ObjectOpenHashMap<String, MutableList<Player.(Item, Item, Int, Int) -> Unit>>(800)
+        private val onItem = Object2ObjectOpenHashMap<String, MutableList<suspend Player.(Item, String) -> Unit>>(2)
+        private val itemOnItem = Object2ObjectOpenHashMap<String, MutableList<suspend Player.(Item, Item, Int, Int) -> Unit>>(800)
         private val options = Object2ObjectOpenHashMap<String, MutableList<suspend Player.(InterfaceOption) -> Unit>>(50)
         private val itemOption = Object2ObjectOpenHashMap<String, MutableList<suspend Player.(ItemOption) -> Unit>>(600)
         private val shops = Object2ObjectOpenHashMap<String, (Player, String) -> Unit>(5)
@@ -198,13 +198,13 @@ interface InterfaceApi {
             }
         }
 
-        fun onItem(player: Player, id: String, item: Item) {
+        suspend fun onItem(player: Player, id: String, item: Item) {
             for (block in onItem["$id:${item.id}"] ?: onItem["*:${item.id}"] ?: onItem["$id:*"] ?: onItem["*:*"] ?: return) {
                 block(player, item, id)
             }
         }
 
-        fun itemOnItem(player: Player, from: Item, to: Item, fromSlot: Int, toSlot: Int) {
+        suspend fun itemOnItem(player: Player, from: Item, to: Item, fromSlot: Int, toSlot: Int) {
             for (block in itemOnItem["${from.id}:${to.id}"] ?: itemOnItem["*:${to.id}"] ?: itemOnItem["${from.id}:*"] ?: itemOnItem["*:*"] ?: return) {
                 block(player, from, to, fromSlot, toSlot)
             }

--- a/engine/src/main/kotlin/world/gregs/voidps/engine/client/ui/Interfaces.kt
+++ b/engine/src/main/kotlin/world/gregs/voidps/engine/client/ui/Interfaces.kt
@@ -104,7 +104,7 @@ class Interfaces(
                 it.remove()
                 sendClose(id)
                 InterfaceApi.close(player, id)
-                (player as? Player)?.queue?.clearWeak()
+                player.queue.clearWeak()
                 children.add(id)
             }
         }

--- a/engine/src/main/kotlin/world/gregs/voidps/engine/entity/character/player/Teleport.kt
+++ b/engine/src/main/kotlin/world/gregs/voidps/engine/entity/character/player/Teleport.kt
@@ -39,7 +39,7 @@ interface Teleport {
         }
     }
 
-    fun objTeleportLand(option: String = "*", obj: String = "*", block: Player.(obj: GameObject, option: String) -> Unit) {
+    fun objTeleportLand(option: String = "*", obj: String = "*", block: suspend Player.(obj: GameObject, option: String) -> Unit) {
         Script.checkLoading()
         Wildcards.find(obj, Wildcard.Object) { id ->
             objectLand["$option:$id"] = block
@@ -51,7 +51,7 @@ interface Teleport {
         private val items = Object2ObjectOpenHashMap<String, MutableSet<Player.(String) -> Boolean>>(5)
         private val land = Object2ObjectOpenHashMap<String, Player.() -> Unit>(5)
         private val objectTakeOff = Object2ObjectOpenHashMap<String, suspend Player.(GameObject, String) -> Int>(50)
-        private val objectLand = Object2ObjectOpenHashMap<String, Player.(GameObject, String) -> Unit>(20)
+        private val objectLand = Object2ObjectOpenHashMap<String, suspend Player.(GameObject, String) -> Unit>(20)
 
         const val CONTINUE = 0
         const val CANCEL = -1
@@ -83,7 +83,7 @@ interface Teleport {
             return handler.invoke(player, target, option)
         }
 
-        fun land(player: Player, target: GameObject, option: String) {
+        suspend fun land(player: Player, target: GameObject, option: String) {
             val handler = objectLand["$option:${target.id}"] ?: objectLand["*:${target.id}"] ?: objectLand["$option:*"] ?: objectLand["*:*"] ?: return
             handler.invoke(player, target, option)
         }

--- a/engine/src/main/kotlin/world/gregs/voidps/engine/entity/character/player/Teleport.kt
+++ b/engine/src/main/kotlin/world/gregs/voidps/engine/entity/character/player/Teleport.kt
@@ -32,7 +32,7 @@ interface Teleport {
         items.getOrPut(type) { mutableSetOf() }.add(block)
     }
 
-    fun objTeleportTakeOff(option: String = "*", obj: String = "*", block: Player.(obj: GameObject, option: String) -> Int) {
+    fun objTeleportTakeOff(option: String = "*", obj: String = "*", block: suspend Player.(obj: GameObject, option: String) -> Int) {
         Script.checkLoading()
         Wildcards.find(obj, Wildcard.Object) { id ->
             objectTakeOff["$option:$id"] = block
@@ -50,7 +50,7 @@ interface Teleport {
         private val takeOff = Object2ObjectOpenHashMap<String, MutableSet<Player.(String) -> Boolean>>(5)
         private val items = Object2ObjectOpenHashMap<String, MutableSet<Player.(String) -> Boolean>>(5)
         private val land = Object2ObjectOpenHashMap<String, Player.() -> Unit>(5)
-        private val objectTakeOff = Object2ObjectOpenHashMap<String, Player.(GameObject, String) -> Int>(50)
+        private val objectTakeOff = Object2ObjectOpenHashMap<String, suspend Player.(GameObject, String) -> Int>(50)
         private val objectLand = Object2ObjectOpenHashMap<String, Player.(GameObject, String) -> Unit>(20)
 
         const val CONTINUE = 0
@@ -78,7 +78,7 @@ interface Teleport {
             land[type]?.invoke(player)
         }
 
-        fun takeOff(player: Player, target: GameObject, option: String): Int {
+        suspend fun takeOff(player: Player, target: GameObject, option: String): Int {
             val handler = objectTakeOff["$option:${target.id}"] ?: objectTakeOff["*:${target.id}"] ?: objectTakeOff["$option:*"] ?: objectTakeOff["*:*"] ?: return CONTINUE
             return handler.invoke(player, target, option)
         }

--- a/engine/src/test/kotlin/world/gregs/voidps/engine/client/ui/InterfaceApiTest.kt
+++ b/engine/src/test/kotlin/world/gregs/voidps/engine/client/ui/InterfaceApiTest.kt
@@ -30,7 +30,9 @@ class InterfaceApiTest {
         }
 
         override fun invoke(args: List<String>) {
-            InterfaceApi.onItem(Player(), "id", Item("item"))
+            runTest {
+                InterfaceApi.onItem(Player(), "id", Item("item"))
+            }
         }
 
         override val apis = listOf(InterfaceApi)
@@ -58,7 +60,9 @@ class InterfaceApiTest {
         }
 
         override fun invoke(args: List<String>) {
-            InterfaceApi.itemOnItem(Player(), Item("from"), Item("to"), 1, 2)
+            runTest {
+                InterfaceApi.itemOnItem(Player(), Item("from"), Item("to"), 1, 2)
+            }
         }
 
         override val apis = listOf(InterfaceApi)

--- a/engine/src/test/kotlin/world/gregs/voidps/engine/entity/character/player/TeleportTest.kt
+++ b/engine/src/test/kotlin/world/gregs/voidps/engine/entity/character/player/TeleportTest.kt
@@ -1,5 +1,6 @@
 package world.gregs.voidps.engine.entity.character.player
 
+import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
@@ -82,7 +83,9 @@ class TeleportTest {
         }
 
         override fun invoke(args: List<String>) {
-            assertEquals(0, Teleport.takeOff(Player(), GameObject(0), "option"))
+            runTest {
+                assertEquals(0, Teleport.takeOff(Player(), GameObject(0), "option"))
+            }
         }
 
         override val apis = listOf(Teleport)

--- a/engine/src/test/kotlin/world/gregs/voidps/engine/entity/character/player/TeleportTest.kt
+++ b/engine/src/test/kotlin/world/gregs/voidps/engine/entity/character/player/TeleportTest.kt
@@ -118,7 +118,9 @@ class TeleportTest {
         }
 
         override fun invoke(args: List<String>) {
-            Teleport.land(Player(), GameObject(0), "option")
+            runTest {
+                Teleport.land(Player(), GameObject(0), "option")
+            }
         }
 
         override val apis = listOf(Teleport)

--- a/game/src/main/kotlin/content/area/asgarnia/taverley/TaverleyDungeon.kt
+++ b/game/src/main/kotlin/content/area/asgarnia/taverley/TaverleyDungeon.kt
@@ -41,14 +41,9 @@ class TaverleyDungeon : Script {
     fun spawn(player: Player, tile: Tile): Boolean {
         val armour = GameObjects.getLayer(tile, ObjectLayer.GROUND) ?: return false
         armour.remove(TimeUnit.MINUTES.toTicks(5))
-        val suit = NPCs.add("suit_of_armour", armour.tile)
+        NPCs.add("suit_of_armour", armour.tile, ticks = TimeUnit.MINUTES.toTicks(5))
         player.message("Suddenly the suit of armour comes to life!")
         //    suit.setAnimation("suit_of_armour_stand") TODO find animation
-        suit.queue("despawn", TimeUnit.MINUTES.toTicks(5)) {
-            World.queue("despawn_${suit.index}") {
-                NPCs.remove(suit)
-            }
-        }
         return true
     }
 

--- a/game/src/main/kotlin/content/area/asgarnia/taverley/TaverleyDungeon.kt
+++ b/game/src/main/kotlin/content/area/asgarnia/taverley/TaverleyDungeon.kt
@@ -5,7 +5,6 @@ import content.quest.quest
 import net.pearx.kasechange.toLowerSpaceCase
 import world.gregs.voidps.engine.Script
 import world.gregs.voidps.engine.client.message
-import world.gregs.voidps.engine.entity.World
 import world.gregs.voidps.engine.entity.character.mode.interact.ItemOnObjectInteract
 import world.gregs.voidps.engine.entity.character.npc.NPCs
 import world.gregs.voidps.engine.entity.character.player.Player
@@ -15,7 +14,6 @@ import world.gregs.voidps.engine.entity.obj.ObjectLayer
 import world.gregs.voidps.engine.entity.obj.remove
 import world.gregs.voidps.engine.inv.inventory
 import world.gregs.voidps.engine.inv.replace
-import world.gregs.voidps.engine.queue.queue
 import world.gregs.voidps.engine.timer.toTicks
 import world.gregs.voidps.type.Tile
 import java.util.concurrent.TimeUnit

--- a/game/src/main/kotlin/content/area/fremennik_province/waterbirth_island_dungeon/DagannothEggHatch.kt
+++ b/game/src/main/kotlin/content/area/fremennik_province/waterbirth_island_dungeon/DagannothEggHatch.kt
@@ -24,7 +24,7 @@ class DagannothEggHatch : Script {
             // Small stand-up delay before attacking
             queue("dagannoth_hatch_attack", 1) {
                 transform("dagannoth_egg_opened")
-                NPCs.add("dagannoth_spawn", tile)
+                NPCs.add("dagannoth_spawn", tile, ticks = TimeUnit.MINUTES.toTicks(5))
                 interactPlayer(target, "Attack")
             }
             queue("dagannoth_respawn", TimeUnit.MINUTES.toTicks(5)) {

--- a/game/src/main/kotlin/content/area/kandarin/baxtorian_falls/ancient_cavern/KuradalsDungeon.kt
+++ b/game/src/main/kotlin/content/area/kandarin/baxtorian_falls/ancient_cavern/KuradalsDungeon.kt
@@ -14,7 +14,6 @@ import world.gregs.voidps.engine.entity.character.player.Teleport
 import world.gregs.voidps.engine.entity.character.player.skill.Skill
 import world.gregs.voidps.engine.entity.character.player.skill.level.Level.has
 import world.gregs.voidps.engine.inv.inventory
-import world.gregs.voidps.engine.queue.queue
 import world.gregs.voidps.type.Direction
 import world.gregs.voidps.type.Tile
 
@@ -22,22 +21,18 @@ class KuradalsDungeon : Script {
     init {
         objTeleportTakeOff("Enter", "kuradal_dungeon_cave") { _, _ ->
             if (inventory.items.any { it.id == "cannon_barrels" || it.id == "cannon_furnace" || it.id == "cannon_stand" || it.id == "cannon_base" }) {
-                queue("kuradal_cannon_ban") {
-                    npc<Neutral>("kuradal", "No cannons are allowed in there.") // TODO proper message
-                }
+                npc<Neutral>("kuradal", "No cannons are allowed in there.") // TODO proper message
                 return@objTeleportTakeOff Teleport.CANCEL
             }
             if (slayerTaskRemaining <= 0 || slayerMaster != "kuradal") {
-                queue("kuradal_task_check") {
-                    npc<Neutral>("kuradal", "Sorry, my dungeon is exclusive only to those who need to go in there.")
-                    player<Quiz>("Exclusive?")
-                    npc<Neutral>("kuradal", "Yes, I only allow pupils of Slayer into this dungeon and only if they need to slayer the creatures I've caught inside.")
-                    player<Quiz>("I see. So what creatures do I need to be assigned to kill; what creatures are inside?")
-                    npc<Happy>("kuradal", "Well, I took a holiday tour of Gielinor and brought back some 'souvenirs'. Of course, as a Slayer master, 'souvenirs' means hellhounds, greater demons, gargoyles, abyssal demons, airut, dark beasts, and blue, iron, and steel dragons.")
-                    player<Laugh>("I'd usually keep it simple with a postcard.")
-                    npc<Quiz>("kuradal", "What was that?")
-                    player<Unamused>("I said that must have been hard.")
-                }
+                npc<Neutral>("kuradal", "Sorry, my dungeon is exclusive only to those who need to go in there.")
+                player<Quiz>("Exclusive?")
+                npc<Neutral>("kuradal", "Yes, I only allow pupils of Slayer into this dungeon and only if they need to slayer the creatures I've caught inside.")
+                player<Quiz>("I see. So what creatures do I need to be assigned to kill; what creatures are inside?")
+                npc<Happy>("kuradal", "Well, I took a holiday tour of Gielinor and brought back some 'souvenirs'. Of course, as a Slayer master, 'souvenirs' means hellhounds, greater demons, gargoyles, abyssal demons, airut, dark beasts, and blue, iron, and steel dragons.")
+                player<Laugh>("I'd usually keep it simple with a postcard.")
+                npc<Quiz>("kuradal", "What was that?")
+                player<Unamused>("I said that must have been hard.")
                 return@objTeleportTakeOff Teleport.CANCEL
             }
             Teleport.CONTINUE

--- a/game/src/main/kotlin/content/area/kandarin/ourania/Eniola.kt
+++ b/game/src/main/kotlin/content/area/kandarin/ourania/Eniola.kt
@@ -11,7 +11,6 @@ import world.gregs.voidps.engine.client.ui.open
 import world.gregs.voidps.engine.entity.character.player.Player
 import world.gregs.voidps.engine.inv.inventory
 import world.gregs.voidps.engine.inv.remove
-import world.gregs.voidps.engine.queue.queue
 import world.gregs.voidps.engine.suspend.Suspension
 import world.gregs.voidps.engine.suspend.pauseString
 
@@ -108,9 +107,7 @@ class Eniola : Script {
             if (inventory.remove(it.component, 20)) {
                 openBank()
             } else {
-                queue("not_enough_runes") {
-                    npc<Sad>("I'm afraid you don't have the necessary runes with you at this time, so I can't allow you to access your account. Please bring twenty runes of one type and you can open your account.")
-                }
+                npc<Sad>("I'm afraid you don't have the necessary runes with you at this time, so I can't allow you to access your account. Please bring twenty runes of one type and you can open your account.")
             }
         }
     }

--- a/game/src/main/kotlin/content/area/kandarin/tree_gnome_stronghold/CaptainErrdo.kt
+++ b/game/src/main/kotlin/content/area/kandarin/tree_gnome_stronghold/CaptainErrdo.kt
@@ -42,7 +42,7 @@ class CaptainErrdo : Script {
             }
         }
 
-        npcOperate("Glider,captain_errdo,captain_bleemadge,captain_dalbur,captain_klemfoodle") { (target) ->
+        npcOperate("Glider", "captain_errdo,captain_bleemadge,captain_dalbur,captain_klemfoodle") { (target) ->
             if (!questCompleted("the_grand_tree")) {
                 takeMe(target)
                 return@npcOperate

--- a/game/src/main/kotlin/content/area/kandarin/tree_gnome_stronghold/GliderMap.kt
+++ b/game/src/main/kotlin/content/area/kandarin/tree_gnome_stronghold/GliderMap.kt
@@ -4,7 +4,6 @@ import content.quest.questCompleted
 import world.gregs.voidps.engine.Script
 import world.gregs.voidps.engine.client.message
 import world.gregs.voidps.engine.client.ui.open
-import world.gregs.voidps.engine.entity.World
 import world.gregs.voidps.engine.entity.character.move.tele
 import world.gregs.voidps.type.Tile
 
@@ -22,20 +21,19 @@ class GliderMap : Script {
             }
             set("gnome_glider_journey", "${current}_to_${it.component}")
             open("fade_out")
-            World.queue("gnome_glider_$index", 3) {
-                val target = when (it.component) {
-                    "ta_quir_priw" -> Tile(2465, 3500, 3)
-                    "sindarpos" -> Tile(2850, 3497)
-                    "lemanto_andra" -> Tile(3325, 3429)
-                    "kar_hewo" -> Tile(3285, 3212)
-                    "lemantolly_undri" -> Tile(2548, 2970)
-                    "gandius" -> Tile(2972, 2965)
-                    else -> return@queue
-                }
-                tele(target)
-                open("fade_in")
-                clear("gnome_glider_journey")
+            delay(3)
+            val target = when (it.component) {
+                "ta_quir_priw" -> Tile(2465, 3500, 3)
+                "sindarpos" -> Tile(2850, 3497)
+                "lemanto_andra" -> Tile(3325, 3429)
+                "kar_hewo" -> Tile(3285, 3212)
+                "lemantolly_undri" -> Tile(2548, 2970)
+                "gandius" -> Tile(2972, 2965)
+                else -> return@interfaceOption
             }
+            tele(target)
+            open("fade_in")
+            clear("gnome_glider_journey")
         }
 
         interfaceOpened("glider_map") {

--- a/game/src/main/kotlin/content/area/karamja/brimhaven/Saniboch.kt
+++ b/game/src/main/kotlin/content/area/karamja/brimhaven/Saniboch.kt
@@ -88,9 +88,7 @@ class Saniboch : Script {
 
         objTeleportTakeOff("Enter", "brimhaven_dungeon_entrance") { _, _ ->
             if (!get("can_enter_brimhaven_dungeon", false)) {
-                queue("saniboch_door_access_check") {
-                    statement("You can't go in there without paying!")
-                }
+                statement("You can't go in there without paying!")
                 return@objTeleportTakeOff Teleport.CONTINUE
             }
 

--- a/game/src/main/kotlin/content/area/karamja/brimhaven/Saniboch.kt
+++ b/game/src/main/kotlin/content/area/karamja/brimhaven/Saniboch.kt
@@ -9,7 +9,6 @@ import world.gregs.voidps.engine.Script
 import world.gregs.voidps.engine.entity.character.player.Teleport
 import world.gregs.voidps.engine.inv.inventory
 import world.gregs.voidps.engine.inv.remove
-import world.gregs.voidps.engine.queue.queue
 
 class Saniboch : Script {
 

--- a/game/src/main/kotlin/content/area/misthalin/ClanCupPlaque.kt
+++ b/game/src/main/kotlin/content/area/misthalin/ClanCupPlaque.kt
@@ -13,21 +13,25 @@ class ClanCupPlaque : Script {
             interfaces.sendText("clan_cup_interface", "main_text", "Current Winners")
             interfaces.sendText("clan_cup_interface", "sub_text", "The victorious winners of the 2010 Jagex Clan Cup<br><br>Combat - Runescape Dinasty<br>Skilling - Divination<br>Combined - BasedIn2Minutes")
         }
+
         interfaceOption("Current-winners", "clan_cup_interface:current_winners_button") {
             interfaces.sendText("clan_cup_interface", "current_winners", "Current")
             interfaces.sendText("clan_cup_interface", "main_text", "Current Winners")
             interfaces.sendText("clan_cup_interface", "sub_text", "The victorious winners of the 2010 Jagex Clan Cup<br><br>Combat - Runescape Dinasty<br>Skilling - Divination<br>Combined - Basedin2minutes")
         }
+
         interfaceOption("Combat-winners", "clan_cup_interface:combat_winners_button") {
             interfaces.sendText("clan_cup_interface", "combat_winners", "Combat")
             interfaces.sendText("clan_cup_interface", "main_text", "Combat winners")
             interfaces.sendText("clan_cup_interface", "sub_text", "2010 - Runescape Dinasty<br>2009 - The Titans")
         }
+
         interfaceOption("Skilling-winners", "clan_cup_interface:skilling_winners_button") {
             interfaces.sendText("clan_cup_interface", "skilling_winners", "Skilling")
             interfaces.sendText("clan_cup_interface", "main_text", "Skilling Winners")
             interfaces.sendText("clan_cup_interface", "sub_text", "2010 - Divination<br> 2009 - Divination")
         }
+
         interfaceOption("Combined-winners", "clan_cup_interface:combined_winners_button") {
             interfaces.sendText("clan_cup_interface", "combined_winners", "Combined")
             interfaces.sendText("clan_cup_interface", "main_text", "Combined Winners")

--- a/game/src/main/kotlin/content/area/misthalin/barbarian_village/Dororan.kt
+++ b/game/src/main/kotlin/content/area/misthalin/barbarian_village/Dororan.kt
@@ -26,13 +26,11 @@ class Dororan : Script {
                 noInterest()
                 return@itemOnItem
             }
-            queue("engraving") {
-                item("dororans_engraved_ring", "You engrave 'Gudrun the Fair, Gudrun the Fiery' onto the ring.")
-                anim("engrave")
-                exp(Skill.Crafting, 125.0)
-                inventory.replace("ring_from_jeffery", "dororans_engraved_ring")
-                set("gunnars_ground", "engraved_ring")
-            }
+            item("dororans_engraved_ring", "You engrave 'Gudrun the Fair, Gudrun the Fiery' onto the ring.")
+            anim("engrave")
+            exp(Skill.Crafting, 125.0)
+            inventory.replace("ring_from_jeffery", "dororans_engraved_ring")
+            set("gunnars_ground", "engraved_ring")
         }
 
         npcOperate("Talk-to", "dororan_*") {

--- a/game/src/main/kotlin/content/area/misthalin/barbarian_village/Dororan.kt
+++ b/game/src/main/kotlin/content/area/misthalin/barbarian_village/Dororan.kt
@@ -21,11 +21,13 @@ class Dororan : Script {
 
     init {
         itemOnItem("chisel", "ring_from_jeffery") { _, _ ->
+            println("Item on item")
             if (quest("gunnars_ground") == "jeffery_ring") {
                 noInterest()
                 return@itemOnItem
             }
             item("dororans_engraved_ring", "You engrave 'Gudrun the Fair, Gudrun the Fiery' onto the ring.")
+            println("Engraved")
             anim("engrave")
             exp(Skill.Crafting, 125.0)
             inventory.replace("ring_from_jeffery", "dororans_engraved_ring")

--- a/game/src/main/kotlin/content/area/misthalin/barbarian_village/Dororan.kt
+++ b/game/src/main/kotlin/content/area/misthalin/barbarian_village/Dororan.kt
@@ -16,7 +16,6 @@ import world.gregs.voidps.engine.inv.add
 import world.gregs.voidps.engine.inv.carriesItem
 import world.gregs.voidps.engine.inv.inventory
 import world.gregs.voidps.engine.inv.replace
-import world.gregs.voidps.engine.queue.queue
 
 class Dororan : Script {
 

--- a/game/src/main/kotlin/content/area/misthalin/barbarian_village/stronghold_of_security/StrongholdOfSecurityLadders.kt
+++ b/game/src/main/kotlin/content/area/misthalin/barbarian_village/stronghold_of_security/StrongholdOfSecurityLadders.kt
@@ -8,16 +8,13 @@ import content.entity.player.dialogue.type.warning
 import world.gregs.voidps.engine.Script
 import world.gregs.voidps.engine.client.message
 import world.gregs.voidps.engine.entity.character.player.Teleport
-import world.gregs.voidps.engine.queue.queue
 import world.gregs.voidps.type.equals
 
 class StrongholdOfSecurityLadders(val teleports: ObjectTeleports) : Script {
 
     init {
         objTeleportLand("Climb-down", "stronghold_of_security_entrance") { _, _ ->
-            queue("stronghold_of_security_entrance") {
-                statement("You squeeze through the hole and find a ladder a few feet down leading into the Stronghold of Security.")
-            }
+            statement("You squeeze through the hole and find a ladder a few feet down leading into the Stronghold of Security.")
         }
 
         objTeleportTakeOff("Climb-up", "stronghold_war_ladder_up") { target, _ ->

--- a/game/src/main/kotlin/content/area/misthalin/barbarian_village/stronghold_of_security/StrongholdOfSecurityLadders.kt
+++ b/game/src/main/kotlin/content/area/misthalin/barbarian_village/stronghold_of_security/StrongholdOfSecurityLadders.kt
@@ -39,15 +39,13 @@ class StrongholdOfSecurityLadders(val teleports: ObjectTeleports) : Script {
             if (get("warning_stronghold_of_security_ladders", 0) == 7) {
                 return@objTeleportTakeOff Teleport.CONTINUE
             }
-            queue("stronghold_warning") {
-                if (!warning("stronghold_of_security_ladders")) {
-                    player<Shifty>("No thanks, I don't want to die!")
-                } else {
-                    message("You climb down the ladder to the next level.")
-                    clear("stronghold_safe_space")
-                    val definition = teleports.get(option)[target.tile.id]!!
-                    teleports.teleportContinue(this, definition, target)
-                }
+            if (!warning("stronghold_of_security_ladders")) {
+                player<Shifty>("No thanks, I don't want to die!")
+            } else {
+                message("You climb down the ladder to the next level.")
+                clear("stronghold_safe_space")
+                val definition = teleports.get(option)[target.tile.id]!!
+                teleports.teleportContinue(this, definition, target)
             }
             Teleport.CANCEL
         }

--- a/game/src/main/kotlin/content/area/misthalin/edgeville/monastery/EdgevilleMonastery.kt
+++ b/game/src/main/kotlin/content/area/misthalin/edgeville/monastery/EdgevilleMonastery.kt
@@ -11,26 +11,23 @@ import world.gregs.voidps.engine.client.variable.start
 import world.gregs.voidps.engine.entity.character.player.Teleport
 import world.gregs.voidps.engine.entity.character.player.skill.Skill
 import world.gregs.voidps.engine.entity.character.player.skill.level.Level.has
-import world.gregs.voidps.engine.queue.queue
 
 class EdgevilleMonastery : Script {
     init {
         objTeleportTakeOff("Climb-up", "monastery_ladder_up") { _, _ ->
             if (!get("edgeville_monastery_order_member", false)) {
-                queue("edgeville_monastery_member_dialogue") {
-                    npc<Neutral>("abbot_langley", "I'm sorry but only members of our order are allowed in the second level of the monastery.")
-                    choice {
-                        option<Neutral>("Well can I join your order?") {
-                            if (!has(Skill.Prayer, 31)) {
-                                npc<Neutral>("abbot_langley", "No. I am sorry, but I feel you are not devout enough.")
-                                message("You need a prayer level of 31 to join the order.")
-                                return@option
-                            }
-                            npc<Happy>("abbot_langley", "Ok, I see you are someone suitable for our order. You may join.")
-                            set("edgeville_monastery_order_member", true)
+                npc<Neutral>("abbot_langley", "I'm sorry but only members of our order are allowed in the second level of the monastery.")
+                choice {
+                    option<Neutral>("Well can I join your order?") {
+                        if (!has(Skill.Prayer, 31)) {
+                            npc<Neutral>("abbot_langley", "No. I am sorry, but I feel you are not devout enough.")
+                            message("You need a prayer level of 31 to join the order.")
+                            return@option
                         }
-                        option<Sad>("Oh, sorry.")
+                        npc<Happy>("abbot_langley", "Ok, I see you are someone suitable for our order. You may join.")
+                        set("edgeville_monastery_order_member", true)
                     }
+                    option<Sad>("Oh, sorry.")
                 }
                 return@objTeleportTakeOff Teleport.CANCEL
             }

--- a/game/src/main/kotlin/content/area/misthalin/lumbridge/catacomb/LumbridgeCatacombs.kt
+++ b/game/src/main/kotlin/content/area/misthalin/lumbridge/catacomb/LumbridgeCatacombs.kt
@@ -40,11 +40,8 @@ class LumbridgeCatacombs : Script {
                 "unstarted" -> {
                     val xenia = NPCs.findBySpawnOrNull(Tile(3244, 3198), "xenia")
                     if (xenia != null) {
-                        queue("xenia_greet") {
-                            talkWith(xenia) {
-                                npc<Neutral>("Hey! I want to talk to you!")
-                            }
-                        }
+                        talkWith(xenia)
+                        npc<Neutral>("Hey! I want to talk to you!")
                     }
                     Teleport.CANCEL
                 }
@@ -52,23 +49,19 @@ class LumbridgeCatacombs : Script {
                 else -> {
                     setInstanceLogout(Tile(3246, 3198, 0))
                     if (quest("blood_pact") == "started") {
-                        longQueue("blood_pact_intro") {
-                            open("fade_out")
-                            delay(1)
-                            cutscene()
-                        }
+                        open("fade_out")
+                        delay(1)
+                        cutscene()
                     } else {
-                        longQueue("blood_pact_reenter") {
-                            open("fade_out")
-                            delay(1)
-                            smallInstance(Region(15446))
-                            val offset = instanceOffset()
-                            val destination = offset.tile(3877, 5528, 1)
-                            tele(destination)
-                            face(Direction.NORTH)
-                            respawnInstance(offset)
-                            open("fade_in")
-                        }
+                        open("fade_out")
+                        delay(1)
+                        smallInstance(Region(15446))
+                        val offset = instanceOffset()
+                        val destination = offset.tile(3877, 5528, 1)
+                        tele(destination)
+                        face(Direction.NORTH)
+                        respawnInstance(offset)
+                        open("fade_in")
                     }
                     Teleport.CANCEL
                 }

--- a/game/src/main/kotlin/content/area/misthalin/lumbridge/church/LumbridgeChurch.kt
+++ b/game/src/main/kotlin/content/area/misthalin/lumbridge/church/LumbridgeChurch.kt
@@ -23,7 +23,6 @@ import world.gregs.voidps.engine.event.AuditLog
 import world.gregs.voidps.engine.inv.inventory
 import world.gregs.voidps.engine.inv.remove
 import world.gregs.voidps.engine.queue.longQueue
-import world.gregs.voidps.engine.queue.queue
 import world.gregs.voidps.engine.timer.toTicks
 import world.gregs.voidps.type.Direction
 import world.gregs.voidps.type.Region
@@ -166,10 +165,7 @@ class LumbridgeChurch : Script {
         delay(1)
         sound("bigghost_appear")
         delay(1)
-        val ghost = NPCs.add("restless_ghost", ghostSpawn, Direction.SOUTH)
+        val ghost = NPCs.add("restless_ghost", ghostSpawn, Direction.SOUTH, ticks = TimeUnit.SECONDS.toTicks(60))
         ghost.animDelay("restless_ghost_awakens")
-        ghost.queue("despawn", TimeUnit.SECONDS.toTicks(60)) {
-            NPCs.remove(ghost)
-        }
     }
 }

--- a/game/src/main/kotlin/content/area/misthalin/lumbridge/swamp/Shamus.kt
+++ b/game/src/main/kotlin/content/area/misthalin/lumbridge/swamp/Shamus.kt
@@ -80,10 +80,7 @@ class Shamus : Script {
                 npc<Angry>("Hey! Yer big elephant! Don't go choppin' down me house, now!")
                 return@objectOperate
             }
-            shamus = NPCs.add("shamus", Tile(3139, 3211))
-            shamus.queue("shamus_despawn", TimeUnit.SECONDS.toTicks(60)) {
-                NPCs.remove(shamus)
-            }
+            shamus = NPCs.add("shamus", Tile(3139, 3211), ticks = TimeUnit.SECONDS.toTicks(60))
             talkWith(shamus)
             interactNpc(shamus, "Talk-to")
         }

--- a/game/src/main/kotlin/content/area/misthalin/lumbridge/swamp/Shamus.kt
+++ b/game/src/main/kotlin/content/area/misthalin/lumbridge/swamp/Shamus.kt
@@ -17,7 +17,6 @@ import world.gregs.voidps.engine.client.ui.dialogue.talkWith
 import world.gregs.voidps.engine.entity.character.npc.NPC
 import world.gregs.voidps.engine.entity.character.npc.NPCs
 import world.gregs.voidps.engine.entity.character.player.Player
-import world.gregs.voidps.engine.queue.queue
 import world.gregs.voidps.engine.timer.toTicks
 import world.gregs.voidps.type.Tile
 import java.util.concurrent.TimeUnit

--- a/game/src/main/kotlin/content/area/misthalin/paterdomus/Drezel.kt
+++ b/game/src/main/kotlin/content/area/misthalin/paterdomus/Drezel.kt
@@ -24,7 +24,6 @@ import content.quest.refreshQuestJournal
 import world.gregs.voidps.engine.Script
 import world.gregs.voidps.engine.client.message
 import world.gregs.voidps.engine.client.ui.dialogue.talkWith
-import world.gregs.voidps.engine.entity.World.queue
 import world.gregs.voidps.engine.entity.character.jingle
 import world.gregs.voidps.engine.entity.character.npc.NPCs
 import world.gregs.voidps.engine.entity.character.player.Player
@@ -638,7 +637,7 @@ class Drezel : Script {
     }
 
     private fun Player.sendQuestReward() {
-        queue("quest_complete") {
+        longQueue("quest_complete") {
             jingle("quest_complete_1")
             exp(Skill.Prayer, 1406.0)
             addOrDrop("wolfbane")

--- a/game/src/main/kotlin/content/area/wilderness/WildernessLevers.kt
+++ b/game/src/main/kotlin/content/area/wilderness/WildernessLevers.kt
@@ -12,7 +12,6 @@ import world.gregs.voidps.engine.entity.character.player.Teleport
 import world.gregs.voidps.engine.entity.character.player.chat.ChatType
 import world.gregs.voidps.engine.entity.character.sound
 import world.gregs.voidps.engine.entity.obj.GameObject
-import world.gregs.voidps.engine.queue.queue
 
 class WildernessLevers(val teleports: ObjectTeleports) : Script {
 

--- a/game/src/main/kotlin/content/area/wilderness/WildernessLevers.kt
+++ b/game/src/main/kotlin/content/area/wilderness/WildernessLevers.kt
@@ -19,34 +19,28 @@ class WildernessLevers(val teleports: ObjectTeleports) : Script {
     init {
         objTeleportTakeOff("Pull", "lever_*") { target, option ->
             if (target.def(this).stringId == "lever_ardougne_edgeville" && get("wilderness_lever_warning", true)) {
-                queue("wilderness_lever_warning") {
-                    statement("Warning! Pulling the lever will teleport you deep into the Wilderness.")
-                    choice("Are you sure you wish to pull it?") {
-                        option("Yes I'm brave.") {
-                            pullLever(target)
-                        }
-                        option("Eeep! The Wilderness... No thank you.") {
-                            return@option
-                        }
-                        option("Yes please, don't show this message again.") {
-                            set("wilderness_lever_warning", false)
-                            pullLever(target)
-                        }
+                statement("Warning! Pulling the lever will teleport you deep into the Wilderness.")
+                choice("Are you sure you wish to pull it?") {
+                    option("Yes I'm brave.") {
+                        pullLever(target)
+                    }
+                    option("Eeep! The Wilderness... No thank you.")
+                    option("Yes please, don't show this message again.") {
+                        set("wilderness_lever_warning", false)
+                        pullLever(target)
                     }
                 }
                 return@objTeleportTakeOff Teleport.CANCEL
             }
             pullLever(this)
-            queue("pull_lever") {
-                val definition = teleports.get("Pull")[target.tile.id]!!
-                val tile = teleports.teleportTile(this, definition)
-                anim("teleport_modern")
-                sound("teleport")
-                gfx("teleport_modern")
-                delay(3)
-                tele(tile)
-                Teleport.land(this, target, option)
-            }
+            val definition = teleports.get("Pull")[target.tile.id]!!
+            val tile = teleports.teleportTile(this, definition)
+            anim("teleport_modern")
+            sound("teleport")
+            gfx("teleport_modern")
+            delay(3)
+            tele(tile)
+            Teleport.land(this, target, option)
             return@objTeleportTakeOff Teleport.CANCEL
         }
 

--- a/game/src/main/kotlin/content/area/wilderness/chaos_tunnels/ChaosTunnels.kt
+++ b/game/src/main/kotlin/content/area/wilderness/chaos_tunnels/ChaosTunnels.kt
@@ -6,7 +6,6 @@ import world.gregs.voidps.engine.Script
 import world.gregs.voidps.engine.entity.character.player.Player
 import world.gregs.voidps.engine.entity.character.player.Teleport
 import world.gregs.voidps.engine.entity.obj.GameObject
-import world.gregs.voidps.engine.queue.queue
 
 class ChaosTunnels(val teleports: ObjectTeleports) : Script {
     init {

--- a/game/src/main/kotlin/content/area/wilderness/chaos_tunnels/ChaosTunnels.kt
+++ b/game/src/main/kotlin/content/area/wilderness/chaos_tunnels/ChaosTunnels.kt
@@ -7,7 +7,6 @@ import world.gregs.voidps.engine.entity.character.player.Player
 import world.gregs.voidps.engine.entity.character.player.Teleport
 import world.gregs.voidps.engine.entity.obj.GameObject
 import world.gregs.voidps.engine.queue.queue
-import world.gregs.voidps.type.equals
 
 class ChaosTunnels(val teleports: ObjectTeleports) : Script {
     init {
@@ -24,14 +23,12 @@ class ChaosTunnels(val teleports: ObjectTeleports) : Script {
         }
     }
 
-    private fun Player.rift(target: GameObject, direction: String): Int = if (get("warning_chaos_tunnels_$direction", 0) == 7) {
+    private suspend fun Player.rift(target: GameObject, direction: String): Int = if (get("warning_chaos_tunnels_$direction", 0) == 7) {
         Teleport.CONTINUE
     } else {
-        queue("warning_chaos_tunnels_$direction") {
-            if (warning("chaos_tunnels_$direction")) {
-                val definition = teleports.get("Enter")[target.tile.id]!!
-                teleports.teleportContinue(this@rift, definition, target)
-            }
+        if (warning("chaos_tunnels_$direction")) {
+            val definition = teleports.get("Enter")[target.tile.id]!!
+            teleports.teleportContinue(this@rift, definition, target)
         }
         Teleport.CANCEL
     }

--- a/game/src/main/kotlin/content/area/wilderness/chaos_tunnels/HuntForSurok.kt
+++ b/game/src/main/kotlin/content/area/wilderness/chaos_tunnels/HuntForSurok.kt
@@ -61,19 +61,17 @@ class HuntForSurok(val teleports: ObjectTeleports) : Script {
                     val instance = smallInstance(Region(12374))
                     setInstanceLogout(Tile(3142, 5545))
                     gfx("curse_impact")
-                    queue("enter_bork_lair") {
-                        val cutscene = startCutscene("bork", instance, instanceOffset())
-                        cutscene.onEnd(destroyInstance = false) {
-                            tele(3142, 5545)
-                            clearCamera()
-                        }
-                        if (get("bork_kill_count", 0) == 0) {
-                            cutscene()
-                        } else {
-                            repeat()
-                        }
-                        cutscene.end(destroyInstance = false, invokeEnd = false)
+                    val cutscene = startCutscene("bork", instance, instanceOffset())
+                    cutscene.onEnd(destroyInstance = false) {
+                        tele(3142, 5545)
+                        clearCamera()
                     }
+                    if (get("bork_kill_count", 0) == 0) {
+                        cutscene()
+                    } else {
+                        repeat()
+                    }
+                    cutscene.end(destroyInstance = false, invokeEnd = false)
                 }
                 Teleport.CANCEL
             } else {

--- a/game/src/main/kotlin/content/area/wilderness/chaos_tunnels/HuntForSurok.kt
+++ b/game/src/main/kotlin/content/area/wilderness/chaos_tunnels/HuntForSurok.kt
@@ -30,7 +30,6 @@ import world.gregs.voidps.engine.entity.character.npc.NPCs
 import world.gregs.voidps.engine.entity.character.player.Player
 import world.gregs.voidps.engine.entity.character.player.Teleport
 import world.gregs.voidps.engine.entity.character.player.name
-import world.gregs.voidps.engine.queue.queue
 import world.gregs.voidps.engine.timer.epochSeconds
 import world.gregs.voidps.type.Direction
 import world.gregs.voidps.type.Region

--- a/game/src/main/kotlin/content/entity/npc/Sheep.kt
+++ b/game/src/main/kotlin/content/entity/npc/Sheep.kt
@@ -1,6 +1,5 @@
 package content.entity.npc
 
-import content.entity.effect.clearTransform
 import content.entity.effect.transform
 import content.entity.player.dialogue.*
 import content.entity.player.dialogue.type.player
@@ -17,7 +16,6 @@ import world.gregs.voidps.engine.entity.item.floor.FloorItems
 import world.gregs.voidps.engine.inv.add
 import world.gregs.voidps.engine.inv.carriesItem
 import world.gregs.voidps.engine.inv.inventory
-import world.gregs.voidps.engine.queue.queue
 import world.gregs.voidps.engine.timer.Timer
 import world.gregs.voidps.type.random
 

--- a/game/src/main/kotlin/content/entity/npc/Sheep.kt
+++ b/game/src/main/kotlin/content/entity/npc/Sheep.kt
@@ -102,8 +102,6 @@ class Sheep : Script {
         delay(1)
         areaSound("sheep_baa${if (colour == "black") "" else "2"}", target.tile)
         target.say("Baa!")
-        target.queue("regrow_wool", Settings["world.npcs.sheep.regrowTicks", 50]) {
-            target.clearTransform()
-        }
+        target.revert(Settings["world.npcs.sheep.regrowTicks", 50])
     }
 }

--- a/game/src/main/kotlin/content/entity/obj/ship/CharterShip.kt
+++ b/game/src/main/kotlin/content/entity/obj/ship/CharterShip.kt
@@ -18,7 +18,6 @@ import world.gregs.voidps.engine.entity.character.player.Player
 import world.gregs.voidps.engine.entity.character.player.chat.ChatType
 import world.gregs.voidps.engine.inv.inventory
 import world.gregs.voidps.engine.inv.remove
-import world.gregs.voidps.engine.queue.queue
 import world.gregs.voidps.type.Tile
 
 class CharterShip(val ships: CharterShips, val teles: ObjectTeleports) : Script {

--- a/game/src/main/kotlin/content/entity/obj/ship/CharterShip.kt
+++ b/game/src/main/kotlin/content/entity/obj/ship/CharterShip.kt
@@ -106,35 +106,33 @@ class CharterShip(val ships: CharterShips, val teles: ObjectTeleports) : Script 
                 return@interfaceOption
             }
             val readablePrice = price.toDigitGroupString()
-            queue("charter_ship") {
-                if (!inventory.contains("coins", price)) {
-                    choice("Sailing to ${component.toTitleCase()} costs $readablePrice coins.") {
-                        option("Choose again") {
-                            open("charter_ship_map")
-                        }
-                        option("No")
-                    }
-                    return@queue
-                }
-                statement("To sail to ${component.toTitleCase()} from here will cost you $readablePrice gold. Are you sure you want to pay that?")
-                choice {
-                    option("Ok") {
-                        if (inventory.remove("coins", price)) {
-                            jingle("sailing_theme_short")
-                            open("fade_out")
-                            delay(4)
-                            val teleport = teles.get("${component}_gangplank_enter", "Cross").first()
-                            tele(teleport.to)
-                            open("fade_in")
-                            delay(3)
-                            message("You pay the fare and sail to ${component.toTitleCase()}.", ChatType.Filter)
-                        }
-                    }
+            if (!inventory.contains("coins", price)) {
+                choice("Sailing to ${component.toTitleCase()} costs $readablePrice coins.") {
                     option("Choose again") {
                         open("charter_ship_map")
                     }
                     option("No")
                 }
+                return@interfaceOption
+            }
+            statement("To sail to ${component.toTitleCase()} from here will cost you $readablePrice gold. Are you sure you want to pay that?")
+            choice {
+                option("Ok") {
+                    if (inventory.remove("coins", price)) {
+                        jingle("sailing_theme_short")
+                        open("fade_out")
+                        delay(4)
+                        val teleport = teles.get("${component}_gangplank_enter", "Cross").first()
+                        tele(teleport.to)
+                        open("fade_in")
+                        delay(3)
+                        message("You pay the fare and sail to ${component.toTitleCase()}.", ChatType.Filter)
+                    }
+                }
+                option("Choose again") {
+                    open("charter_ship_map")
+                }
+                option("No")
             }
         }
     }

--- a/game/src/main/kotlin/content/entity/player/modal/tab/Emotes.kt
+++ b/game/src/main/kotlin/content/entity/player/modal/tab/Emotes.kt
@@ -14,7 +14,6 @@ import world.gregs.voidps.engine.entity.character.player.Player
 import world.gregs.voidps.engine.entity.character.player.equip.equipped
 import world.gregs.voidps.engine.entity.character.player.skill.Skill
 import world.gregs.voidps.engine.map.collision.blocked
-import world.gregs.voidps.engine.queue.strongQueue
 import world.gregs.voidps.network.login.protocol.visual.update.player.EquipSlot
 import world.gregs.voidps.type.Direction
 import world.gregs.voidps.type.random
@@ -40,40 +39,35 @@ class Emotes : Script {
         }
 
         interfaceOption(id = "emotes:*") {
-            if (queue.contains("emote")) {
-                return@interfaceOption
-            }
             val id = it.option.toSnakeCase()
             val componentId = InterfaceDefinitions.getComponent(it.id, it.component)!!
             if (componentId.index > 23 && !unlocked(id, it.option)) {
                 return@interfaceOption
             }
-            strongQueue("emote") {
-                when (id) {
-                    "skillcape" -> {
-                        val cape = equipped(EquipSlot.Cape)
-                        val skill: Skill? = cape.def.getOrNull<Int>("skillcape_skill")?.let { int -> Skill.all[int] }
-                        when {
-                            cape.id == "quest_point_cape" -> playSkillCapeEmote("quest_point")
-                            cape.id == "dungeoneering_master_cape" -> playDungeoneeringMasterCapeEmote()
-                            skill == Skill.Dungeoneering -> playDungeoneeringCapeEmote()
-                            skill != null -> playSkillCapeEmote(skill.name.lowercase())
-                        }
+            when (id) {
+                "skillcape" -> {
+                    val cape = equipped(EquipSlot.Cape)
+                    val skill: Skill? = cape.def.getOrNull<Int>("skillcape_skill")?.let { int -> Skill.all[int] }
+                    when {
+                        cape.id == "quest_point_cape" -> playSkillCapeEmote("quest_point")
+                        cape.id == "dungeoneering_master_cape" -> playDungeoneeringMasterCapeEmote()
+                        skill == Skill.Dungeoneering -> playDungeoneeringCapeEmote()
+                        skill != null -> playSkillCapeEmote(skill.name.lowercase())
                     }
-                    "seal_of_approval" -> playSealOfApprovalEmote()
-                    "give_thanks" -> playGiveThanksEmote()
-                    "angry" if equipped(EquipSlot.Hat).id == "a_powdered_wig" -> playEnhancedEmote(id)
-                    "yawn" if equipped(EquipSlot.Hat).id == "sleeping_cap" -> playEnhancedYawnEmote()
-                    "bow" if equipped(EquipSlot.Legs).id == "pantaloons" -> playEnhancedEmote(id)
-                    "dance" if equipped(EquipSlot.Legs).id == "flared_trousers" -> playEnhancedEmote(id)
-                    "flap" if equipped(EquipSlot.Feet).id == "chicken_feet" && equipped(EquipSlot.Legs).id == "chicken_legs" && equipped(EquipSlot.Chest).id == "chicken_wings" && equipped(EquipSlot.Hat).id == "chicken_head" -> playEnhancedEmote(id)
-                    else -> {
-                        if (id == "air_guitar") {
-                            jingle(id)
-                        }
-                        gfx("emote_$id")
-                        animDelay("emote_$id")
+                }
+                "seal_of_approval" -> playSealOfApprovalEmote()
+                "give_thanks" -> playGiveThanksEmote()
+                "angry" if equipped(EquipSlot.Hat).id == "a_powdered_wig" -> playEnhancedEmote(id)
+                "yawn" if equipped(EquipSlot.Hat).id == "sleeping_cap" -> playEnhancedYawnEmote()
+                "bow" if equipped(EquipSlot.Legs).id == "pantaloons" -> playEnhancedEmote(id)
+                "dance" if equipped(EquipSlot.Legs).id == "flared_trousers" -> playEnhancedEmote(id)
+                "flap" if equipped(EquipSlot.Feet).id == "chicken_feet" && equipped(EquipSlot.Legs).id == "chicken_legs" && equipped(EquipSlot.Chest).id == "chicken_wings" && equipped(EquipSlot.Hat).id == "chicken_head" -> playEnhancedEmote(id)
+                else -> {
+                    if (id == "air_guitar") {
+                        jingle(id)
                     }
+                    gfx("emote_$id")
+                    animDelay("emote_$id")
                 }
             }
         }

--- a/game/src/main/kotlin/content/entity/player/modal/tab/ItemEmotes.kt
+++ b/game/src/main/kotlin/content/entity/player/modal/tab/ItemEmotes.kt
@@ -116,12 +116,10 @@ class ItemEmotes : Script {
                 message("Please wait till you've finished performing your current emote.")
                 return@itemOption
             }
-            queue("snow_globe") {
-                message("You shake the snow globe.")
-                animDelay("emote_shake_snow_globe")
-                jingle("harmony_snow_globe")
-                open("snow_globe")
-            }
+            message("You shake the snow globe.")
+            animDelay("emote_shake_snow_globe")
+            jingle("harmony_snow_globe")
+            open("snow_globe")
         }
 
         for (option in listOf("Play", "Loop", "Walk", "Crazy")) {

--- a/game/src/main/kotlin/content/minigame/barrows/BarrowsCrypts.kt
+++ b/game/src/main/kotlin/content/minigame/barrows/BarrowsCrypts.kt
@@ -20,7 +20,6 @@ import world.gregs.voidps.engine.entity.character.player.skill.Skill
 import world.gregs.voidps.engine.entity.character.sound
 import world.gregs.voidps.engine.entity.item.Item
 import world.gregs.voidps.engine.map.collision.random
-import world.gregs.voidps.engine.queue.queue
 import world.gregs.voidps.engine.timer.Timer
 import world.gregs.voidps.engine.timer.toTicks
 import world.gregs.voidps.type.Direction
@@ -172,11 +171,8 @@ class BarrowsCrypts : Script {
                 random < 76 -> "bloodworm" // 32/128
                 else -> "skeleton_barrows" // 52/128
             }
-            val npc = NPCs.add(id, spawn)
+            val npc = NPCs.add(id, spawn, ticks = TimeUnit.MINUTES.toTicks(2))
             npc.interactPlayer(this, "Attack")
-            npc.queue("despawn", TimeUnit.MINUTES.toTicks(2)) {
-                NPCs.remove(npc)
-            }
         }
     }
 

--- a/game/src/main/kotlin/content/quest/member/ghosts_ahoy/Ectopool.kt
+++ b/game/src/main/kotlin/content/quest/member/ghosts_ahoy/Ectopool.kt
@@ -33,13 +33,11 @@ class Ectopool : Script {
                 return@objTeleportTakeOff Teleport.CANCEL
             }
             anim("jump_up")
-            queue("jump_to") {
-                val teleports = get<ObjectTeleports>()
-                val definition = teleports.get(target.id, option).first()
-                val tile = teleports.teleportTile(this, definition)
-                tele(tile.addX(1))
-                exactMoveDelay(tile, startDelay = 49, delay = 68, direction = Direction.WEST)
-            }
+            val teleports = get<ObjectTeleports>()
+            val definition = teleports.get(target.id, option).first()
+            val tile = teleports.teleportTile(this, definition)
+            tele(tile.addX(1))
+            exactMoveDelay(tile, startDelay = 49, delay = 68, direction = Direction.WEST)
             return@objTeleportTakeOff Teleport.CANCEL
         }
     }

--- a/game/src/main/kotlin/content/quest/member/ghosts_ahoy/Ectopool.kt
+++ b/game/src/main/kotlin/content/quest/member/ghosts_ahoy/Ectopool.kt
@@ -8,7 +8,6 @@ import world.gregs.voidps.engine.entity.character.player.Teleport
 import world.gregs.voidps.engine.entity.character.player.skill.Skill
 import world.gregs.voidps.engine.entity.character.player.skill.level.Level.has
 import world.gregs.voidps.engine.get
-import world.gregs.voidps.engine.queue.queue
 import world.gregs.voidps.type.Direction
 
 class Ectopool : Script {

--- a/game/src/main/kotlin/content/quest/member/ogre/ZogreFleshEaters.kt
+++ b/game/src/main/kotlin/content/quest/member/ogre/ZogreFleshEaters.kt
@@ -295,7 +295,6 @@ class ZogreFleshEaters : Script {
                     set("thzfe_sithik_transformed", 1)
                 }
             }
-
             Teleport.CONTINUE
         }
 

--- a/game/src/main/kotlin/content/quest/member/plague_city/PlagueCity.kt
+++ b/game/src/main/kotlin/content/quest/member/plague_city/PlagueCity.kt
@@ -17,7 +17,6 @@ import world.gregs.voidps.engine.entity.character.sound
 import world.gregs.voidps.engine.inv.carriesItem
 import world.gregs.voidps.engine.inv.inventory
 import world.gregs.voidps.engine.inv.remove
-import world.gregs.voidps.engine.queue.queue
 import world.gregs.voidps.network.login.protocol.visual.update.player.EquipSlot
 
 class PlagueCity : Script {
@@ -556,17 +555,13 @@ class PlagueCity : Script {
 
         crafted { def ->
             if (def.add.any { it.id == "chocolatey_milk" }) {
-                queue("milk") {
-                    item("chocolatey_milk", "You mix the chocolate into the bucket.")
-                }
+                item("chocolatey_milk", "You mix the chocolate into the bucket.")
             }
         }
 
         crafted { def ->
             if (def.add.any { it.id == "hangover_cure" }) {
-                queue("cure") {
-                    item("hangover_cure", "You mix the snape grass into the bucket.")
-                }
+                item("hangover_cure", "You mix the snape grass into the bucket.")
             }
         }
     }

--- a/game/src/main/kotlin/content/skill/farming/Baskets.kt
+++ b/game/src/main/kotlin/content/skill/farming/Baskets.kt
@@ -87,12 +87,10 @@ class Baskets : Script {
 
             itemOption("Remove-one", "${fruit.plural}_#") { (item, slot) ->
                 val current = item.id.removePrefix("${fruit.plural}_").toInt()
-
                 inventory.transaction {
                     add(id)
                     replace(slot, item.id, if (current == 1) "basket" else "${fruit.plural}_${current - 1}")
                 }
-
                 when (inventory.transaction.error) {
                     is TransactionError.Full -> inventoryFull()
                     TransactionError.None -> message("You take ${fruit.description} out of the ${fruit.name} basket.")

--- a/game/src/main/kotlin/content/skill/farming/PlantPots.kt
+++ b/game/src/main/kotlin/content/skill/farming/PlantPots.kt
@@ -15,7 +15,9 @@ class PlantPots : Script {
         itemOnObjectOperate("plant_pot_empty", "*_patch_weeds_*") {
             message("This patch needs weeding first.")
         }
+
         itemOnObjectOperate("plant_pot_empty", "*_patch_weeded", handler = ::plantPot)
+
         itemOnItem("watering_can_0", "*_seedling") { _, _ ->
             message("You need to fill the watering can first.")
         }

--- a/game/src/main/kotlin/content/skill/magic/book/modern/Alchemy.kt
+++ b/game/src/main/kotlin/content/skill/magic/book/modern/Alchemy.kt
@@ -22,7 +22,6 @@ import world.gregs.voidps.engine.inv.inventory
 import world.gregs.voidps.engine.inv.transact.TransactionError
 import world.gregs.voidps.engine.inv.transact.operation.AddItem.add
 import world.gregs.voidps.engine.inv.transact.operation.RemoveItem.remove
-import world.gregs.voidps.engine.queue.queue
 
 class Alchemy : Script {
     init {
@@ -33,17 +32,14 @@ class Alchemy : Script {
             }
             val spell = id.substringAfter(":")
             if (item.def.cost >= get("alchemy_warning_limit", Settings["magic.alchemy.warningLimit", 25_000])) {
-                queue("alch_warning") {
-                    choice("The item you are about to alch has a high value.") {
-                        option("I wish to continue.") {
-                            alch(this, spell, item)
-                        }
-                        option("I do not want to alch this item.")
+                choice("The item you are about to alch has a high value.") {
+                    option("I wish to continue.") {
+                        alch(this, spell, item)
                     }
+                    option("I do not want to alch this item.")
                 }
                 return@onItem
             }
-
             alch(this, spell, item)
         }
     }

--- a/game/src/main/kotlin/content/skill/runecrafting/MysteriousRuins.kt
+++ b/game/src/main/kotlin/content/skill/runecrafting/MysteriousRuins.kt
@@ -63,16 +63,14 @@ class MysteriousRuins(val teleports: ObjectTeleports) : Script {
 
         objTeleportTakeOff("Enter", "*_altar_portal") { target, option ->
             if (target.id == "chaos_altar_portal" && !hasClock("chaos_altar_skip")) {
-                queue("chaos_altar_check") {
-                    statement("Warning! This portal will teleport you into the Wilderness.")
-                    choice("Are you sure you wish to use this portal?") {
-                        option("Yes, I'm brave.") {
-                            start("chaos_altar_skip", 1)
-                            teleports.teleport(this, target, option, target.def(this))
-                        }
-                        option("Eeep! The Wilderness... No thank you.") {
-                            message("You decide not to use this portal.")
-                        }
+                statement("Warning! This portal will teleport you into the Wilderness.")
+                choice("Are you sure you wish to use this portal?") {
+                    option("Yes, I'm brave.") {
+                        start("chaos_altar_skip", 1)
+                        teleports.teleport(this, target, option, target.def(this))
+                    }
+                    option("Eeep! The Wilderness... No thank you.") {
+                        message("You decide not to use this portal.")
                     }
                 }
                 return@objTeleportTakeOff Teleport.CANCEL

--- a/game/src/main/kotlin/content/skill/runecrafting/MysteriousRuins.kt
+++ b/game/src/main/kotlin/content/skill/runecrafting/MysteriousRuins.kt
@@ -12,7 +12,6 @@ import world.gregs.voidps.engine.entity.character.player.Player
 import world.gregs.voidps.engine.entity.character.player.Teleport
 import world.gregs.voidps.engine.entity.character.player.equip.equipped
 import world.gregs.voidps.engine.entity.character.sound
-import world.gregs.voidps.engine.queue.queue
 import world.gregs.voidps.network.login.protocol.visual.update.player.EquipSlot
 import world.gregs.voidps.type.equals
 

--- a/game/src/main/kotlin/content/skill/slayer/EnchantedGem.kt
+++ b/game/src/main/kotlin/content/skill/slayer/EnchantedGem.kt
@@ -13,22 +13,19 @@ import world.gregs.voidps.engine.Script
 import world.gregs.voidps.engine.client.message
 import world.gregs.voidps.engine.data.definition.Tables
 import world.gregs.voidps.engine.entity.character.player.name
-import world.gregs.voidps.engine.queue.queue
 
 class EnchantedGem : Script {
 
     init {
         itemOption("Activate", "enchanted_gem") {
-            queue("enchanted_gem_activate") {
-                val master = slayerMaster
-                npc<Happy>(master, "Hello there ${this@itemOption.name}, what can I help you with?")
-                choice {
-                    howAmIDoing()
-                    whoAreYou()
-                    whereAreYou()
-                    anyTips()
-                    option<Neutral>("That's all thanks.")
-                }
+            val master = slayerMaster
+            npc<Happy>(master, "Hello there ${this@itemOption.name}, what can I help you with?")
+            choice {
+                howAmIDoing()
+                whoAreYou()
+                whereAreYou()
+                anyTips()
+                option<Neutral>("That's all thanks.")
             }
         }
 

--- a/game/src/test/kotlin/InstructionCalls.kt
+++ b/game/src/test/kotlin/InstructionCalls.kt
@@ -183,8 +183,8 @@ fun Player.interfaceUse(
                 fromInterfaceId = 149,
                 fromComponentId = 0,
                 toInterfaceId = 149,
-                toComponentId = 0
-            )
+                toComponentId = 0,
+            ),
         )
     }
 }
@@ -294,8 +294,8 @@ fun Player.itemOnItem(
                 fromInterfaceId = 149,
                 fromComponentId = 0,
                 toInterfaceId = 149,
-                toComponentId = 0
-            )
+                toComponentId = 0,
+            ),
         )
     }
 }

--- a/game/src/test/kotlin/InstructionCalls.kt
+++ b/game/src/test/kotlin/InstructionCalls.kt
@@ -174,7 +174,18 @@ fun Player.interfaceUse(
 ) {
     Assertions.assertTrue(hasOpen(id)) { "Player $this doesn't have interface $id open" }
     runTest {
-        InterfaceApi.itemOnItem(this@interfaceUse, fromItem, toItem, fromSlot, toSlot)
+        instructions.trySend(
+            InteractInterfaceItem(
+                fromItem = fromItem.def.id,
+                toItem = toItem.def.id,
+                fromSlot = fromSlot,
+                toSlot = toSlot,
+                fromInterfaceId = 149,
+                fromComponentId = 0,
+                toInterfaceId = 149,
+                toComponentId = 0
+            )
+        )
     }
 }
 
@@ -274,7 +285,18 @@ fun Player.itemOnItem(
 ) {
     val inv = inventories.inventory("inventory")
     runTest {
-        InterfaceApi.itemOnItem(this@itemOnItem, inv[firstSlot], inv[secondSlot], firstSlot, secondSlot)
+        instructions.send(
+            InteractInterfaceItem(
+                fromItem = inv[firstSlot].def.id,
+                toItem = inv[secondSlot].def.id,
+                fromSlot = firstSlot,
+                toSlot = secondSlot,
+                fromInterfaceId = 149,
+                fromComponentId = 0,
+                toInterfaceId = 149,
+                toComponentId = 0
+            )
+        )
     }
 }
 

--- a/game/src/test/kotlin/InstructionCalls.kt
+++ b/game/src/test/kotlin/InstructionCalls.kt
@@ -173,7 +173,9 @@ fun Player.interfaceUse(
     toSlot: Int = -1,
 ) {
     Assertions.assertTrue(hasOpen(id)) { "Player $this doesn't have interface $id open" }
-    InterfaceApi.itemOnItem(this, fromItem, toItem, fromSlot, toSlot)
+    runTest {
+        InterfaceApi.itemOnItem(this@interfaceUse, fromItem, toItem, fromSlot, toSlot)
+    }
 }
 
 fun Player.interfaceSwitch(
@@ -271,7 +273,9 @@ fun Player.itemOnItem(
     secondSlot: Int,
 ) {
     val inv = inventories.inventory("inventory")
-    InterfaceApi.itemOnItem(this, inv[firstSlot], inv[secondSlot], firstSlot, secondSlot)
+    runTest {
+        InterfaceApi.itemOnItem(this@itemOnItem, inv[firstSlot], inv[secondSlot], firstSlot, secondSlot)
+    }
 }
 
 fun Player.npcOption(npc: NPC, option: String) {

--- a/game/src/test/kotlin/content/activity/penguin_hide_and_seek/PenguinHideAndSeekTest.kt
+++ b/game/src/test/kotlin/content/activity/penguin_hide_and_seek/PenguinHideAndSeekTest.kt
@@ -142,6 +142,7 @@ class PenguinHideAndSeekTest : WorldTest() {
         player.interfaces = interfaces
         player.dialogueContinue(4)
         player.itemOption("Read", "spy_notebook")
+        tick()
         assertTrue(player.containsMessage("You have recently spotted 2 penguins."))
         assertFalse(player.containsMessage("polar bear agent"))
         assertTrue(player.containsMessage("You have 3 Penguin Points to spend with Larry."))

--- a/game/src/test/kotlin/content/entity/player/inv/ItemOnItemsTest.kt
+++ b/game/src/test/kotlin/content/entity/player/inv/ItemOnItemsTest.kt
@@ -38,7 +38,6 @@ class ItemOnItemsTest : WorldTest() {
         player.inventory.add("chocolate_dust", 14)
 
         player.itemOnItem(12, 14)
-
         val amount = 5
         tick(1)
         player["skill_creation_amount"] = amount

--- a/game/src/test/kotlin/content/quest/member/tower_of_life/SatchelTest.kt
+++ b/game/src/test/kotlin/content/quest/member/tower_of_life/SatchelTest.kt
@@ -51,6 +51,7 @@ internal class SatchelTest : WorldTest() {
         player.inventory.add(item)
 
         player.itemOnItem(1, 0)
+        tick(1)
 
         assertNotEquals(0, player.inventory.charges(player, 0))
         assertFalse(player.inventory.contains(item))
@@ -64,6 +65,7 @@ internal class SatchelTest : WorldTest() {
         player.inventory.add(item)
 
         player.itemOnItem(1, 0)
+        tick(1)
 
         assertEquals(7, player.inventory.charges(player, 0))
         assertTrue(player.inventory.contains(item))

--- a/game/src/test/kotlin/content/skill/constitution/drink/TeaTest.kt
+++ b/game/src/test/kotlin/content/skill/constitution/drink/TeaTest.kt
@@ -104,6 +104,7 @@ internal class TeaTest : WorldTest() {
         player.inventory.add("empty_cup")
 
         player.itemOnItem(0, 1)
+        tick(1)
 
         assertTrue(player.inventory.contains("cup_of_tea"))
         assertEquals(0, player.inventory.charges(player, 0))
@@ -116,6 +117,7 @@ internal class TeaTest : WorldTest() {
         player.inventory.add("cup_of_tea")
 
         player.itemOnItem(1, 0)
+        tick(1)
 
         assertTrue(player.inventory.contains("empty_cup"))
         assertEquals(2, player.inventory.charges(player, 0))
@@ -128,6 +130,7 @@ internal class TeaTest : WorldTest() {
         player.inventory.add("cup_of_tea")
 
         player.itemOnItem(1, 0)
+        tick(1)
 
         assertTrue(player.inventory.contains("cup_of_tea"))
         assertEquals(5, player.inventory.charges(player, 0))

--- a/game/src/test/kotlin/content/skill/farming/PlantPotsTest.kt
+++ b/game/src/test/kotlin/content/skill/farming/PlantPotsTest.kt
@@ -19,6 +19,7 @@ class PlantPotsTest : WorldTest() {
         player.inventory.add("plant_pot_empty")
         player.inventory.add("gardening_trowel")
         player["farming_veg_patch_falador_se"] = "weeds_2"
+        println(GameObjects.at(Tile(3058, 3308)))
         val patch = GameObjects.find(Tile(3058, 3308), "farming_veg_patch_falador_se")
 
         player.itemOnObject(patch, 0)

--- a/game/src/test/kotlin/content/skill/magic/DungeoneeringBoxTest.kt
+++ b/game/src/test/kotlin/content/skill/magic/DungeoneeringBoxTest.kt
@@ -50,7 +50,7 @@ abstract class DungeoneeringBoxTest : WorldTest() {
         player.inventory.add(runes)
 
         player.itemOnItem(1, 0)
-        println(player.inventory.items)
+        tick(1)
 
         for (rune in runes) {
             assertFalse("Expected no $rune in inventory, ${player.inventory.count(rune.id)} found.") {

--- a/game/src/test/kotlin/content/skill/magic/DungeoneeringRewardStaffTest.kt
+++ b/game/src/test/kotlin/content/skill/magic/DungeoneeringRewardStaffTest.kt
@@ -22,6 +22,7 @@ abstract class DungeoneeringRewardStaffTest : WorldTest() {
         player.inventory.add(staff)
 
         player.itemOnItem(0, 1)
+        tick(1)
 
         assertEquals(0, player.inventory.count(rune))
         assertEquals(10, player.inventory.charges(player, 1))
@@ -35,6 +36,7 @@ abstract class DungeoneeringRewardStaffTest : WorldTest() {
         player.inventory.charge(player, 1, 995)
 
         player.itemOnItem(0, 1)
+        tick(1)
 
         assertEquals(5, player.inventory.count(rune))
         assertEquals(1000, player.inventory.charges(player, 1))
@@ -48,6 +50,7 @@ abstract class DungeoneeringRewardStaffTest : WorldTest() {
         player.inventory.charge(player, 1, 1000)
 
         player.itemOnItem(0, 1)
+        tick(1)
 
         assertEquals(10, player.inventory.count(rune))
         assertEquals(1000, player.inventory.charges(player, 1))

--- a/game/src/test/kotlin/content/skill/magic/book/lunar/FertileSoilTest.kt
+++ b/game/src/test/kotlin/content/skill/magic/book/lunar/FertileSoilTest.kt
@@ -2,6 +2,7 @@ package content.skill.magic.book.lunar
 
 import WorldTest
 import containsMessage
+import messages
 import org.junit.jupiter.api.Test
 import world.gregs.voidps.engine.client.instruction.handle.interactOn
 import world.gregs.voidps.engine.client.ui.open
@@ -56,19 +57,19 @@ class FertileSoilTest : WorldTest() {
 
     @Test
     fun `Can't fertilise other objects`() {
-        val player = createPlayer(Tile(3057, 3308))
+        val player = createPlayer(Tile(3062, 3310))
         player.levels.set(Skill.Magic, 83)
         player.open("lunar_spellbook")
         player.inventory.add("astral_rune", 3)
         player.inventory.add("nature_rune", 2)
         player.inventory.add("earth_rune", 15)
 
-        val obj = createObject("bank_booth", Tile(3058, 3308))
+        val obj = GameObjects.find(Tile(3061, 3311), "oak")
         player.interactOn(obj, "lunar_spellbook", "fertile_soil")
         tick(5)
 
         assertTrue(player.containsMessage("I don't want to fertilise that!"))
-        assertFalse(player.containsVarbit("patch_super_compost", "bank_booth"))
+        assertFalse(player.containsVarbit("patch_super_compost", "oak"))
         assertEquals(0.0, player.experience.get(Skill.Magic))
     }
 }

--- a/game/src/test/kotlin/content/skill/magic/book/lunar/FertileSoilTest.kt
+++ b/game/src/test/kotlin/content/skill/magic/book/lunar/FertileSoilTest.kt
@@ -2,7 +2,6 @@ package content.skill.magic.book.lunar
 
 import WorldTest
 import containsMessage
-import messages
 import org.junit.jupiter.api.Test
 import world.gregs.voidps.engine.client.instruction.handle.interactOn
 import world.gregs.voidps.engine.client.ui.open

--- a/game/src/test/kotlin/content/skill/mining/CoalBagTest.kt
+++ b/game/src/test/kotlin/content/skill/mining/CoalBagTest.kt
@@ -18,6 +18,7 @@ internal class CoalBagTest : WorldTest() {
         player.inventory.add("coal", 5)
 
         player.itemOnItem(0, 1)
+        tick(1)
 
         assertEquals(0, player.inventory.count("coal"))
         assertEquals(5, player["coal_bag_coal", 0])
@@ -31,6 +32,7 @@ internal class CoalBagTest : WorldTest() {
         player.inventory.add("coal", 5)
 
         player.itemOnItem(0, 1)
+        tick(1)
 
         assertEquals(0, player.inventory.count("coal"))
         assertEquals(15, player["coal_bag_coal", 0])
@@ -44,6 +46,7 @@ internal class CoalBagTest : WorldTest() {
         player.inventory.add("coal", 10)
 
         player.itemOnItem(0, 1)
+        tick(1)
 
         assertEquals(4, player.inventory.count("coal"))
         assertEquals(81, player["coal_bag_coal", 0])
@@ -57,6 +60,7 @@ internal class CoalBagTest : WorldTest() {
         player.inventory.add("coal", 5)
 
         player.itemOnItem(0, 1)
+        tick(1)
 
         assertEquals(5, player.inventory.count("coal"))
         assertEquals(81, player["coal_bag_coal", 0])

--- a/game/src/test/kotlin/content/skill/mining/GemBagTest.kt
+++ b/game/src/test/kotlin/content/skill/mining/GemBagTest.kt
@@ -19,6 +19,7 @@ internal class GemBagTest : WorldTest() {
         player.inventory.add("uncut_diamond", 4)
 
         player.itemOnItem(0, 1)
+        tick(1)
 
         assertEquals(0, player.inventory.count("uncut_emerald"))
         assertEquals(4, player.inventory.count("uncut_diamond"))
@@ -33,6 +34,7 @@ internal class GemBagTest : WorldTest() {
         player.inventory.add("uncut_ruby", 5)
 
         player.itemOnItem(0, 1)
+        tick(1)
 
         assertEquals(0, player.inventory.count("uncut_ruby"))
         assertEquals(15, player["gem_bag_ruby", 0])
@@ -49,6 +51,7 @@ internal class GemBagTest : WorldTest() {
         player.inventory.add("uncut_diamond", 5)
 
         player.itemOnItem(1, 0)
+        tick(1)
 
         assertEquals(3, player.inventory.count("uncut_diamond"))
         assertEquals(10, player["gem_bag_diamond", 0])
@@ -65,6 +68,7 @@ internal class GemBagTest : WorldTest() {
         player.inventory.add("uncut_sapphire", 5)
 
         player.itemOnItem(1, 0)
+        tick(1)
 
         assertEquals(5, player.inventory.count("uncut_sapphire"))
         assertEquals(25, player["gem_bag_sapphire", 0])

--- a/game/src/test/kotlin/content/skill/runecrafting/EssencePouchTest.kt
+++ b/game/src/test/kotlin/content/skill/runecrafting/EssencePouchTest.kt
@@ -153,6 +153,7 @@ internal class EssencePouchTest : WorldTest() {
         player.inventory.add("pure_essence", 2)
 
         player.itemOnItem(1, 0)
+        tick(1)
 
         assertEquals(1, player.inventory.count("rune_essence"))
         assertEquals(2, player.inventory.count("pure_essence"))
@@ -170,6 +171,7 @@ internal class EssencePouchTest : WorldTest() {
         player.inventory.add("pure_essence", 2)
 
         player.itemOnItem(3, 0)
+        tick(1)
 
         assertEquals(2, player.inventory.count("rune_essence"))
         assertEquals(2, player.inventory.count("pure_essence"))
@@ -187,6 +189,7 @@ internal class EssencePouchTest : WorldTest() {
         player.inventory.add("pure_essence", 2)
 
         player.itemOnItem(3, 0)
+        tick(1)
 
         assertEquals(2, player.inventory.count("rune_essence"))
         assertEquals(2, player.inventory.count("pure_essence"))


### PR DESCRIPTION
Closes #982
- Fix FertileSoilTest breaking other farming tests due to invalid object id
- Fix gnome glider right click option
- Make most interface handlers suspendable
- Remove unnecessary queues for dialogues in interface handlers
- Replace despawn queues for npcs with lifecycle calls