### PR TITLE
fix: stop Freaky Forester pheasants granting combat experience

### DIFF
--- a/cache/src/main/kotlin/world/gregs/voidps/cache/definition/Params.kt
+++ b/cache/src/main/kotlin/world/gregs/voidps/cache/definition/Params.kt
@@ -28,6 +28,7 @@ object Params {
     const val COLLECT_FOR_NEXT_LAYER = 5024
     const val COLLISION = 5025
     const val COMBAT_DEF = 5026
+    const val COMBAT_EXP = 5266
     const val COMBO = 5027
     const val COMPOSTABLE = 5028
     const val CURRENCY = 5029
@@ -365,6 +366,7 @@ object Params {
         "collect_for_next_layer" -> COLLECT_FOR_NEXT_LAYER
         "collision" -> COLLISION
         "combat_def" -> COMBAT_DEF
+        "combat_exp" -> COMBAT_EXP
         "combo" -> COMBO
         "compostable" -> COMPOSTABLE
         "currency" -> CURRENCY

--- a/data/activity/event/random/freaky_forester/freaky_forester.npcs.toml
+++ b/data/activity/event/random/freaky_forester/freaky_forester.npcs.toml
@@ -12,6 +12,7 @@ def = 3
 style = "stab"
 max_hit_melee = 10
 respawn_delay = 5
+combat_exp = false
 examine = "A brightly coloured game bird."
 
 [pheasant_1_tail_2]

--- a/game/src/main/kotlin/content/entity/player/combat/CombatExperience.kt
+++ b/game/src/main/kotlin/content/entity/player/combat/CombatExperience.kt
@@ -77,6 +77,10 @@ class CombatExperience : Script {
     }
 
     fun grant(player: Player, target: Character, skill: Skill, experience: Double) {
+        // Some npcs, like random event pheasants, give no combat experience when killed.
+        if (target is NPC && !target.transformDef["combat_exp", true]) {
+            return
+        }
         player.exp(skill, experience * calcBonus(target))
     }
 

--- a/game/src/test/kotlin/content/activity/event/random/FreakyForesterTest.kt
+++ b/game/src/test/kotlin/content/activity/event/random/FreakyForesterTest.kt
@@ -1,5 +1,6 @@
 package content.activity.event.random
 
+import FakeRandom
 import WorldTest
 import content.entity.combat.hit.damage
 import npcOption
@@ -7,10 +8,14 @@ import org.junit.jupiter.api.Test
 import skipDialogues
 import world.gregs.voidps.engine.entity.character.mode.combat.CombatApi
 import world.gregs.voidps.engine.entity.character.player.name
+import world.gregs.voidps.engine.entity.character.player.skill.Skill
 import world.gregs.voidps.engine.entity.item.floor.FloorItems
 import world.gregs.voidps.engine.inv.add
+import world.gregs.voidps.engine.inv.equipment
 import world.gregs.voidps.engine.inv.inventory
+import world.gregs.voidps.network.login.protocol.visual.update.player.EquipSlot
 import world.gregs.voidps.type.Tile
+import world.gregs.voidps.type.setRandom
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertNotNull
@@ -109,5 +114,31 @@ class FreakyForesterTest : WorldTest() {
         val pheasant = createNPC("pheasant_4_tails", Tile(2603, 4777))
 
         assertFalse(CombatApi.canAttack(player, pheasant))
+    }
+
+    @Test
+    fun `Killing a pheasant grants no combat experience`() {
+        setRandom(object : FakeRandom() {
+            override fun nextInt(until: Int) = until
+            override fun nextInt(from: Int, until: Int) = until
+        })
+        val player = startInClearing("ff_no_xp", task = 2)
+        val pheasant = createNPC("pheasant_2_tails", Tile(2602, 4777))
+        player.equipment.set(EquipSlot.Weapon.index, "dragon_longsword")
+        player.experience.set(Skill.Attack, EXPERIENCE)
+        player.experience.set(Skill.Strength, EXPERIENCE)
+        player.experience.set(Skill.Constitution, EXPERIENCE)
+
+        player.npcOption(pheasant, "Attack")
+        tickIf { pheasant.levels.get(Skill.Constitution) > 0 }
+        tick(4)
+
+        assertEquals(EXPERIENCE, player.experience.get(Skill.Attack))
+        assertEquals(EXPERIENCE, player.experience.get(Skill.Strength))
+        assertEquals(EXPERIENCE, player.experience.get(Skill.Constitution))
+    }
+
+    companion object {
+        private const val EXPERIENCE = 14_000_000.0
     }
 }


### PR DESCRIPTION
## Problem

Killing pheasants during the Freaky Forester random event grants full combat experience (attack style xp + Constitution), which can disrupt goals for skiller builds. On rs wiki behavior the event pheasants give no combat experience.

## Solution

- Adds a `combat_exp` npc definition param (default `true`), checked once in `CombatExperience.grant` so all xp paths (melee/magic/range, Constitution, familiars) respect it.
- Sets `combat_exp = false` on the pheasant base definition; all variants inherit it via `clone`.
- The flag is reusable for any other npc that shouldn't give combat xp.

## Testing

- New WorldTest: kills a pheasant through real combat and asserts Attack/Strength/Constitution experience is unchanged.
- Negative-checked: with the flag flipped to `true` the test fails at the xp assertion, so the guard is what's being exercised.
- Existing `FreakyForesterTest` and `CombatTest` suites pass.