### PR TITLE
Add quest reset command & f2p bot limitations

### DIFF
--- a/data/bot/fletching.templates.toml
+++ b/data/bot/fletching.templates.toml
@@ -1,5 +1,6 @@
 [fletching_arrow_shafts_template]
 requires = [
+    { members = { req = true } },
     { bank = { id = "$logs", min = 27 } }
 ]
 setup = [
@@ -19,6 +20,7 @@ produces = [
 
 [fletching_shortbow_template]
 requires = [
+    { members = { req = true } },
     { bank = { id = "$logs", min = 27 } }
 ]
 setup = [
@@ -37,6 +39,7 @@ produces = [
 
 [fletching_longbow_template]
 requires = [
+    { members = { req = true } },
     { bank = { id = "$logs", min = 27 } }
 ]
 setup = [

--- a/data/bot/thieving.templates.toml
+++ b/data/bot/thieving.templates.toml
@@ -1,5 +1,6 @@
 [pickpocketting_template]
 requires = [
+    { members = { req = true } },
     { skill = { id = "constitution", min = 100 } },
     { skill = { id = "thieving", min = 1, max = 10 } },
 ]

--- a/data/quest/quests.toml
+++ b/data/quest/quests.toml
@@ -123,6 +123,15 @@ region = 39
 start_point = "Talk to one of the barbarian guards at the outer entrance of the Barbarian Outpost Agility Course."
 start_path = [[ 2544, 3569 ]]
 reward = "Access to the Barbarian Outpost agility course"
+variables = [
+  "bar_crawl_miniquest",
+  "barcrawl_signatures",
+  "alfred_grimhands_barcrawl",
+  "bar_crawl_started",
+]
+item = [
+  "barcrawl_card"
+]
 
 [between_a_rock]
 id = 19
@@ -213,6 +222,18 @@ req_items = "None."
 req_combat = "Must be able to defeat three low-level enemies."
 points = 1
 reward = "Reese's sword<br>Kayle's sling (requires no arrows)<br>Caitlin's staff (requires no air runes)<br>Access to the Lumbridge Catacombs dungeon"
+variables = [
+  "blood_pact",
+  "blood_pact_kayle",
+  "blood_pact_caitlin",
+  "blood_pact_reese",
+  "blood_pact_ilona_departed",
+]
+items = [
+  "reeses_sword",
+  "kayles_sling",
+  "caitlins_staff",
+]
 
 [blood_runs_deep]
 id = 163
@@ -393,6 +414,18 @@ req_combat = "None."
 points = 1
 reward = "500 coins<br>20 sardines<br>Access to the cook's range"
 xp = "300 Cooking XP"
+variables = [
+  "cooks_assistant",
+  "cooks_assistant_milk",
+  "cooks_assistant_egg",
+  "cooks_assistant_flour",
+  "cooks_assistant_talked_to_millie",
+]
+items = [
+  "super_large_egg",
+  "top_quality_milk",
+  "extra_fine_flour",
+]
 
 [creature_of_fenkenstrain]
 id = 26
@@ -586,6 +619,26 @@ req_combat = "You must defeat several cultists, and a powerful demon!"
 points = 3
 reward = "The holy sword, Silverlight<br>Avernic wand and book"
 xp = "3 combat XP lamps worth 100 XP each"
+variables = [
+  "demon_slayer",
+  "demon_slayer_aber",
+  "demon_slayer_camerinthum",
+  "demon_slayer_carlem",
+  "demon_slayer_gabindo",
+  "demon_slayer_purchai",
+  "demon_slayer_silverlight",
+  "demon_slayer_drain_dislodged",
+  "demon_slayer_summoned",
+  "demon_slayer_silverlight_case",
+  "demon_slayer_sir_prysin_sword",
+  "demon_slayer_bones",
+]
+items = [
+  "silverlight_key_wizard_traiborn",
+  "silverlight_key_captain_rovin",
+  "silverlight_key_sir_prysin",
+  "silverlight",
+]
 
 [desert_slayer_dungeon_miniquest]
 id = 285
@@ -714,6 +767,9 @@ req_combat = "None."
 points = 1
 reward = "180 coins<br>Access to Doric's anvils"
 xp = "1,300 Mining XP"
+variables = [
+  "dorics_quest"
+]
 
 [dragon_slayer]
 id = 4
@@ -764,6 +820,15 @@ req_combat = "None."
 points = 4
 reward = "15 noted guam<br>15 noted eye of newt"
 xp = "250 Herblore XP"
+variables = [
+  "druidic_ritual"
+]
+items = [
+  "enchanted_beef",
+  "enchanted_rat_meat",
+  "enchanted_bear_meat",
+  "enchanted_chicken",
+]
 
 [dwarf_cannon]
 id = 34
@@ -935,6 +1000,26 @@ req_skills = {
 }
 reward = "Access to the Abyss"
 xp = "1,000 Runecrafting XP"
+variables = [
+  "enter_the_abyss",
+  "abyss_obstacles",
+  "enter_abyss_knows_mages",
+  "enter_abyss_where_runes",
+  "enter_abyss_offer",
+  "enter_abyss_has_orb",
+  "enter_abyss_taken_orb",
+  "last_npc_teleport_to_rune_essence_mine",
+  "scrying_orb_sedridor",
+  "scrying_orb_aubury",
+  "scrying_orb_wizard_cromperty",
+  "scrying_orb_brimstail",
+  "scrying_orb_wizard_distentor",
+]
+items = [
+  "scrying_orb_full",
+  "scrying_orb",
+  "abyssal_book",
+]
 
 [ernest_the_chicken]
 id = 5
@@ -1300,6 +1385,16 @@ req_items = "Approximately 1,000 coins, thread, silk, spade, oak shieldbow, nett
 req_combat = "You will need to defeat a level 42 giant lobster."
 points = 2
 reward = "Free passage into Port Phasmatys<br>The ectophial"
+variables = [
+  "the_restless_ghost",
+  "restless_ghost_coffin",
+  "rocks_restless_ghost",
+]
+items = [
+  "ghostspeak_amulet",
+  "muddy_skull",
+  "ancient_bones_the_restless_ghost",
+]
 
 [the_giant_dwarf]
 id = 54
@@ -1491,6 +1586,28 @@ req_combat = "None."
 points = 5
 reward = "Swanky boots<br>Talk to Dororan for more Crafting tasks"
 xp = "300 Crafting XP<br>Antique lamp"
+variables = [
+  "gunnars_ground",
+  "kjell",
+  "dororan",
+  "gudrun",
+  "dororan_after_quest",
+  "gudrun_after_quest",
+  "dororan_after_cutscene",
+  "gudrun_after_cutscene",
+  "dororan_ruby_bracelet",
+  "dororan_dragonstone_necklace",
+  "dororan_onyx_amulet",
+]
+items = [
+  "ring_from_jeffery",
+  "dororans_engraved_ring",
+  "gunnars_ground",
+  "gunnars_ground_post_quest",
+  "love_poem",
+  "swanky_boots",
+  "swanky_boots_2",
+]
 
 [hand_in_the_sand]
 id = 57
@@ -1708,6 +1825,9 @@ req_combat = "Must be able to defeat multiple level 2 imps."
 points = 1
 reward = "An amulet of accuracy<br>Access to Mizgog's amulet shop"
 xp = "875 Magic XP"
+variables = [
+  "imp_catcher",
+]
 
 [in_aid_of_the_myreque]
 id = 64
@@ -1873,6 +1993,15 @@ req_combat = "You will need to defeat or evade level 54 enemies."
 points = 1
 reward = "Ability to smith blurite (members)"
 xp = "12,725 Smithing XP lamp"
+variables = [
+  "the_knights_sword"
+]
+items = [
+  "portrait",
+  "blurite_sword",
+  "blurite_ore",
+  "blurite_bar",
+]
 
 [lair_of_tarn_razorlor_miniquest]
 id = 296
@@ -1998,6 +2127,13 @@ req_items = "None."
 req_combat = "You will need to defeat a level 63 tree spirit."
 points = 3
 reward = "Access to Zanaris<br>Ability to wield dragon longswords and dragon daggers<br>Ability to craft cosmic runes<br>Access to Chaeldar the Slayer master (requires level 75 combat)"
+variables = [
+  "lost_city",
+]
+items = [
+  "dramen_branch",
+  "dramen_staff",
+]
 
 [lost_her_marbles_miniquest]
 id = 281
@@ -2334,6 +2470,16 @@ variables = [
   "ns_brown_correct",
   "ns_grey_correct"
 ]
+items = [
+  "druid_pouch",
+  "druid_pouch_2",
+  "silver_sickle_b",
+  "washing_bowl",
+  "mirror",
+  "journal_nature_spirit",
+  "druidic_spell",
+  "a_used_spell",
+]
 
 [nomads_requiem]
 id = 162
@@ -2502,6 +2648,26 @@ req_combat = "None."
 points = 1
 reward = "Ardougne Teleport spell<br>Access to West Ardougne<br>Gas mask"
 xp = "2,425 Mining XP"
+variables = [
+  "plague_city",
+  "plaguecity_hide_edmond_up_top",
+  "plaguecity_elena_at_home",
+  "plaguecity_dug_mud_pile",
+  "plaguecity_checked_grill",
+  "plaguecity_pipe",
+  "plaguecity_picture_asked",
+  "plaguecity_key_asked",
+]
+items = [
+  "warrant",
+  "hangover_cure",
+  "a_magic_scroll",
+  "gas_mask",
+  "a_small_key",
+  "a_scruffy_note",
+  "book_turnip_growing_for_beginners",
+  "picture_plague_city",
+]
 
 [priest_in_peril]
 id = 84
@@ -2532,6 +2698,20 @@ variables = [
   "priestperil_7_swapped",
   "priestperiltrappedmonk_hide"
 ]
+items = [
+  "pipkey_gold",
+  "pipkey_iron",
+  "piptinderbox_gold",
+  "pipcandle_gold",
+  "pippot_gold",
+  "piphammer_gold",
+  "pipfeather_gold",
+  "pipneedle_gold",
+  "wolfbane",
+  "bucket_murkywater",
+  "bucket_blessedwater",
+  "golden_tinderbox_2",
+]
 reward = "The blessed wolfbane dagger<br>5 kudos from Historian Minas at the Varrock Museum"
 
 [prince_ali_rescue]
@@ -2547,6 +2727,17 @@ req_items = "Soft clay, 3 balls of wool, yellow dye, redberries, ashes, bucket o
 req_combat = "You will need to get past aggressive level 26 jail guards."
 points = 3
 reward = "700 coins<br>Free passage through the Lumbridge - Al Kharid toll gate"
+variables = [
+  "prince_ali_rescue",
+  "prince_ali_rescue_leela",
+  "prince_ali_rescue_key_made",
+  "prince_ali_rescue_key_given",
+]
+items = [
+  "bronze_key_prince_ali_rescue",
+  "blue_partyhat_2",
+  "key_print",
+]
 
 [purple_cat_miniquest]
 id = 276
@@ -2999,6 +3190,14 @@ req_items = "None."
 req_combat = "None."
 points = 1
 reward = "An Air Talisman<br>The ability to mine rune essence"
+variables = [
+  "rune_mysteries"
+]
+items = [
+  "research_package_rune_mysteries",
+  "research_notes_rune_mysteries",
+  "talisman_rune_mysteries",
+]
 
 [scorpion_catcher]
 id = 93
@@ -3104,6 +3303,15 @@ start_path = [[ 3189, 3273 ]]
 req_combat = "None, but watch out for rams."
 xp = "150 Crafting XP"
 reward = "2000 coins"
+variables = [
+  "sheep_shearer_miniquest",
+  "sheep_shearer_black_balls_of_wool",
+  "the_thing_interacted",
+]
+items = [
+  "black_wool",
+  "ball_of_black_wool",
+]
 
 [shield_of_arrav]
 id = 15
@@ -3387,6 +3595,19 @@ req_combat = "None."
 points = 1
 reward = "Ability to collect Tears of Guthix once a week<br>Ability to make an ornate bowl for increased XP (requires 80 Mining and Crafting)<br>Juna teleport option on the games necklace"
 xp = "1,000 Crafting XP"
+variables = [
+  "tears_of_guthix",
+  "tears_of_guthix_time",
+  "tears_of_guthix_points",
+  "juna_stories",
+  "tears_of_guthix_cooldown",
+  "tears_reminder_cooldown",
+  "tears_reminder",
+]
+items = [
+  "magical_stone",
+  "stone_bowl",
+]
 
 [temple_at_senntisten]
 id = 157
@@ -3877,4 +4098,10 @@ variables = [
   "thzfe_brentle_skele",
   "thzfe_cut_scene",
   "thzfe_grish_warning_yes",
+]
+items = [
+  "zogre_ogre_trans_potion",
+  "necromancy_book",
+  "ogre_gate_key",
+  "ogre_coffin_key",
 ]

--- a/data/quest/quests.toml
+++ b/data/quest/quests.toml
@@ -129,7 +129,7 @@ variables = [
   "alfred_grimhands_barcrawl",
   "bar_crawl_started",
 ]
-item = [
+items = [
   "barcrawl_card"
 ]
 

--- a/data/skill/slayer/slayer.vars.toml
+++ b/data/skill/slayer/slayer.vars.toml
@@ -18,10 +18,6 @@ format = "int"
 persist = true
 format = "string"
 
-[slayer_task_streak]
-persist = true
-format = "int"
-
 [broader_fletching]
 persist = true
 format = "boolean"

--- a/game/src/main/kotlin/content/bot/behaviour/condition/BotMembers.kt
+++ b/game/src/main/kotlin/content/bot/behaviour/condition/BotMembers.kt
@@ -1,0 +1,10 @@
+package content.bot.behaviour.condition
+
+import world.gregs.voidps.engine.entity.World
+import world.gregs.voidps.engine.entity.character.player.Player
+
+data class BotMembers(val members: Boolean) : Condition(1) {
+    override fun keys() = setOf("members")
+    override fun events() = setOf("members")
+    override fun check(player: Player) = World.members == members
+}

--- a/game/src/main/kotlin/content/bot/behaviour/condition/Condition.kt
+++ b/game/src/main/kotlin/content/bot/behaviour/condition/Condition.kt
@@ -248,7 +248,7 @@ sealed class Condition(val priority: Int) {
 
         private fun parseMembers(list: List<Map<String, Any>>): BotMembers? {
             val map = list.single()
-            if (map.containsKey("members")) {
+            if (map.containsKey("req")) {
                 return BotMembers(map["req"] as Boolean)
             }
             return null

--- a/game/src/main/kotlin/content/bot/behaviour/condition/Condition.kt
+++ b/game/src/main/kotlin/content/bot/behaviour/condition/Condition.kt
@@ -94,6 +94,7 @@ sealed class Condition(val priority: Int) {
             "owns" -> parseOwns(list)
             "variable" -> parseVariable(list)
             "clock" -> parseClock(list)
+            "members" -> parseMembers(list)
             "timer" -> parseTimer(list)
             "queue" -> parseQueue(list)
             "area" -> parseArea(list)
@@ -241,6 +242,14 @@ sealed class Condition(val priority: Int) {
                     )
                 }
                 return BotHasClock(id = map["id"] as String)
+            }
+            return null
+        }
+
+        private fun parseMembers(list: List<Map<String, Any>>): BotMembers? {
+            val map = list.single()
+            if (map.containsKey("members")) {
+                return BotMembers(map["req"] as Boolean)
             }
             return null
         }

--- a/game/src/main/kotlin/content/entity/player/combat/CombatExperience.kt
+++ b/game/src/main/kotlin/content/entity/player/combat/CombatExperience.kt
@@ -48,9 +48,6 @@ class CombatExperience : Script {
                     grant(this, target, Skill.Ranged, damage / 2.5)
                 }
             }
-            if (target is NPC && isTask(target)) {
-                grant(this, target, Skill.Slayer, target.def["slayer_xp", 0.0])
-            }
             grant(this, target, Skill.Constitution, damage / 7.5)
         }
     }

--- a/game/src/main/kotlin/content/entity/player/combat/CombatExperience.kt
+++ b/game/src/main/kotlin/content/entity/player/combat/CombatExperience.kt
@@ -3,7 +3,6 @@ package content.entity.player.combat
 import content.entity.combat.hit.Hit
 import content.skill.melee.weapon.attackStyle
 import content.skill.melee.weapon.attackType
-import content.skill.slayer.isTask
 import world.gregs.voidps.engine.Script
 import world.gregs.voidps.engine.data.definition.Tables
 import world.gregs.voidps.engine.entity.character.Character

--- a/game/src/main/kotlin/content/entity/player/modal/tab/QuestJournals.kt
+++ b/game/src/main/kotlin/content/entity/player/modal/tab/QuestJournals.kt
@@ -23,7 +23,7 @@ import world.gregs.voidps.engine.timer.Timer
 
 class QuestJournals(
     val accounts: AccountDefinitions,
-    val questDefinitions: QuestDefinitions
+    val questDefinitions: QuestDefinitions,
 ) : Script {
 
     val logger = InlineLogger()

--- a/game/src/main/kotlin/content/entity/player/modal/tab/QuestJournals.kt
+++ b/game/src/main/kotlin/content/entity/player/modal/tab/QuestJournals.kt
@@ -1,15 +1,30 @@
 package content.entity.player.modal.tab
 
 import com.github.michaelbull.logging.InlineLogger
+import content.entity.player.bank.bank
+import content.entity.player.command.find
 import content.quest.refreshQuestJournal
 import world.gregs.voidps.engine.Script
 import world.gregs.voidps.engine.client.clearCamera
+import world.gregs.voidps.engine.client.command.adminCommand
+import world.gregs.voidps.engine.client.command.boolArg
+import world.gregs.voidps.engine.client.command.stringArg
 import world.gregs.voidps.engine.client.ui.InterfaceApi
 import world.gregs.voidps.engine.client.ui.closeInterfaces
+import world.gregs.voidps.engine.data.definition.AccountDefinitions
 import world.gregs.voidps.engine.data.definition.QuestDefinitions
+import world.gregs.voidps.engine.entity.character.player.Player
+import world.gregs.voidps.engine.entity.character.player.Players
+import world.gregs.voidps.engine.inv.beastOfBurden
+import world.gregs.voidps.engine.inv.equipment
+import world.gregs.voidps.engine.inv.inventory
+import world.gregs.voidps.engine.inv.removeToLimit
 import world.gregs.voidps.engine.timer.Timer
 
-class QuestJournals(val questDefinitions: QuestDefinitions) : Script {
+class QuestJournals(
+    val accounts: AccountDefinitions,
+    val questDefinitions: QuestDefinitions
+) : Script {
 
     val logger = InlineLogger()
 
@@ -66,5 +81,46 @@ class QuestJournals(val questDefinitions: QuestDefinitions) : Script {
                 set("quest_journal_order", type)
             }
         }
+
+        adminCommand(
+            "reset_quest",
+            stringArg("quest", desc = "Name of the quest to reset", autofill = questDefinitions.ids.keys),
+            boolArg("remove-items", desc = "Removes all quest related items from the player", optional = true),
+            stringArg("player-name", optional = true, autofill = accounts.displayNames.keys),
+            desc = "Resets a quest for the player",
+            handler = ::resetQuest,
+        )
+    }
+
+    /**
+     * Resets a player's progress on a quest
+     * Note: Not foolproof
+     *   - Doesn't remove them from a quest area
+     *   - Dropped quest items can avoid the reset
+     *   - Doesn't reset rewards
+     *   - Allows player to reclaim rewards (such as XP)
+     */
+    fun resetQuest(player: Player, args: List<String>) {
+        val target = Players.find(player, args.getOrNull(2)) ?: return
+        val id = args[0]
+        val def = questDefinitions.getOrNull(id) ?: return
+        val vars: List<String> = def.getOrNull("variables") ?: emptyList()
+        for (variable in vars) {
+            target.clear(variable)
+        }
+        val removeItems = args.getOrNull(1)?.toBooleanStrictOrNull() ?: true
+        if (removeItems) {
+            val items: List<String> = def.getOrNull("items") ?: emptyList()
+            for (item in items) {
+                removeItems(target, item)
+            }
+        }
+    }
+
+    private fun removeItems(player: Player, item: String) {
+        player.inventory.removeToLimit(item, Int.MAX_VALUE)
+        player.bank.removeToLimit(item, Int.MAX_VALUE)
+        player.beastOfBurden.removeToLimit(item, Int.MAX_VALUE)
+        player.equipment.removeToLimit(item, Int.MAX_VALUE)
     }
 }


### PR DESCRIPTION
- Add quest reset command for testing
- Stop bots from being assigned members tasks on free-to-play worlds
- Fix slayer xp being granted on task hit instead of death
