### PR TITLE
fix: gravestone loot despawning in seconds instead of minutes

### DIFF
--- a/game/src/main/kotlin/content/area/misthalin/lumbridge/church/Gravestone.kt
+++ b/game/src/main/kotlin/content/area/misthalin/lumbridge/church/Gravestone.kt
@@ -9,6 +9,7 @@ import world.gregs.voidps.engine.entity.character.player.Player
 import world.gregs.voidps.engine.entity.character.player.male
 import world.gregs.voidps.engine.entity.character.player.name
 import world.gregs.voidps.engine.timer.epochSeconds
+import world.gregs.voidps.engine.timer.toTicks
 import world.gregs.voidps.type.Tile
 import java.util.concurrent.TimeUnit
 
@@ -31,7 +32,9 @@ object Gravestone {
         // https://www.youtube.com/watch?v=JGf7EHMVpPQ
         player.message("Your gravestone has appeared and will last $minutes ${"minute".plural(minutes)} before crumbling to dust. You")
         player.message("can find the location of your gravestone by looking at the world map.")
-        return minutes
+        // Callers use this as a tick count for the dropped items' reveal/disappear timers,
+        // so return ticks - not minutes, which made loot go public in seconds.
+        return TimeUnit.SECONDS.toTicks(seconds)
     }
 
     val times = mapOf(

--- a/game/src/test/kotlin/content/area/misthalin/lumbridge/church/GravestonesTest.kt
+++ b/game/src/test/kotlin/content/area/misthalin/lumbridge/church/GravestonesTest.kt
@@ -17,6 +17,7 @@ import world.gregs.voidps.engine.inv.add
 import world.gregs.voidps.engine.inv.inventory
 import world.gregs.voidps.engine.timer.*
 import world.gregs.voidps.type.Tile
+import java.util.concurrent.TimeUnit
 import kotlin.test.*
 
 class GravestonesTest : WorldTest() {
@@ -46,6 +47,24 @@ class GravestonesTest : WorldTest() {
         assertEquals(300, remaining - epochSeconds())
         assertFalse(player.inventory.contains("coins", 10))
         assertEquals(Tile(3221, 3219), player.tile)
+    }
+
+    @Test
+    fun `Dropped items last the gravestone duration in ticks not minutes`() {
+        val tile = Tile(3235, 3220)
+        val player = createPlayer(tile)
+        player.inventory.add("coins", 10)
+        tick()
+
+        player.damage(101)
+        tick(9)
+
+        // 5 minute memorial plaque: reveal near 300s of ticks (500), not 5 ticks (3 seconds).
+        // The floor timer has already counted down a couple of ticks by now.
+        val coins = FloorItems.firstOrNull(tile, "coins")
+        assertNotNull(coins)
+        assertTrue(coins.revealTicks >= 490, "reveal should be ~500 ticks (5 min), was ${coins.revealTicks}")
+        assertTrue(coins.disappearTicks >= 550, "disappear should be ~560 ticks, was ${coins.disappearTicks}")
     }
 
     @Test

--- a/game/src/test/kotlin/content/area/misthalin/lumbridge/church/GravestonesTest.kt
+++ b/game/src/test/kotlin/content/area/misthalin/lumbridge/church/GravestonesTest.kt
@@ -17,7 +17,6 @@ import world.gregs.voidps.engine.inv.add
 import world.gregs.voidps.engine.inv.inventory
 import world.gregs.voidps.engine.timer.*
 import world.gregs.voidps.type.Tile
-import java.util.concurrent.TimeUnit
 import kotlin.test.*
 
 class GravestonesTest : WorldTest() {


### PR DESCRIPTION
## Problem

When a player dies, their dropped items go public within seconds and vanish after ~39s instead of lasting the gravestone's lifetime.

`Gravestone.spawn()` returned the gravestone lifetime in **minutes**, but `PlayerDeath.dropItems` uses that value as a **tick** count for the dropped items' reveal and disappear timers. A 5-minute memorial plaque became 5 ticks, so loot revealed after ~3s and disappeared after ~39s (5 + 60 ticks).

Closes #1074

## Fix

Return the lifetime in ticks (`TimeUnit.SECONDS.toTicks(seconds)`), matching the repair/bless path in `Gravestones.updateItems`, which already sets the floor items' timers in ticks. A memorial plaque now keeps loot private for its full 5 minutes, and the longer gravestones (up to the royal dwarven's 15) scale correctly.

## Test

`GravestonesTest` now kills a player and asserts the dropped coins get a reveal timer near 500 ticks (5 minutes), not 5. The test fails against the pre-fix code.
