### PR TITLE
fix: dialogue / combat queue conflict

### DIFF
--- a/engine/src/main/kotlin/world/gregs/voidps/engine/entity/character/mode/combat/CombatMovement.kt
+++ b/engine/src/main/kotlin/world/gregs/voidps/engine/entity/character/mode/combat/CombatMovement.kt
@@ -1,6 +1,5 @@
 package world.gregs.voidps.engine.entity.character.mode.combat
 
-import world.gregs.voidps.engine.client.ui.dialogue
 import world.gregs.voidps.engine.client.variable.hasClock
 import world.gregs.voidps.engine.data.config.CombatDefinition
 import world.gregs.voidps.engine.data.definition.CombatDefinitions
@@ -43,9 +42,6 @@ class CombatMovement(
     }
 
     override fun tick() {
-        if (character is Player && character.dialogue != null) {
-            return
-        }
         if (target.tile.level != character.tile.level) {
             character.mode = EmptyMode
             return

--- a/engine/src/main/kotlin/world/gregs/voidps/engine/queue/ActionQueue.kt
+++ b/engine/src/main/kotlin/world/gregs/voidps/engine/queue/ActionQueue.kt
@@ -1,6 +1,7 @@
 package world.gregs.voidps.engine.queue
 
 import kotlinx.coroutines.*
+import world.gregs.voidps.engine.client.ui.closeDialogue
 import world.gregs.voidps.engine.client.ui.closeMenu
 import world.gregs.voidps.engine.client.ui.dialogue
 import world.gregs.voidps.engine.client.ui.hasMenuOpen
@@ -34,6 +35,7 @@ class ActionQueue<C : Character>(
     fun tick() {
         if (queue.contains(ActionPriority.Strong)) {
             (character as? Player)?.closeMenu()
+            (character as? Player)?.closeDialogue()
             weakQueue.clear()
         }
         process(queue)
@@ -45,7 +47,7 @@ class ActionQueue<C : Character>(
         while (action != null) {
             // Cache end to exit before the last action can add any children
             val end = action.next == null
-            if (action.process() && canProcess()) {
+            if (action.process() && (action.priority == ActionPriority.Strong || canProcess())) {
                 val next = action.next
                 queue.remove(action)
                 scope.launch(action)

--- a/game/src/main/kotlin/content/entity/combat/Combat.kt
+++ b/game/src/main/kotlin/content/entity/combat/Combat.kt
@@ -7,7 +7,6 @@ import content.skill.magic.Magic
 import content.skill.melee.weapon.*
 import world.gregs.voidps.engine.Script
 import world.gregs.voidps.engine.client.message
-import world.gregs.voidps.engine.client.ui.dialogue
 import world.gregs.voidps.engine.client.variable.hasClock
 import world.gregs.voidps.engine.client.variable.start
 import world.gregs.voidps.engine.client.variable.stop
@@ -165,11 +164,8 @@ class Combat(val combatDefinitions: CombatDefinitions) :
                 character.mode = CombatMovement(character, target)
                 character.target = target
             }
-            val movement = character.mode as CombatMovement
-            if (character is Player && character.dialogue != null) {
-                return
-            }
-            if (character.target == null || !Target.attackable(character, target)) {
+        val movement = character.mode as CombatMovement
+        if (character.target == null || !Target.attackable(character, target)) {
                 character.mode = EmptyMode
                 return
             }

--- a/game/src/main/kotlin/content/entity/player/dialogue/type/LevelUp.kt
+++ b/game/src/main/kotlin/content/entity/player/dialogue/type/LevelUp.kt
@@ -1,6 +1,7 @@
 package content.entity.player.dialogue.type
 
 import world.gregs.voidps.engine.Script
+import world.gregs.voidps.engine.client.message
 import world.gregs.voidps.engine.client.ui.*
 import world.gregs.voidps.engine.client.ui.chat.an
 import world.gregs.voidps.engine.client.ui.close
@@ -66,6 +67,7 @@ class LevelUp : Script {
             jingle("level_up_${skill.name.lowercase()}${if (unlock) "_unlock" else ""}", 0.5)
             addVarbit("skill_stat_flash", skill.name.lowercase())
             val level = if (skill == Constitution) to / 10 else to
+            message("Congratulations! You've just advanced${skill.name.an()} ${skill.name} level! You have now reached level $level!")
             weakQueue("level_up") {
                 levelUp(
                     this,


### PR DESCRIPTION
The Bug
When a dialogue (like a level-up or a random event) opened during combat, the player and their attacker was completely frozen. Combat stopped with no movement, no attacks, no damage. The player had to manually dismiss the dialogue before combat resumed. When this would happen, damage would "pool up behind the dialogue". This is unintended behavior and reference videos alongside historical sources show that combat actually interrupts the dialogue interface. Furthermore, this adds in the chat message for leveling up and ensures the player sees the message even if the dialogue is closed by a strong queue action.

Changes
CombatMovement.kt
Removed the character.dialogue != null early return from tick().

Before: If the player had a dialogue open, CombatMovement.tick() returned immediately and the player stopped moving toward their target and stopped attacking.

After: Combat movement ticks normally regardless of dialogue state. The player continues chasing targets, pathfinding, and triggering attacks.

Combat.kt
Removed the character.dialogue != null early return from combat().

Before: Even if CombatMovement.tick() ran, the actual attack logic in Combat.combat() also bailed out when dialogue was open. No swings, no damage, no XP until the dialogue was cleared. 

After: Attack rolls, damage, and combat XP all process normally while dialogue is visible.

ActionQueue.kt
Strong actions now bypass canProcess(), and Strong actions close dialogue.

Two changes here:

process() now checks action.priority == ActionPriority.Strong || canProcess() instead of just canProcess(). This means player damage hits (strongQueue("hit")) execute immediately instead of pooling in the queue behind the dialogue interrupt check.

The existing closeMenu() call in tick() (which fires when a Strong action is pending) now also calls closeDialogue(). Getting hit is a Strong action, so it force-closes any open dialogue — matching the original RS2 behavior where combat interrupts the level-up display.

LevelUp.kt
Added a message() call alongside the level-up interface.

The congratulations text is now sent as a ChatType.Game chat message in addition to being displayed in the level-up interface. This is historically accurate to 2011 RS2, where both the chatbox message and the interface were sent on level-up.