### PR TITLE
Fix report abuse breaking the chat box

### DIFF
--- a/data/client/client.scripts.toml
+++ b/data/client/client.scripts.toml
@@ -64,6 +64,9 @@ id = 143
 [close_entry]
 id = 101
 
+[close_report_abuse]
+id = 244
+
 [int_entry]
 id = 108
 

--- a/game/src/main/kotlin/content/social/report/ReportAbuse.kt
+++ b/game/src/main/kotlin/content/social/report/ReportAbuse.kt
@@ -4,6 +4,8 @@ import content.social.chat.ChatHistory
 import world.gregs.voidps.engine.Script
 import world.gregs.voidps.engine.client.instruction.instruction
 import world.gregs.voidps.engine.client.message
+import world.gregs.voidps.engine.client.sendScript
+import world.gregs.voidps.engine.client.ui.close
 import world.gregs.voidps.engine.client.ui.hasMenuOpen
 import world.gregs.voidps.engine.client.ui.open
 import world.gregs.voidps.engine.client.variable.hasClock
@@ -49,7 +51,12 @@ class ReportAbuse(val reports: Reports, val accounts: AccountDefinitions) : Scri
             }
         }
 
+        interfaceClosed("report_abuse") {
+            sendScript("close_report_abuse")
+        }
+
         instruction<ReportAbuse> { player ->
+            player.close("report_abuse")
             val rule = Rule.byId(type) ?: return@instruction
             val name = name.trim()
             if (name.isEmpty()) {

--- a/game/src/test/kotlin/content/social/report/ReportAbuseTest.kt
+++ b/game/src/test/kotlin/content/social/report/ReportAbuseTest.kt
@@ -3,12 +3,14 @@ package content.social.report
 import WorldTest
 import interfaceOption
 import io.mockk.mockkStatic
+import io.mockk.unmockkStatic
 import io.mockk.verify
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
 import world.gregs.voidps.cache.definition.data.InterfaceDefinition
 import world.gregs.voidps.engine.client.ui.hasOpen
+import world.gregs.voidps.engine.client.ui.open
 import world.gregs.voidps.engine.entity.character.player.PlayerRights
 import world.gregs.voidps.engine.entity.character.player.chat.ChatType
 import world.gregs.voidps.engine.entity.character.player.rights
@@ -16,6 +18,7 @@ import world.gregs.voidps.network.client.instruction.ChatPublic
 import world.gregs.voidps.network.client.instruction.ReportAbuse
 import world.gregs.voidps.network.login.protocol.encode.interfaceVisibility
 import world.gregs.voidps.network.login.protocol.encode.message
+import world.gregs.voidps.network.login.protocol.encode.sendScript
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
@@ -37,6 +40,25 @@ internal class ReportAbuseTest : WorldTest() {
 
         verify {
             client.message("Thank-you, your abuse report has been received.", ChatType.Game.id)
+        }
+    }
+
+    @Test
+    fun `Submitting a report closes the interface and restores the chat box`() = runTest {
+        val (player, client) = createClient("snitch")
+        createPlayer(name = "scammer")
+        player.open("report_abuse")
+        assertTrue(player.hasOpen("report_abuse"))
+
+        mockkStatic("world.gregs.voidps.network.login.protocol.encode.ScriptEncoderKt")
+        try {
+            player.instructions.send(ReportAbuse("scammer", 15, 0, ""))
+            tick()
+
+            assertFalse(player.hasOpen("report_abuse"))
+            verify { client.sendScript(244, any()) } // close_report_abuse
+        } finally {
+            unmockkStatic("world.gregs.voidps.network.login.protocol.encode.ScriptEncoderKt")
         }
     }
 


### PR DESCRIPTION
Closes #1061

## Problem

After submitting (or cancelling) an abuse report, the reporter couldn't type in chat or press Enter for quick-chat until they relogged.

## Root cause (client-side, from the 634 cache cs2 + void-client source)

- Opening report abuse in select-player mode runs **cs2 246**, which sets the report-mode varc 11 = 1 and **removes the chat box key listener** (`if_setonkey(137:55, -1)`) so keystrokes feed the report screen instead. Script 73 (the removed handler) is what processes all chat typing and Enter.
- The client's close script (**cs2 675**) only closes the modal. It never re-registers the listener, and the send path (**cs2 135**) never resets varc 11. Keyboard chat stays dead; relogging fixes it because listeners/varcs rebuild on login.
- The restore script is **cs2 244** (re-registers script 73 on 137:55 via cs2 132, sets varc 11 = 0, clears the reported-name varc 24).

## Fix

- Run cs2 244 (`close_report_abuse`) whenever the `report_abuse` interface closes.
- Close the interface server-side when the `ReportAbuse` instruction arrives (before validation — the client has already dismissed its side), keeping server interface state in sync and triggering the restore on every path (submit, cancel, X).

## Testing

- New WorldTest asserts the interface closes and script 244 is sent after submitting a report; all existing `ReportAbuseTest` cases pass.
- Verified in the client: reported via right-click chat line, via the Report button, and cancelled without submitting, chat keeps working after each.