### PR TITLE
fix: stop GE claims blocking player offer saves

### DIFF
--- a/database/src/main/kotlin/world/gregs/voidps/storage/DatabaseStorage.kt
+++ b/database/src/main/kotlin/world/gregs/voidps/storage/DatabaseStorage.kt
@@ -576,6 +576,11 @@ class DatabaseStorage : Storage {
             Database.connect(HikariDataSource(config))
             transaction {
                 SchemaUtils.create(*tables, inBatch = true)
+                // Drop the legacy grand_exchange_claims -> grand_exchange_offers foreign key.
+                // Claims and offers are persisted by independent, uncoordinated save paths, so the
+                // RESTRICT constraint blocked the per-player offer delete/reinsert. IF EXISTS keeps
+                // this idempotent and a no-op on fresh databases.
+                exec("ALTER TABLE grand_exchange_claims DROP CONSTRAINT IF EXISTS fk_grand_exchange_claims_offer_id__id")
             }
         }
 

--- a/database/src/main/kotlin/world/gregs/voidps/storage/Tables.kt
+++ b/database/src/main/kotlin/world/gregs/voidps/storage/Tables.kt
@@ -152,7 +152,7 @@ internal object PlayerHistoryTable : Table("player_exchange_history") {
 }
 
 internal object ClaimsTable : Table("grand_exchange_claims") {
-    val offerId = integer("offer_id").references(OffersTable.id).uniqueIndex()
+    val offerId = integer("offer_id").uniqueIndex()
     val amount = integer("amount")
     val coins = integer("coins")
 }

--- a/database/src/main/kotlin/world/gregs/voidps/storage/Tables.kt
+++ b/database/src/main/kotlin/world/gregs/voidps/storage/Tables.kt
@@ -152,6 +152,8 @@ internal object PlayerHistoryTable : Table("player_exchange_history") {
 }
 
 internal object ClaimsTable : Table("grand_exchange_claims") {
+    // Logically references OffersTable.id, but without a foreign key constraint: claims and offers
+    // are saved by independent paths, so enforcement would block the per-player offer delete/reinsert.
     val offerId = integer("offer_id").uniqueIndex()
     val amount = integer("amount")
     val coins = integer("coins")

--- a/database/src/test/kotlin/world/gregs/voidps/storage/StorageTest.kt
+++ b/database/src/test/kotlin/world/gregs/voidps/storage/StorageTest.kt
@@ -3,6 +3,7 @@ package world.gregs.voidps.storage
 import org.junit.jupiter.api.Test
 import world.gregs.voidps.engine.data.PlayerSave
 import world.gregs.voidps.engine.data.Storage
+import world.gregs.voidps.engine.data.exchange.Claim
 import world.gregs.voidps.engine.data.exchange.ExchangeHistory
 import world.gregs.voidps.engine.data.exchange.ExchangeOffer
 import world.gregs.voidps.engine.data.exchange.OfferState
@@ -239,6 +240,21 @@ abstract class StorageTest {
     @Test
     fun `No accounts gives empty clans`() {
         assertTrue(storage.clans().isEmpty())
+    }
+
+    @Test
+    fun `Re-saving offers with an outstanding claim doesn't fail`() {
+        // The seed account holds offer id 1; persist it first.
+        storage.save(listOf(save))
+
+        // A claim can reference an existing offer while that offer's owner is offline.
+        storage.saveClaims(mapOf(1 to Claim(4, 123)))
+
+        // Re-saving the account deletes and reinserts the player's offers. This previously threw a
+        // foreign-key violation because the outstanding claim still referenced offer id 1.
+        storage.save(listOf(save))
+
+        assertEquals(Claim(4, 123), storage.claims()[1])
     }
 
     companion object {


### PR DESCRIPTION
The grand_exchange_claims.offer_id foreign key referenced grand_exchange_offers.id with the default RESTRICT rule. Claims and offers are persisted by two independent, uncoordinated save paths (per-player save vs. the hourly Grand Exchange save), so a claim row can still reference an offer that the player-save path is about to delete-and-reinsert. The DELETE was blocked by the FK, failing the whole player-save transaction (xp, levels, inventory, everything) and retrying forever.

Drop the FK so the two tables' lifecycles are fully decoupled; offer_id keeps its unique index. Existing databases are migrated on startup with an idempotent ALTER ... DROP CONSTRAINT IF EXISTS, a no-op on fresh DBs.

Adds a regression test that reproduces the FK violation pre-fix.