### PR TITLE
fix: return free samples to sample stock when sold back

### DIFF
--- a/game/src/main/kotlin/content/entity/npc/shop/general/GeneralStoreRestrictions.kt
+++ b/game/src/main/kotlin/content/entity/npc/shop/general/GeneralStoreRestrictions.kt
@@ -6,7 +6,7 @@ import world.gregs.voidps.engine.inv.restrict.ItemRestrictionRule
 object GeneralStoreRestrictions : ItemRestrictionRule {
     override fun restricted(id: String): Boolean {
         if (id == "coins") {
-            return false
+            return true
         }
         val def = ItemDefinitions.getOrNull(id) ?: return false
         return !def["tradeable", true] || def.lendTemplateId != -1 || def.dummyItem != 0

--- a/game/src/main/kotlin/content/entity/npc/shop/sell/ShopSell.kt
+++ b/game/src/main/kotlin/content/entity/npc/shop/sell/ShopSell.kt
@@ -1,23 +1,28 @@
 package content.entity.npc.shop.sell
 
 import com.github.michaelbull.logging.InlineLogger
+import content.entity.npc.shop.shop
 import content.entity.npc.shop.shopInventory
 import content.entity.player.bank.isNote
 import content.entity.player.bank.noted
 import world.gregs.voidps.engine.Script
 import world.gregs.voidps.engine.client.message
 import world.gregs.voidps.engine.client.ui.chat.plural
+import world.gregs.voidps.engine.data.definition.InventoryDefinitions
+import world.gregs.voidps.engine.data.definition.ItemDefinitions
 import world.gregs.voidps.engine.entity.character.player.Player
 import world.gregs.voidps.engine.entity.character.player.chat.inventoryFull
 import world.gregs.voidps.engine.entity.item.Item
 import world.gregs.voidps.engine.event.AuditLog
+import world.gregs.voidps.engine.inv.Inventory
 import world.gregs.voidps.engine.inv.Items
 import world.gregs.voidps.engine.inv.inventory
 import world.gregs.voidps.engine.inv.transact.TransactionError
 import world.gregs.voidps.engine.inv.transact.operation.AddItem.add
 import world.gregs.voidps.engine.inv.transact.operation.MoveItemLimit.moveToLimit
+import kotlin.math.min
 
-class ShopSell : Script {
+class ShopSell(val inventoryDefinitions: InventoryDefinitions) : Script {
 
     val logger = InlineLogger()
 
@@ -28,7 +33,8 @@ class ShopSell : Script {
                 message("You can't sell this item to this shop.")
                 return@interfaceOption
             }
-            val price = item.sellPrice()
+            val unnoted = (if (item.isNote) item.noted else item) ?: item
+            val price = if (sampleDeficit(unnoted.id) != null) 0 else item.sellPrice()
             val currency = shopCurrency().plural(price)
             message("${item.def.name}: shop will buy for $price $currency.")
         }
@@ -49,6 +55,22 @@ class ShopSell : Script {
 
     fun Player.shopCurrency(): String = this["shop_currency", "coins"]
 
+    /**
+     * The shop's sample inventory paired with how many of [itemId] are missing
+     * from its default stock, or null if the item isn't a sample or samples are full.
+     */
+    fun Player.sampleDeficit(itemId: String): Pair<Inventory, Int>? {
+        val definition = inventoryDefinitions.getOrNull("${shop()}_sample") ?: return null
+        val index = definition.ids?.indexOf(ItemDefinitions.get(itemId).id) ?: return null
+        if (index == -1) {
+            return null
+        }
+        val maximum = definition.amounts?.getOrNull(index) ?: return null
+        val sample = shopInventory(true)
+        val deficit = maximum - sample[index].amount
+        return if (deficit > 0) sample to deficit else null
+    }
+
     fun sell(player: Player, item: Item, amount: Int) {
         val notNoted = if (item.isNote) item.noted else item
         if (notNoted == null) {
@@ -56,13 +78,32 @@ class ShopSell : Script {
             player.message("You can't sell this item to this shop.")
             return
         }
+        // Samples are returned to the sample stock for free until it has respawned
+        var returned = 0
+        val (sampleInventory, deficit) = player.sampleDeficit(notNoted.id) ?: (null to 0)
+        if (sampleInventory != null && deficit > 0) {
+            player.inventory.transaction {
+                returned = moveToLimit(item.id, min(amount, deficit), sampleInventory, notNoted.id)
+            }
+            if (player.inventory.transaction.error != TransactionError.None) {
+                returned = 0
+            } else if (returned > 0) {
+                val actual = Item(item.id, returned)
+                AuditLog.event(player, "sold", actual, sampleInventory.id, 0)
+                Items.sold(player, actual)
+            }
+        }
+        val remaining = amount - returned
+        if (remaining <= 0) {
+            return
+        }
         val shop = player.shopInventory(false)
         var moved = 0
         val price = item.sellPrice()
         player.inventory.transaction {
-            moved = moveToLimit(item.id, amount, shop, notNoted.id)
+            moved = moveToLimit(item.id, remaining, shop, notNoted.id)
             if (moved == 0) {
-                this.error = TransactionError.Full(amount)
+                this.error = TransactionError.Full(remaining)
                 return@transaction
             }
             if (price > 0) {
@@ -71,7 +112,9 @@ class ShopSell : Script {
         }
         when (player.inventory.transaction.error) {
             is TransactionError.Full -> {
-                if (player.inventory.isFull() && !player.inventory.contains("coins")) {
+                if (returned > 0) {
+                    // Sold-out remainder after a sample return isn't an error
+                } else if (player.inventory.isFull() && !player.inventory.contains("coins")) {
                     player.inventoryFull()
                 } else if (shop.isFull()) {
                     player.message("The shop is currently full.")
@@ -79,7 +122,9 @@ class ShopSell : Script {
                     player.message("You can't sell this item to this shop.")
                 }
             }
-            TransactionError.Invalid -> player.message("You can't sell this item to this shop.")
+            TransactionError.Invalid -> if (returned == 0) {
+                player.message("You can't sell this item to this shop.")
+            }
             else -> {
                 val actual = Item(item.id, moved)
                 AuditLog.event(player, "sold", actual, shop.id, price)

--- a/game/src/test/kotlin/content/entity/npc/shop/ShopTest.kt
+++ b/game/src/test/kotlin/content/entity/npc/shop/ShopTest.kt
@@ -118,4 +118,19 @@ internal class ShopTest : WorldTest() {
         assertEquals(1, sample.count("bronze_hatchet"))
         assertEquals(11, shop.count("bronze_hatchet"))
     }
+
+    @Test
+    fun `Can't sell coins to a general store`() {
+        val player = createPlayer(emptyTile)
+        val npc = createNPC("shopkeeper_lumbridge", emptyTile.addY(1))
+        player.inventory.add("coins", 100)
+
+        player.npcOption(npc, "Trade")
+        tick()
+        val shop = player.shopInventory(false)
+        player.interfaceOption("shop_side", "inventory", "Sell 1", item = Item("coins"), slot = 0)
+
+        assertEquals(100, player.inventory.count("coins"))
+        assertEquals(0, shop.count("coins"))
+    }
 }

--- a/game/src/test/kotlin/content/entity/npc/shop/ShopTest.kt
+++ b/game/src/test/kotlin/content/entity/npc/shop/ShopTest.kt
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.Test
 import world.gregs.voidps.engine.entity.item.Item
 import world.gregs.voidps.engine.inv.add
 import world.gregs.voidps.engine.inv.inventory
+import world.gregs.voidps.engine.inv.remove
 
 internal class ShopTest : WorldTest() {
 
@@ -58,5 +59,63 @@ internal class ShopTest : WorldTest() {
 
         assertTrue(player.inventory.count("coins") > 0)
         assertEquals(11, shop.count("iron_battleaxe"))
+    }
+
+    @Test
+    fun `Sell sample item back to depleted sample stock for free`() {
+        val player = createPlayer(emptyTile)
+        val npc = createNPC("bob", emptyTile.addY(1))
+        player.inventory.add("bronze_hatchet", 1)
+
+        player.npcOption(npc, "Trade")
+        tick()
+        val sample = player.shopInventory(true)
+        val shop = player.shopInventory(false)
+        sample.remove("bronze_hatchet", 1)
+        assertEquals(0, sample.count("bronze_hatchet"))
+
+        player.interfaceOption("shop_side", "inventory", "Sell 1", item = Item("bronze_hatchet"), slot = 0)
+
+        assertEquals(0, player.inventory.count("coins"))
+        assertEquals(1, sample.count("bronze_hatchet"))
+        assertEquals(10, shop.count("bronze_hatchet"))
+    }
+
+    @Test
+    fun `Sell sample item to main stock for coins when samples are full`() {
+        val player = createPlayer(emptyTile)
+        val npc = createNPC("bob", emptyTile.addY(1))
+        player.inventory.add("bronze_hatchet", 1)
+
+        player.npcOption(npc, "Trade")
+        tick()
+        val sample = player.shopInventory(true)
+        val shop = player.shopInventory(false)
+        player.interfaceOption("shop_side", "inventory", "Sell 1", item = Item("bronze_hatchet"), slot = 0)
+
+        assertTrue(player.inventory.count("coins") > 0)
+        assertEquals(1, sample.count("bronze_hatchet"))
+        assertEquals(11, shop.count("bronze_hatchet"))
+    }
+
+    @Test
+    fun `Selling more than the sample deficit sells the remainder for coins`() {
+        val player = createPlayer(emptyTile)
+        val npc = createNPC("bob", emptyTile.addY(1))
+        player.inventory.add("bronze_hatchet", 2)
+
+        player.npcOption(npc, "Trade")
+        tick()
+        val sample = player.shopInventory(true)
+        val shop = player.shopInventory(false)
+        sample.remove("bronze_hatchet", 1)
+        assertEquals(0, sample.count("bronze_hatchet"))
+
+        player.interfaceOption("shop_side", "inventory", "Sell 5", item = Item("bronze_hatchet"), slot = 0)
+
+        assertTrue(player.inventory.count("coins") > 0)
+        assertEquals(0, player.inventory.count("bronze_hatchet"))
+        assertEquals(1, sample.count("bronze_hatchet"))
+        assertEquals(11, shop.count("bronze_hatchet"))
     }
 }


### PR DESCRIPTION
Fixes #1105

Per the [wiki](https://runescape.wiki/w/Sample_item), sample items sold back to a shop should return to the sample stock for free unless the samples have respawned,only then are they sold to the primary stock for coins.

## Changes

- `ShopSell` now checks the shop's `_sample` inventory before selling: a new `sampleDeficit()` helper compares the live sample slot amount against its default from the inventory definition.
- `sell()` is two-phase: items first refill the sample stock for free (up to the deficit, no coins paid, audit-logged with price 0), then any remainder is sold to the primary stock for coins as before. Sequential transactions so a main-stock failure can't roll back the sample return, and "shop full"/"can't sell" messages are suppressed when the sample return already succeeded.
- "Value" option reports 0 coins when the item would return to samples.
- Noted items, shops without samples, non-coin currencies, and shared general-store main stock all behave as before.
- Also fixes selling coins to general stores: `GeneralStoreRestrictions` explicitly exempted coins, letting players sell coins into the shared store stock. Shop stock never holds coins (sale payments go to the player's inventory), so they're now restricted like any other unsellable item.

## Tests

Four new `ShopTest` cases: depleted sample stock → free return; full sample stock → coins from main stock; selling more than the deficit splits between both; selling coins to a general store is refused. All existing shop tests pass.