### PR TITLE
fix: clan chat messages invisible after clicking clan filter tab

### DIFF
--- a/game/src/main/kotlin/content/social/chat/ChatFilters.kt
+++ b/game/src/main/kotlin/content/social/chat/ChatFilters.kt
@@ -28,19 +28,46 @@ var Player.tradeStatus: String
 
 class ChatFilters : Script {
 
+    val statuses = mapOf(
+        "game_status" to listOf("all", "filter"),
+        "public_status" to listOf("on", "friends", "off", "hide"),
+        "private_status" to listOf("on", "friends", "off"),
+        "trade_status" to listOf("on", "friends", "off"),
+        "clan_status" to listOf("on", "friends", "off"),
+        "assist_status" to listOf("on", "friends", "off"),
+    )
+
     init {
         playerSpawn {
+            // Left-clicking a filter button used to store its "View" option as a status,
+            // leaving an invalid value that hides the filter's messages every session
+            for ((key, values) in statuses) {
+                if (get(key, values.first()) !in values) {
+                    clear(key)
+                }
+            }
             privateStatus(privateStatus)
             publicStatus(publicStatus, tradeStatus)
         }
 
-        interfaceOption("View", id = "filter_buttons:*") {
-            when (it.component) {
-                "game", "clan" -> set("${it.component}_status", it.option.lowercase())
-                "public" -> publicStatus = it.option.lowercase()
-                "private" -> privateStatus = it.option.lowercase()
-                "trade" -> tradeStatus = it.option.lowercase()
+        for (option in listOf("On", "Friends", "Off")) {
+            interfaceOption(option, "filter_buttons:clan") {
+                set("clan_status", option.lowercase())
             }
+            interfaceOption(option, "filter_buttons:trade") {
+                tradeStatus = option.lowercase()
+            }
+        }
+        for (option in listOf("On", "Friends", "Off", "Hide")) {
+            interfaceOption(option, "filter_buttons:public") {
+                publicStatus = option.lowercase()
+            }
+        }
+        interfaceOption("All", "filter_buttons:game") {
+            set("game_status", "all")
+        }
+        interfaceOption("Filter", "filter_buttons:game") {
+            set("game_status", "filter")
         }
     }
 }

--- a/game/src/main/kotlin/content/social/chat/ChatFilters.kt
+++ b/game/src/main/kotlin/content/social/chat/ChatFilters.kt
@@ -50,24 +50,16 @@ class ChatFilters : Script {
             publicStatus(publicStatus, tradeStatus)
         }
 
-        for (option in listOf("On", "Friends", "Off")) {
-            interfaceOption(option, "filter_buttons:clan") {
-                set("clan_status", option.lowercase())
+        interfaceOption(id = "filter_buttons:*") {
+            if (it.option == "View") {
+                return@interfaceOption
             }
-            interfaceOption(option, "filter_buttons:trade") {
-                tradeStatus = option.lowercase()
+            when (it.component) {
+                "game", "clan" -> set("${it.component}_status", it.option.lowercase())
+                "public" -> publicStatus = it.option.lowercase()
+                // "private" is handled by FriendsList's filter_buttons:private handler
+                "trade" -> tradeStatus = it.option.lowercase()
             }
-        }
-        for (option in listOf("On", "Friends", "Off", "Hide")) {
-            interfaceOption(option, "filter_buttons:public") {
-                publicStatus = option.lowercase()
-            }
-        }
-        interfaceOption("All", "filter_buttons:game") {
-            set("game_status", "all")
-        }
-        interfaceOption("Filter", "filter_buttons:game") {
-            set("game_status", "filter")
         }
     }
 }

--- a/game/src/main/kotlin/content/social/friend/FriendsList.kt
+++ b/game/src/main/kotlin/content/social/friend/FriendsList.kt
@@ -111,6 +111,9 @@ class FriendsList(
 
         interfaceOption(id = "filter_buttons:private") {
             val option = it.option
+            if (option != "On" && option != "Friends" && option != "Off") {
+                return@interfaceOption
+            }
             if (privateStatus != "on" && option != "Off") {
                 val next = option.lowercase()
                 notifyBefriends(this, online = true) { p, current ->

--- a/game/src/test/kotlin/content/social/chat/ChatFiltersTest.kt
+++ b/game/src/test/kotlin/content/social/chat/ChatFiltersTest.kt
@@ -1,0 +1,66 @@
+package content.social.chat
+
+import WorldTest
+import interfaceOption
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import world.gregs.voidps.engine.entity.Spawn
+import world.gregs.voidps.engine.entity.character.player.Player
+
+internal class ChatFiltersTest : WorldTest() {
+
+    private lateinit var player: Player
+
+    @BeforeEach
+    fun start() {
+        runBlocking(Dispatchers.Default) {
+            player = createPlayer(name = "player")
+        }
+    }
+
+    @Test
+    fun `Viewing the clan filter tab does not change the filter status`() {
+        player.interfaceOption("filter_buttons", "clan", "View")
+
+        assertEquals("on", player["clan_status", "on"])
+    }
+
+    @Test
+    fun `Clan filter option is applied and persisted`() {
+        player.interfaceOption("filter_buttons", "clan", "Friends")
+
+        assertEquals("friends", player["clan_status", "on"])
+
+        player.interfaceOption("filter_buttons", "clan", "On")
+
+        assertEquals("on", player["clan_status", "on"])
+    }
+
+    @Test
+    fun `Game filter option is applied`() {
+        player.interfaceOption("filter_buttons", "game", "Filter")
+
+        assertEquals("filter", player["game_status", "all"])
+
+        player.interfaceOption("filter_buttons", "game", "View")
+
+        assertEquals("filter", player["game_status", "all"])
+    }
+
+    @Test
+    fun `Invalid persisted filter statuses are cleared on spawn`() {
+        val poisoned = createPlayer(name = "poisoned")
+        poisoned["clan_status"] = "view"
+        poisoned["private_status"] = "view"
+
+        runBlocking(Dispatchers.Default) {
+            Spawn.player(poisoned)
+        }
+
+        assertEquals("on", poisoned["clan_status", "on"])
+        assertEquals("on", poisoned["private_status", "on"])
+    }
+}


### PR DESCRIPTION
## The bug

Left-clicking any chat filter button in the chatbox sends its first interface option, **"View"**, and `ChatFilters` stored it as the filter status:

```kotlin
"game", "clan" -> set("${it.component}_status", it.option.lowercase()) // stores "view"
```

`clan_status` is varp 1054 with `values = ["on", "friends", "off"]` — `"view"` isn't in the list, so `ListValues.toInt` returns `indexOf = -1` and the client receives **varp 1054 = -1**.

The client's chatbox clientscript (script 84 → script 90 in cache index 12) only shows clan messages (type 9) when varp 1054 is 0 ("on") or 1 ("friends" + sender is a friend); any other value silently hides them. Since the varp is `persist = true`, the poisoned value is re-sent on every login — **permanently hiding all clan chat for any player who ever left-clicked the Clan filter tab**. The "Now talking in clan channel" line is message type 11, which bypasses that filter switch, so joining still looked fine while every actual message was invisible.

The same "View" click also poisoned `game_status` (varbit 6161, `["all", "filter"]`) via `ChatFilters` and `private_status` via `FriendsList` (its handler ends with `privateStatus = option.lowercase()`).

## The fix

- `ChatFilters`: register exact option handlers for real filter values only — clan/trade `On/Friends/Off`, public `On/Friends/Off/Hide`, game `All/Filter`. "View" clicks no longer touch any status.
- `FriendsList`: the `filter_buttons:private` handler ignores anything but `On/Friends/Off`.
- `playerSpawn`: any persisted filter status outside its value list is cleared, so already-poisoned saves heal automatically on next login — no manual save cleanup needed.

## Tests

New `ChatFiltersTest`: "View" click leaves status untouched, real options apply and persist, invalid persisted statuses are cleared on spawn. All `content.social.*` tests pass.