### PR TITLE
Fix TzHaar Fight Cave bugs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,4 @@ gradle-app.setting
 .gradletasknamecache
 /gradle/
 *.lock
+/game.properties

--- a/data/minigame/tzhaar_fight_cave/tzhaar_fight_cave.combat.toml
+++ b/data/minigame/tzhaar_fight_cave/tzhaar_fight_cave.combat.toml
@@ -11,7 +11,6 @@ range = 1
 anim = "tz_kih_attack"
 target_sound = "tz_kih_attack"
 target_hit = { offense = "stab", max = 40 }
-impact_drain = { skill = "prayer", amount = 1 }
 
 [tz_kek]
 attack_speed = 4

--- a/game/src/main/kotlin/content/area/karamja/tzhaar_city/TzHaarHealers.kt
+++ b/game/src/main/kotlin/content/area/karamja/tzhaar_city/TzHaarHealers.kt
@@ -40,7 +40,7 @@ class TzHaarHealers : Script {
                 return@npcMoved
             }
             val jad = NPCs.findOrNull(tile.regionLevel, "tztok_jad") ?: return@npcMoved
-            if (tile.within(jad.tile, 5)) {
+            if (tile.distanceTo(jad.tile, jad.size, jad.size) <= 4) {
                 softTimers.start("yt_hur_kot_heal")
             }
         }
@@ -49,13 +49,13 @@ class TzHaarHealers : Script {
 
         npcTimerTick("yt_hur_kot_heal") {
             val jad = NPCs.findOrNull(tile.regionLevel, "tztok_jad") ?: return@npcTimerTick Timer.CONTINUE
-            if (!tile.within(jad.tile, 5)) {
+            if (tile.distanceTo(jad.tile, jad.size, jad.size) > 4) {
                 return@npcTimerTick Timer.CONTINUE
             }
-            val healed = jad.levels.restore(Skill.Constitution, 50)
-            if (healed > 0) {
+            if (jad.levels.getOffset(Skill.Constitution) < 0) {
                 anim("yt_hur_kot_heal")
                 jad.gfx("tzhaar_heal")
+                // The "healed" hit restores the health
                 jad.directHit(50, "healed")
                 areaSound("self_heal", tile, radius = 10)
             }
@@ -64,8 +64,7 @@ class TzHaarHealers : Script {
     }
 
     private fun heal(target: NPC, amount: Int) {
-        val amount = target.levels.restore(Skill.Constitution, amount)
-        if (amount > 0) {
+        if (target.levels.getOffset(Skill.Constitution) < 0) {
             target.directHit(amount, "healed")
             target.gfx("tzhaar_heal")
         }

--- a/game/src/main/kotlin/content/area/karamja/tzhaar_city/TzhaarFightCave.kt
+++ b/game/src/main/kotlin/content/area/karamja/tzhaar_city/TzhaarFightCave.kt
@@ -1,6 +1,7 @@
 package content.area.karamja.tzhaar_city
 
 import com.github.michaelbull.logging.InlineLogger
+import content.entity.combat.Combat
 import content.entity.combat.hit.damage
 import content.entity.combat.killer
 import content.entity.player.dialogue.Angry
@@ -17,7 +18,6 @@ import org.rsmod.game.pathfinder.collision.CollisionStrategies
 import org.rsmod.game.pathfinder.flag.CollisionFlag
 import world.gregs.voidps.cache.definition.data.NPCDefinition
 import world.gregs.voidps.engine.Script
-import world.gregs.voidps.engine.client.instruction.handle.interactPlayer
 import world.gregs.voidps.engine.client.message
 import world.gregs.voidps.engine.client.ui.chat.plural
 import world.gregs.voidps.engine.client.ui.close
@@ -133,7 +133,12 @@ class TzhaarFightCave(
             }
         }
 
-        npcCombatDamage("tz_kek,tz_kek_spawn_point") { (source) ->
+        npcCombatAttack("tz_kih,tz_kih_spawn_point") { (target, damage) ->
+            target.levels.drain(Skill.Prayer, damage.coerceAtLeast(0) / 10 + 1)
+        }
+
+        // Recoil is a "damage" type hit so it isn't reduced by protection prayers
+        npcCombatDamage("tz_kek,tz_kek_spawn_point,tz_kek_spawn", "melee") { (source) ->
             source.damage(10)
         }
 
@@ -310,7 +315,9 @@ class TzhaarFightCave(
     private fun spawn(id: String, tile: Tile, target: Player) {
         val npc = NPCs.add(id, tile)
         npc["in_multi_combat"] = true
-        npc.interactPlayer(target, "Attack")
+        // Engage combat directly; the Interact mode used by interactPlayer gives up (cantReach)
+        // when blocked by an obstacle, leaving the npc to wander off instead of pursuing.
+        Combat.combat(npc, target)
         if (id == "tztok_jad") {
             npc["healed"] = true
         }

--- a/game/src/test/kotlin/content/area/karamja/tzhaar_city/TzHaarHealersTest.kt
+++ b/game/src/test/kotlin/content/area/karamja/tzhaar_city/TzHaarHealersTest.kt
@@ -1,0 +1,46 @@
+package content.area.karamja.tzhaar_city
+
+import WorldTest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import world.gregs.voidps.engine.entity.character.player.skill.Skill
+import world.gregs.voidps.type.Tile
+
+class TzHaarHealersTest : WorldTest() {
+
+    @Test
+    fun `Healers heal jad 50 life points every 4 ticks`() {
+        val jad = createNPC("tztok_jad", Tile(2401, 5088))
+        val healer = createNPC("yt_hur_kot", jad.tile.add(-1, 0))
+        jad.levels.drain(Skill.Constitution, 500)
+        healer.softTimers.start("yt_hur_kot_heal")
+
+        tick(5)
+        assertEquals(2050, jad.levels.get(Skill.Constitution))
+
+        tick(4)
+        assertEquals(2100, jad.levels.get(Skill.Constitution))
+    }
+
+    @Test
+    fun `Healers heal jad within 4 tiles of any side of him`() {
+        val jad = createNPC("tztok_jad", Tile(2401, 5088))
+        val healer = createNPC("yt_hur_kot", jad.tile.add(jad.size + 3, 0))
+        jad.levels.drain(Skill.Constitution, 500)
+        healer.softTimers.start("yt_hur_kot_heal")
+
+        tick(5)
+        assertEquals(2050, jad.levels.get(Skill.Constitution))
+    }
+
+    @Test
+    fun `Healers do not heal jad from more than 4 tiles away`() {
+        val jad = createNPC("tztok_jad", Tile(2401, 5088))
+        val healer = createNPC("yt_hur_kot", jad.tile.add(jad.size + 4, 0))
+        jad.levels.drain(Skill.Constitution, 500)
+        healer.softTimers.start("yt_hur_kot_heal")
+
+        tick(6)
+        assertEquals(2000, jad.levels.get(Skill.Constitution))
+    }
+}

--- a/game/src/test/kotlin/content/area/karamja/tzhaar_city/TzhaarFightCaveTest.kt
+++ b/game/src/test/kotlin/content/area/karamja/tzhaar_city/TzhaarFightCaveTest.kt
@@ -3,6 +3,7 @@ package content.area.karamja.tzhaar_city
 import FakeRandom
 import WorldTest
 import content.entity.combat.hit.directHit
+import content.entity.combat.hit.hit
 import intEntry
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Assertions.*
@@ -11,6 +12,7 @@ import org.koin.test.get
 import world.gregs.voidps.engine.client.instruction.handle.interactObject
 import world.gregs.voidps.engine.data.AccountManager
 import world.gregs.voidps.engine.entity.Spawn
+import world.gregs.voidps.engine.entity.character.mode.combat.CombatMovement
 import world.gregs.voidps.engine.entity.character.move.tele
 import world.gregs.voidps.engine.entity.character.npc.NPCs
 import world.gregs.voidps.engine.entity.character.player.Player
@@ -95,6 +97,50 @@ class TzhaarFightCaveTest : WorldTest() {
         if (killed) {
             tick(7)
         }
+    }
+
+    @Test
+    fun `Tz-Kih attacks drain prayer points`() {
+        val player = createPlayer(name = "JalYt-6")
+        player.levels.set(Skill.Prayer, 50)
+        val npc = createNPC("tz_kih") { it.huntMode = "" }
+
+        npc.hit(player, offensiveType = "stab", damage = 40)
+        tick()
+        assertEquals(45, player.levels.get(Skill.Prayer))
+
+        npc.hit(player, offensiveType = "stab", damage = 0)
+        tick()
+        assertEquals(44, player.levels.get(Skill.Prayer))
+    }
+
+    @Test
+    fun `Tz-Kek recoils melee attacks but not ranged`() {
+        val player = createPlayer(name = "JalYt-7")
+        val npc = createNPC("tz_kek")
+
+        npc.directHit(player, 50, "melee")
+        tick(2)
+        assertEquals(90, player.levels.get(Skill.Constitution))
+
+        npc.directHit(player, 50, "range")
+        tick(2)
+        assertEquals(90, player.levels.get(Skill.Constitution))
+    }
+
+    @Test
+    fun `Fight cave npcs spawn in combat and never give up pursuit`() {
+        setRandom(object : FakeRandom() {
+            override fun nextBits(bitCount: Int): Int = 0
+        })
+        val player = createPlayer(Tile(2438, 5168), "JalYt-8")
+        player["god_mode"] = true
+        val entrance = GameObjects.find(Tile(2437, 5166), "cave_entrance_fight_cave")
+        player.interactObject(entrance, "Enter")
+        tick(5)
+        val npcs = NPCs.at(player.tile.regionLevel).toList()
+        assertTrue(npcs.isNotEmpty())
+        assertTrue(npcs.all { it.mode is CombatMovement })
     }
 
     @Test


### PR DESCRIPTION
## Fixes

### Tz-Kih prayer drain
Tz-Kih attacks were not draining prayer correctly. They now drain `1 + damage/10` prayer points per attack (so at least 1 point even on a 0), replacing the flat `impact_drain` of 1 that only applied on damaging hits.

### Tz-Kek recoil
The recoil hit triggered on any attack style; it now only triggers on melee attacks and also applies to the level 22 Tz-Kek spawns. Recoil is dealt as a "damage" hit so it pierces protection prayers.

### Mobs walking away when blocked
Fight cave npcs were spawned with `interactPlayer(target, "Attack")`. When an obstacle blocked their path, the `Interact` mode gave up (`cantReach`) and cleared to `EmptyMode`, leaving them to wander off. They are now engaged with `Combat.combat(npc, target)` directly so `CombatMovement` keeps them pursuing the player (blocked mobs stand and keep trying, matching original behaviour).

### TzHaar healers double heal + range
`"healed"` hits already restore health in `CombatHitsplats`, so the manual `levels.restore` before `directHit` doubled every heal — Yt-HurKot healed Jad 100 per tick instead of 50, and Yt-MejKot healed 200 instead of 100. Also the Yt-HurKot heal range is now 4 tiles from Jad's occupied area rather than 5 tiles from his south-west corner (which over-reached on his south/west and barely reached on his north/east).

## Tests
- `TzhaarFightCaveTest`: prayer drain amounts (40 damage → 5 points, 0 damage → 1 point), melee-only recoil, spawned npcs immediately in `CombatMovement`.
- New `TzHaarHealersTest`: exactly 50 healed per 4-tick interval, heals from 4 tiles off any side of Jad, no heal from 5 tiles.
- Full `:game:test` suite passes.