### PR TITLE
fix: map blackscreen after teleport from differing height levels

### DIFF
--- a/game/src/main/kotlin/content/entity/world/RegionLoading.kt
+++ b/game/src/main/kotlin/content/entity/world/RegionLoading.kt
@@ -96,7 +96,7 @@ class RegionLoading(val dynamicZones: DynamicZones) : Script {
     /**
      * Check if we're within 4 (default) zones of the last loaded zone.
      */
-    fun inViewOfZone(player: Player, zone: Zone, radius: Int): Boolean = Distance.within(player.tile.zone.x, player.tile.zone.y, zone.x, zone.y, radius)
+    fun inViewOfZone(player: Player, zone: Zone, radius: Int): Boolean = Distance.within(player.tile.zone.x, player.tile.zone.y, player.tile.zone.level, zone.x, zone.y, zone.level, radius)
 
     fun inViewOfRegion(player: Player, region: Region): Boolean {
         val viewport = player.viewport!!


### PR DESCRIPTION
Root cause identified: Client's method3157 has a guard condition that states if zoneX == storedZoneX && zoneY == storedZoneY && !forceRefresh, the body is skipped, leaving scene data cleared by method3120 but never repopulated → black map.

Fix applied: Added Z-level check to inViewOfZone in RegionLoading.kt:99 which previously only checked X/Y, so teleports to the same zone coordinates but different plane (e.g., surface↔dungeon) would NOT trigger a region reload, causing the player to have a black map. 
<img width="615" height="637" alt="image" src="https://github.com/user-attachments/assets/67877642-6ea1-48b4-9367-59128ad3a172" />
