### PR TITLE
fix: infinite item spawns when duplicates despawn on spawn tiles

### DIFF
--- a/game/src/main/kotlin/content/entity/item/spawn/FloorItemRespawn.kt
+++ b/game/src/main/kotlin/content/entity/item/spawn/FloorItemRespawn.kt
@@ -4,8 +4,9 @@ import world.gregs.voidps.engine.Script
 import world.gregs.voidps.engine.entity.World
 import world.gregs.voidps.engine.entity.item.floor.FloorItem
 import world.gregs.voidps.engine.entity.item.floor.FloorItems
+import world.gregs.voidps.engine.entity.item.floor.ItemSpawn
 import world.gregs.voidps.engine.entity.item.floor.ItemSpawns
-import world.gregs.voidps.type.random
+import world.gregs.voidps.type.Tile
 
 class FloorItemRespawn(val spawns: ItemSpawns) : Script {
 
@@ -13,9 +14,12 @@ class FloorItemRespawn(val spawns: ItemSpawns) : Script {
         floorItemDespawn {
             if (isSpawnItem(this)) {
                 val spawn = spawns.get(tile) ?: return@floorItemDespawn
+                val tile = tile
                 // TODO use lifecycle
-                World.queue("respawn_item_${spawn.id}_${spawn.amount}_${random.nextInt(Int.MAX_VALUE)}") {
-                    FloorItems.add(tile, spawn.id, spawn.amount, revealTicks = spawn.delay, owner = "")
+                World.queue("respawn_item_${tile.id}") {
+                    if (!spawnItemExists(tile, spawn)) {
+                        FloorItems.add(tile, spawn.id, spawn.amount, revealTicks = spawn.delay, owner = "")
+                    }
                 }
             }
         }
@@ -24,5 +28,9 @@ class FloorItemRespawn(val spawns: ItemSpawns) : Script {
     fun isSpawnItem(item: FloorItem): Boolean {
         val spawn = spawns.get(item.tile) ?: return false
         return item.id == spawn.id && item.amount == spawn.amount && item.owner == null
+    }
+
+    fun spawnItemExists(tile: Tile, spawn: ItemSpawn): Boolean = FloorItems.at(tile).any {
+        it.id == spawn.id && it.amount == spawn.amount && (it.owner == null || it.owner == "")
     }
 }

--- a/game/src/test/kotlin/content/entity/item/spawn/FloorItemRespawnTest.kt
+++ b/game/src/test/kotlin/content/entity/item/spawn/FloorItemRespawnTest.kt
@@ -1,0 +1,62 @@
+package content.entity.item.spawn
+
+import WorldTest
+import floorItemOption
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import world.gregs.voidps.engine.data.Settings
+import world.gregs.voidps.engine.data.configFiles
+import world.gregs.voidps.engine.entity.item.floor.FloorItems
+import world.gregs.voidps.engine.entity.item.floor.ItemSpawns
+import world.gregs.voidps.engine.entity.item.floor.loadItemSpawns
+import world.gregs.voidps.engine.get
+import world.gregs.voidps.engine.inv.inventory
+import world.gregs.voidps.type.Tile
+
+internal class FloorItemRespawnTest : WorldTest() {
+
+    @Test
+    fun `Duplicate item timing out on a spawn tile doesn't create extra spawns`() {
+        loadItemSpawns(get<ItemSpawns>(), configFiles().list(Settings["spawns.items"]))
+        val tile = Tile(3229, 3300)
+        tick()
+        assertEquals(1, FloorItems.at(tile).count { it.id == "egg" })
+
+        FloorItems.add(tile, "egg", disappearTicks = 2)
+        tick(10)
+
+        assertEquals(1, FloorItems.at(tile).count { it.id == "egg" })
+    }
+
+    @Test
+    fun `Taking a duplicate item on a spawn tile doesn't create extra spawns`() {
+        loadItemSpawns(get<ItemSpawns>(), configFiles().list(Settings["spawns.items"]))
+        val tile = Tile(3229, 3300)
+        val player = createPlayer(tile)
+        val duplicate = FloorItems.add(tile, "egg")
+        tick()
+
+        player.floorItemOption(duplicate, "Take")
+        tick(5)
+
+        assertTrue(player.inventory.contains("egg"))
+        assertEquals(1, FloorItems.at(tile).count { it.id == "egg" })
+    }
+
+    @Test
+    fun `Spawn item still respawns after being taken`() {
+        loadItemSpawns(get<ItemSpawns>(), configFiles().list(Settings["spawns.items"]))
+        val tile = Tile(3229, 3300)
+        val player = createPlayer(tile)
+        tick()
+
+        val egg = FloorItems.at(tile).first { it.id == "egg" }
+        player.floorItemOption(egg, "Take")
+        tick(1)
+
+        assertTrue(player.inventory.contains("egg"))
+        tick(10)
+        assertEquals(1, FloorItems.at(tile).count { it.id == "egg" })
+    }
+}


### PR DESCRIPTION
## Problem

Ground item spawns (e.g. the eggs in the Lumbridge chicken pen, one at 3229,3300) accumulate infinitely over time.

Chickens periodically lay a public egg (`Chicken.kt`, `lay_eggs` timer) that expires after 100 ticks. When one is laid on an item spawn tile, its expiry fires `floorItemDespawn`, and `FloorItemRespawn.isSpawnItem` matched it (same id/amount, owner `null`), so a respawn was queued even though the actual spawn item was still on the tile. Each respawned item is permanent, so every lay-on-spawn-tile added one more egg, forever. The same duplication applied to any matching public item despawning on a spawn tile (player drops timing out, taking a duplicate off the tile, the `reload` command's `FloorItems.clear()`).

The queue name also included `random.nextInt(...)`, so simultaneous despawns on the same tile could never collapse into a single respawn.

## Fix

- Respawn queue name is now deterministic per tile (`respawn_item_${tile.id}`), so duplicate despawns on the same tile collapse to one queued respawn, and different tiles with the same item no longer collide.
- Before adding, the queued respawn checks whether a matching spawn item (public, or a pending hidden respawn with owner `""`) is already on the tile and skips if so.

## Tests

New `FloorItemRespawnTest` (3 cases): laid egg timing out on a spawn tile, taking a duplicate off a spawn tile, and normal take-then-respawn. The first two fail on the previous code and pass with the fix; `DropTest` still passes.