### PR TITLE
fix: reject GE offers whose total price overflows Int

### DIFF
--- a/engine/src/main/kotlin/world/gregs/voidps/engine/data/exchange/Aggregate.kt
+++ b/engine/src/main/kotlin/world/gregs/voidps/engine/data/exchange/Aggregate.kt
@@ -31,15 +31,15 @@ data class Aggregate(
         volume += amount
         count++
 
-        val midpoint = (high + low) / 2
+        val midpoint = (high.toLong() + low) / 2
 
         if (price >= midpoint) {
             // Update running average for high prices
-            averageHigh = ((averageHigh * volumeHigh) + (price * amount)) / (volumeHigh + amount)
+            averageHigh = ((averageHigh * volumeHigh) + (price.toDouble() * amount)) / (volumeHigh + amount)
             volumeHigh += amount
         } else {
             // Update running average for low prices
-            averageLow = ((averageLow * volumeLow) + (price * amount)) / (volumeLow + amount)
+            averageLow = ((averageLow * volumeLow) + (price.toDouble() * amount)) / (volumeLow + amount)
             volumeLow += amount
         }
     }

--- a/game/src/main/kotlin/content/social/trade/exchange/GrandExchangeConfirm.kt
+++ b/game/src/main/kotlin/content/social/trade/exchange/GrandExchangeConfirm.kt
@@ -30,6 +30,13 @@ class GrandExchangeConfirm(val exchange: GrandExchange) : Script {
             val itemId: String = get("grand_exchange_item") ?: return@interfaceOption
             val amount: Int = get("grand_exchange_quantity") ?: return@interfaceOption
             val price: Int = get("grand_exchange_price") ?: return@interfaceOption
+            if (amount < 1 || price < 0) {
+                return@interfaceOption
+            }
+            if (price.toLong() * amount > Int.MAX_VALUE) {
+                message("The total value of your offer cannot exceed 2147m coins.")
+                return@interfaceOption
+            }
             when (get("grand_exchange_page", "offers")) {
                 "buy" -> {
                     val total = price * amount

--- a/game/src/test/kotlin/content/social/trade/exchange/GrandExchangeTest.kt
+++ b/game/src/test/kotlin/content/social/trade/exchange/GrandExchangeTest.kt
@@ -684,6 +684,24 @@ class GrandExchangeTest : WorldTest() {
         assertTrue(buyer.containsMessage("You don't have enough coins."))
     }
 
+    @Test
+    fun `Can't buy when total price overflows`() {
+        Settings.load(mapOf("grandExchange.priceLimit" to "false"))
+        val buyer = createPlayer(Tile(3164, 3487), "buyer")
+        buyer.inventory.add("coins", 10_000)
+
+        buy(buyer, "rune_longsword")
+        buyer.interfaceOption("grand_exchange", "add_x", "Edit Quantity")
+        (buyer.suspension as? Suspension.IntEntry)?.resume(3)
+        buyer.interfaceOption("grand_exchange", "offer_x", "Edit Price")
+        (buyer.suspension as? Suspension.IntEntry)?.resume(1_431_655_766)
+        confirm(buyer)
+        tick()
+        assertTrue(buyer.offers[0].isEmpty())
+        assertEquals(10_000, buyer.inventory.count("coins"))
+        assertTrue(buyer.containsMessage("The total value of your offer cannot exceed 2147m coins."))
+    }
+
     private fun buy(player: Player, item: String) {
         player.npcOption(clerk, "Exchange")
         tick()


### PR DESCRIPTION
## Problem

`price * amount` in the confirm handler is Int arithmetic, so a sufficiently large price × quantity can overflow `Int.MAX_VALUE` and wrap to a tiny value. That let the total coins charged for an offer diverge from the offer actually created, which could be abused when the price limit is disabled.

## Fix

- `GrandExchangeConfirm`: compute the total as a `Long` and reject (with a message) any offer whose total exceeds `Int.MAX_VALUE`, for both buy and sell. Also reject `amount < 1` / `price < 0`, since the int-entry packet is a raw `readInt` and the buy quantity had no lower bound.
- `Aggregate`: same overflow class in the price-history running averages (widen before the Double maths) and the `(high + low) / 2` midpoint.

## Testing

Added a regression test asserting an overflowing total creates no offer and removes no coins. All existing GrandExchange + price history tests pass.