### PR TITLE
fix: allow inventory reordering while bank is open

### DIFF
--- a/data/entity/player/bank/bank.ifaces.toml
+++ b/data/entity/player/bank/bank.ifaces.toml
@@ -259,7 +259,7 @@ type = "overlay_tab"
 [.inventory]
 id = 0
 inventory = "inventory"
-options = { Deposit-1 = 0, Deposit-5 = 1, Deposit-10 = 2, Deposit-* = 3, Deposit-X = 4, Deposit-All = 5, Examine = 9 }
+options = { Deposit-1 = 0, Deposit-5 = 1, Deposit-10 = 2, Deposit-* = 3, Deposit-X = 4, Deposit-All = 5, Examine = 9, Drag-Source = 17, Drag = 20 }
 
 [bank_help]
 id = 767

--- a/engine/src/main/kotlin/world/gregs/voidps/engine/client/instruction/handle/InterfaceSwitchHandler.kt
+++ b/engine/src/main/kotlin/world/gregs/voidps/engine/client/instruction/handle/InterfaceSwitchHandler.kt
@@ -17,6 +17,11 @@ class InterfaceSwitchHandler(
             val temp = fromItemId
             fromItemId = toItemId
             toItemId = temp
+        } else if (fromInterfaceId == 763 && toInterfaceId == 763) {
+            // The client reorders the side inventory before sending, so each item id arrives paired with the slot it was dropped into
+            val temp = fromItemId
+            fromItemId = toItemId
+            toItemId = temp
         }
         val (fromId, fromComponent) = handler.getInterfaceItem(player, fromInterfaceId, fromComponentId, fromItemId, fromSlot) ?: return false
         val (toId, toComponent) = handler.getInterfaceItem(player, toInterfaceId, toComponentId, toItemId, toSlot) ?: return false

--- a/game/src/main/kotlin/content/entity/player/bank/BankDeposit.kt
+++ b/game/src/main/kotlin/content/entity/player/bank/BankDeposit.kt
@@ -16,14 +16,14 @@ import world.gregs.voidps.engine.inv.beastOfBurden
 import world.gregs.voidps.engine.inv.equipment
 import world.gregs.voidps.engine.inv.inventory
 import world.gregs.voidps.engine.inv.transact.TransactionError
-import world.gregs.voidps.engine.inv.transact.operation.MoveItemLimit.moveToLimit
+import world.gregs.voidps.engine.inv.transact.operation.AddItemLimit.addToLimit
 import world.gregs.voidps.engine.inv.transact.operation.RemoveItem.remove
 import world.gregs.voidps.engine.inv.transact.operation.ShiftItem.shift
 
 class BankDeposit : Script {
 
     init {
-        interfaceOption(id = "bank_side:inventory") { (item, _, option) ->
+        interfaceOption(id = "bank_side:inventory") { (item, slot, option) ->
             val amount = when (option) {
                 "Deposit-1" -> 1
                 "Deposit-5" -> 5
@@ -35,10 +35,10 @@ class BankDeposit : Script {
                 }
                 else -> return@interfaceOption
             }
-            deposit(this, inventory, item, amount)
+            deposit(this, inventory, item, amount, slot)
         }
 
-        interfaceOption(id = "bank_deposit_box:inventory") { (item, _, option) ->
+        interfaceOption(id = "bank_deposit_box:inventory") { (item, slot, option) ->
             val amount = when (option) {
                 "Deposit-1" -> 1
                 "Deposit-5" -> 5
@@ -49,7 +49,7 @@ class BankDeposit : Script {
                 }
                 else -> return@interfaceOption
             }
-            deposit(this, inventory, item, amount)
+            deposit(this, inventory, item, amount, slot)
         }
 
         interfaceOption("Deposit carried items", "bank:carried") {
@@ -107,7 +107,7 @@ class BankDeposit : Script {
         for (index in inventory.indices) {
             val item = inventory[index]
             if (item.isNotEmpty()) {
-                deposit(player, inventory, item, item.amount)
+                deposit(player, inventory, item, item.amount, index)
             }
         }
     }
@@ -115,7 +115,7 @@ class BankDeposit : Script {
     companion object {
         private val logger = InlineLogger()
 
-        private fun deposit(player: Player, inventory: Inventory, item: Item, amount: Int, check: Boolean = true) {
+        private fun deposit(player: Player, inventory: Inventory, item: Item, amount: Int, slot: Int = -1, check: Boolean = true) {
             if ((check && player.menu != "bank" && player.menu != "bank_deposit_box") || amount < 1) {
                 return
             }
@@ -147,15 +147,24 @@ class BankDeposit : Script {
             var shifted = false
             inventory.transaction {
                 val existing = bank.indexOf(notNoted.id)
-                val moved = moveToLimit(item.id, amount, bank, notNoted.id)
-                if (moved == 0) {
+                val available = inventory.count(item.id).toInt()
+                val added = link(bank).addToLimit(notNoted.id, minOf(amount, available))
+                if (added == 0) {
                     error = TransactionError.Full()
-                } else if (moved > 0 && tab > 0 && existing == -1) {
-                    // Shift item into tab
-                    val index = bank.freeIndex() - 1
-                    val to = tabIndex(player, tab + 1)
-                    link(bank).shift(index, to)
-                    shifted = true
+                } else {
+                    // Remove from the slot clicked before taking from other slots
+                    if (slot in inventory.indices && inventory[slot].id == item.id) {
+                        remove(slot, item.id, added)
+                    } else {
+                        remove(item.id, added)
+                    }
+                    if (tab > 0 && existing == -1) {
+                        // Shift item into tab
+                        val index = bank.freeIndex() - 1
+                        val to = tabIndex(player, tab + 1)
+                        link(bank).shift(index, to)
+                        shifted = true
+                    }
                 }
             }
             when (inventory.transaction.error) {

--- a/game/src/main/kotlin/content/entity/player/bank/BankOpen.kt
+++ b/game/src/main/kotlin/content/entity/player/bank/BankOpen.kt
@@ -1,5 +1,6 @@
 package content.entity.player.bank
 
+import com.github.michaelbull.logging.InlineLogger
 import content.entity.player.bank.Bank.tabs
 import content.entity.player.bank.pin.openBank
 import content.entity.player.bank.pin.openCollection
@@ -18,9 +19,13 @@ import world.gregs.voidps.engine.client.ui.open
 import world.gregs.voidps.engine.data.definition.AccountDefinitions
 import world.gregs.voidps.engine.entity.character.player.Player
 import world.gregs.voidps.engine.entity.character.player.Players
+import world.gregs.voidps.engine.inv.inventory
 import world.gregs.voidps.engine.inv.sendInventory
+import world.gregs.voidps.engine.inv.swap
 
 class BankOpen(val accounts: AccountDefinitions) : Script {
+
+    val logger = InlineLogger()
 
     init {
         adminCommand("bank", stringArg("player-name", optional = true, autofill = accounts.displayNames.keys), desc = "Open the players bank", handler = ::bank)
@@ -71,6 +76,12 @@ class BankOpen(val accounts: AccountDefinitions) : Script {
             interfaceOptions.unlockAll("bank", "inventory", 0 until 516)
             interfaceOptions.unlockAll("bank_side", "inventory", 0 until 28)
             tab(Tab.Inventory)
+        }
+
+        interfaceSwap("bank_side:inventory", "bank_side:inventory") { _, _, fromSlot, toSlot ->
+            if (!inventory.swap(fromSlot, toSlot)) {
+                logger.info { "Failed switching bank side items $this" }
+            }
         }
 
         interfaceOption("Search", "bank:search") {

--- a/game/src/test/kotlin/content/entity/player/bank/BankTest.kt
+++ b/game/src/test/kotlin/content/entity/player/bank/BankTest.kt
@@ -6,6 +6,7 @@ import io.mockk.mockk
 import io.mockk.mockkStatic
 import io.mockk.unmockkStatic
 import io.mockk.verify
+import kotlinx.coroutines.test.runTest
 import objectOption
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.Test
@@ -15,6 +16,8 @@ import world.gregs.voidps.engine.inv.add
 import world.gregs.voidps.engine.inv.equipment
 import world.gregs.voidps.engine.inv.inventory
 import world.gregs.voidps.network.client.Client
+import world.gregs.voidps.network.client.instruction.MoveInventoryItem
+import world.gregs.voidps.network.login.protocol.encode.sendInterfaceItemUpdate
 import world.gregs.voidps.network.login.protocol.encode.sendScript
 import world.gregs.voidps.network.login.protocol.encode.sendVarc
 import world.gregs.voidps.network.login.protocol.visual.update.player.EquipSlot
@@ -41,6 +44,98 @@ internal class BankTest : WorldTest() {
         assertFalse(player.inventory.contains("bronze_sword"))
         assertEquals(Item("coins", 10), player.bank[0])
         assertEquals(Item("bronze_sword", 4), player.bank[1])
+    }
+
+    @Test
+    fun `Reorder inventory items while bank is open`() {
+        val player = createPlayer(emptyTile)
+        val bank = createObject(bankBooth, emptyTile.addY(4))
+        player.inventory.add("coins", 1000)
+        player.inventory.add("bronze_sword", 2)
+
+        player.objectOption(bank, "Use-quickly")
+        tick(5)
+        assertTrue(player.interfaces.contains("bank_side"))
+        // The client reorders before sending, so each item id is paired with the slot it was dropped into
+        runTest {
+            player.instructions.send(MoveInventoryItem(763, 0, 1277, 0, 763, 0, 995, 1))
+        }
+        tick()
+
+        assertEquals(Item("bronze_sword", 1), player.inventory[0])
+        assertEquals(Item("coins", 1000), player.inventory[1])
+        assertTrue(player.interfaces.contains("bank"))
+
+        // Dragging onto an empty slot leaves the origin slot empty (-1) in the packet
+        runTest {
+            player.instructions.send(MoveInventoryItem(763, 0, -1, 1, 763, 0, 995, 5))
+        }
+        tick()
+
+        assertEquals(Item.EMPTY, player.inventory[1])
+        assertEquals(Item("coins", 1000), player.inventory[5])
+    }
+
+    @Test
+    fun `Reordering inventory while banked resends both slots to the client`() {
+        val player = createPlayer(emptyTile, "bank_reorder")
+        val client: Client = mockk(relaxed = true)
+        player.client = client
+        (player.variables as PlayerVariables).client = client
+        val bank = createObject(bankBooth, emptyTile.addY(1))
+        player.inventory.add("coins", 1000)
+        player.inventory.add("bronze_sword", 2)
+
+        player.objectOption(bank, "Use-quickly")
+        tick(5)
+
+        mockkStatic("world.gregs.voidps.network.login.protocol.encode.InterfaceEncodersKt")
+        try {
+            runTest {
+                player.instructions.send(MoveInventoryItem(763, 0, 1277, 0, 763, 0, 995, 1))
+            }
+            tick()
+
+            assertEquals(Item("bronze_sword", 1), player.inventory[0])
+            assertEquals(Item("coins", 1000), player.inventory[1])
+            verify {
+                client.sendInterfaceItemUpdate(
+                    key = 93,
+                    updates = match { updates -> updates.any { it.first == 0 } && updates.any { it.first == 1 } },
+                    secondary = false,
+                )
+            }
+        } finally {
+            unmockkStatic("world.gregs.voidps.network.login.protocol.encode.InterfaceEncodersKt")
+        }
+
+        player.interfaceOption("bank_side", "inventory", "Deposit-All", item = Item("coins"), slot = 1)
+        assertEquals(Item("coins", 1000), player.bank[0])
+    }
+
+    @Test
+    fun `Deposit removes the item from the slot clicked, not the first match`() {
+        val player = createPlayer(emptyTile)
+        val bank = createObject(bankBooth, emptyTile.addY(1))
+        player.inventory.add("bronze_sword", 3)
+        player.inventory.add("coins", 100)
+
+        player.objectOption(bank, "Use-quickly")
+        tick(5)
+        player.interfaceOption("bank_side", "inventory", "Deposit-1", item = Item("bronze_sword"), slot = 2)
+
+        assertEquals(Item("bronze_sword", 1), player.inventory[0])
+        assertEquals(Item("bronze_sword", 1), player.inventory[1])
+        assertEquals(Item.EMPTY, player.inventory[2])
+        assertEquals(Item("coins", 100), player.inventory[3])
+        assertEquals(Item("bronze_sword", 1), player.bank[0])
+
+        // Depositing more than the clicked slot holds takes the rest from the earliest slots
+        player.interfaceOption("bank_side", "inventory", "Deposit-5", item = Item("bronze_sword"), slot = 1)
+
+        assertEquals(Item.EMPTY, player.inventory[0])
+        assertEquals(Item.EMPTY, player.inventory[1])
+        assertEquals(Item("bronze_sword", 3), player.bank[0])
     }
 
     @Test


### PR DESCRIPTION
Closes #1060

## Problem
Dragging items to reorder the inventory while the bank (or deposit box) was open did nothing. Additionally, depositing an item when carrying multiples deposited the first matching slot instead of the one clicked (noted in the issue comments).

## Cause
Three separate gaps:

1. **Client never initiated drags on `bank_side` (763).** The 634 client requires two access mask conditions for an item drag: drag-depth bits 18-20 != 0 on the source slot and bit 21 on the drop target (`Class348_Sub44.method3304`/`method3302` in the deob). `bank_side`'s options only unlocked the deposit/examine bits. The same combination is already what makes the normal inventory tab (`Option12 = 17` + `Drag = 20` on 149) and the music playlist work.
2. **Item ids arrive crossed in `763->763` switch packets.** The client reorders its own display *before* sending, so each item id is paired with the slot it was dropped into. Validation compared the post-swap client state against the pre-swap server state and rejected the packet - leaving the client visually reordered but the server unchanged, which then desynced every later click on those slots. Interface 149 has the same crossing (its handler already swaps `fromItemId`/`toItemId` alongside the ghost-slot `-28`); 763 needs the id swap without the slot translation, since it uses real slots 0-27.
3. **Deposits ignored the clicked slot.** `moveToLimit(item.id, ...)` removes by id from the first matching slot.

## Changes
- `bank.ifaces.toml`: add `Drag-Source = 17` (bit 18, drag-depth 1) and `Drag = 20` (bit 21) to `bank_side` inventory options, making the unlocked mask 2360446 - covers both the bank and deposit box paths
- `InterfaceSwitchHandler`: swap the crossed item ids for `763->763` switches
- `BankOpen`: handle `interfaceSwap("bank_side:inventory", "bank_side:inventory")` with `inventory.swap` (exact pair, so a future drag-to-deposit onto the bank grid isn't misrouted into an inventory swap)
- `BankDeposit`: pass the clicked slot through and remove via `RemoveItem.remove(slot, id, amount)` - empties the clicked slot first, then any remainder from the earliest slots; bank-capacity clamping now happens up front via `addToLimit`
- `BankTest`: reorder while banked (including onto an empty slot, and the crossed-id packet semantics), verifies both slots are resent to the client after a swap, deposit-after-reorder, and clicked-slot deposits

Tested in-game: dragging, reordering onto empty slots, and slot-accurate deposits all work with the bank and deposit box open.