### PR TITLE
fix: animation queue bug

### DIFF
--- a/game/src/main/kotlin/content/entity/Movement.kt
+++ b/game/src/main/kotlin/content/entity/Movement.kt
@@ -9,7 +9,7 @@ import world.gregs.voidps.engine.data.definition.Areas
 import world.gregs.voidps.engine.entity.character.Character
 import world.gregs.voidps.engine.entity.character.mode.EmptyMode
 import world.gregs.voidps.engine.entity.character.mode.PauseMode
-import world.gregs.voidps.engine.entity.character.mode.interact.PlayerOnObjectInteract
+import world.gregs.voidps.engine.entity.character.mode.interact.Interact
 import world.gregs.voidps.engine.entity.character.npc.NPCs
 import world.gregs.voidps.engine.entity.character.player.Players
 import world.gregs.voidps.engine.entity.character.player.equip.equipped
@@ -53,7 +53,7 @@ class Movement : Script {
             if (player.contains("delay")) {
                 return@instruction
             }
-            if (player.mode is PlayerOnObjectInteract) {
+            if (player.mode is Interact) {
                 player.clearAnim()
             }
             player.closeInterfaces()

--- a/game/src/main/kotlin/content/skill/fishing/Fishing.kt
+++ b/game/src/main/kotlin/content/skill/fishing/Fishing.kt
@@ -138,6 +138,7 @@ class Fishing : Script {
         }
         target.get<MutableSet<String>>("fishers")?.remove(player.name)
         player.softTimers.stop("fishing")
+        player.clearAnim()
     }
 
     fun addCatch(player: Player, catch: String) {

--- a/game/src/main/kotlin/content/skill/mining/Mining.kt
+++ b/game/src/main/kotlin/content/skill/mining/Mining.kt
@@ -129,6 +129,7 @@ class Mining : Script {
                 stop("action_delay")
             }
             softTimers.stop("mining")
+            clearAnim()
         }
 
         objectApproach("Prospect") { (target) ->

--- a/game/src/main/kotlin/content/skill/woodcutting/Woodcutting.kt
+++ b/game/src/main/kotlin/content/skill/woodcutting/Woodcutting.kt
@@ -98,6 +98,7 @@ class Woodcutting(val drops: DropTables) : Script {
             player.stop("action_delay")
         }
         player.softTimers.stop("woodcutting")
+        player.clearAnim()
     }
 
     fun tryDropNest(player: Player, ivy: Boolean) {


### PR DESCRIPTION
Root cause: When a gathering action (mining, woodcutting, fishing) ends either by the player walking away or the resource depleting the animation was never properly cleared on the client. The server's visuals.reset() clears the animation flag but not the animation data when the animation is infinite, and even for non-infinite animations, the client was never sent a "stop animation" packet because no one flagged the cleared animation.

Changes made (4 files):

Movement.kt:56: Widened the Walk handler's clearAnim() check from player.mode is PlayerOnObjectInteract to player.mode is Interact. This ensures animation is cleared when walking away from any interaction type (NPC interactions like fishing spots were previously missed).
Woodcutting.kt:101: Added player.clearAnim() after the chop loop exits. Previously the animation persisted after the tree was depleted, inventory was full, or the player lacked the level/hatchet.
Mining.kt:132: Added clearAnim() after the mine loop exits. (Mining already called it specifically on ore depletion at line 124, but not for other exit conditions like inventory full or missing level.)
Fishing.kt:141: Added player.clearAnim() after the fish loop exits.

Firemaking already had this pattern correctly at Firemaking.kt:95. No changes were made to this skill. 