### PR TITLE
fix: Chaeldar (Zanaris slayer master) giving no tasks

### DIFF
--- a/data/area/kandarin/feldip_hills/feldip_hills.npcs.toml
+++ b/data/area/kandarin/feldip_hills/feldip_hills.npcs.toml
@@ -109,6 +109,7 @@ immune_poison = true
 [jungle_strykewyrm]
 id = 9467
 combat_def = "jungle_strykewyrm"
+slayer_level = 73
 examine = "Who said worms were small and harmless?"
 
 [swamp_toad_feldip_hills]

--- a/data/skill/slayer/slayer.tables.toml
+++ b/data/skill/slayer/slayer.tables.toml
@@ -219,6 +219,9 @@ npc = "jelly"
 [.jungle_horrors]
 npc = "jungle_horror"
 
+[.jungle_strykewyrm]
+npc = "jungle_strykewyrm"
+
 [.kalphites]
 npc = "kalphite_worker"
 combat_level = 15

--- a/game/src/main/kotlin/content/skill/slayer/Slayer.kt
+++ b/game/src/main/kotlin/content/skill/slayer/Slayer.kt
@@ -103,7 +103,9 @@ private fun rollTask(player: Player, master: String): Pair<String, Int>? {
 
 private fun hasRequirements(player: Player, table: TableDefinition, row: Int): Boolean {
     val category = Rows.get(row).rowId
-    val npc = Tables.int("slayer_tasks.$category.npc")
+    // A master listing a task with no matching slayer_tasks entry shouldn't crash the whole
+    // assignment - skip it so the other tasks can still be rolled.
+    val npc = Tables.intOrNull("slayer_tasks.$category.npc") ?: return false
     val slayerLevel = NPCDefinitions.get(npc)["slayer_level", 1]
     if (!player.has(Skill.Slayer, slayerLevel)) {
         return false

--- a/game/src/test/kotlin/content/skill/slayer/SlayerTaskTest.kt
+++ b/game/src/test/kotlin/content/skill/slayer/SlayerTaskTest.kt
@@ -196,4 +196,23 @@ class SlayerTaskTest : WorldTest() {
         assertEquals(150, player.slayerStreak)
         assertEquals(15, player.slayerPoints)
     }
+
+    @Test
+    fun `Chaeldar assigns a task without crashing on its jungle strykewyrm entry`() {
+        setRandom(object : FakeRandom() {
+            override fun nextInt(until: Int): Int = 0
+            override fun nextBits(bitCount: Int): Int = bitCount
+        })
+        val player = createPlayer(Tile(3231, 3298))
+        player.levels.set(Skill.Slayer, 99)
+
+        // Chaeldar lists jungle_strykewyrm, which had no slayer_tasks entry and threw
+        // "Row not found" while rolling, so the master gave no task at all.
+        val (type, amount) = assignTask(player, "chaeldar")
+
+        assertTrue(type.isNotEmpty())
+        assertTrue(amount > 0)
+        assertEquals("chaeldar", player.slayerMaster)
+        assertEquals(type, player.slayerTask)
+    }
 }


### PR DESCRIPTION
## Problem

Talking to Chaeldar (the Zanaris slayer master) and asking for a task hands out nothing.

Chaeldar's task table lists `jungle_strykewyrm`, but the shared `slayer_tasks` table has no matching entry. When the assignment loop checks each candidate's requirements it looks up `slayer_tasks.jungle_strykewyrm.npc`, which throws `IllegalStateException: Row 'jungle_strykewyrm' not found`. Because the loop iterates every one of Chaeldar's tasks, the crash happens on every assignment regardless of the player's level, so the master never gives a task.

Closes #1073

## Fix

- Add the missing `[.jungle_strykewyrm]` entry to `slayer_tasks`, mapping it to the existing `jungle_strykewyrm` NPC, and give that NPC the `73` Slayer requirement it has in-game (in line with the ice/desert strykewyrms).
- Make `hasRequirements` skip a task category that has no `slayer_tasks` entry (`intOrNull ?: return false`) instead of throwing, so a future data gap degrades gracefully rather than taking out the whole master.

## Test

`SlayerTaskTest` now asserts Chaeldar assigns a valid task without throwing. The test fails against the pre-fix code with the exact `Row 'jungle_strykewyrm' not found` error.
