### PR TITLE
Add missing skill master skillcape dialogue

### DIFF
--- a/game/src/main/kotlin/content/area/asgarnia/burthorpe/rogues_den/MartinThwait.kt
+++ b/game/src/main/kotlin/content/area/asgarnia/burthorpe/rogues_den/MartinThwait.kt
@@ -4,32 +4,46 @@ import content.entity.npc.shop.openShop
 import content.entity.player.dialogue.Happy
 import content.entity.player.dialogue.Neutral
 import content.entity.player.dialogue.Quiz
+import content.entity.player.dialogue.Sad
 import content.entity.player.dialogue.Shifty
 import content.entity.player.dialogue.Shock
+import content.entity.player.dialogue.skillcapeMastered
+import content.entity.player.dialogue.skillcapeShop
 import content.entity.player.dialogue.type.choice
 import content.entity.player.dialogue.type.npc
 import world.gregs.voidps.engine.Script
+import world.gregs.voidps.engine.entity.character.player.Player
+import world.gregs.voidps.engine.entity.character.player.skill.Skill
+import world.gregs.voidps.engine.entity.character.player.skill.level.Level.has
 
 class MartinThwait : Script {
     init {
-        npcOperate("Talk-to", "martin_thwait") { (target) ->
+        npcOperate("Talk-to", "martin_thwait") {
             npc<Shifty>("You know it's sometimes funny how things work out, I lose some gold but find an item, or I lose an item and find some gold... no-one ever knows what's gone where ya know.")
             choice {
                 option("Yeah I know what you mean, found anything recently?") {
-                    openShop(target.def["shop"])
+                    lostAndFound()
                 }
                 option<Quiz>("Can you tell me about your cape?") {
                     npc<Happy>("Certainly! Skillcapes are a symbol of achievement. Only people who have mastered a skill and reached level 99 can get their hands on them and gain the benefits they carry.")
                     npc<Neutral>("The Cape of Thieving provides a nice boost to your chances of pickpocketing when worn. Is there anything else I can help you with?")
                     choice {
                         option("Have you found anything recently?") {
-                            openShop(target.def["shop"])
+                            lostAndFound()
                         }
                         option("No thank you.")
                     }
                 }
                 option<Shock>("Okay... I'll be going now.")
             }
+        }
+    }
+
+    suspend fun Player.lostAndFound() {
+        when {
+            skillcapeMastered(Skill.Thieving) || (has(Skill.Thieving, 50) && has(Skill.Agility, 50)) -> openShop(skillcapeShop(Skill.Thieving, "martin_thwaits_lost_and_found"))
+            !has(Skill.Thieving, 50) -> npc<Sad>("Sorry, mate. Train up your Thieving skill to at least 50 and I might be able to help you out.")
+            else -> npc<Sad>("Sorry, mate. Train up your Agility skill to at least 50 and I might be able to help you out.")
         }
     }
 }

--- a/game/src/main/kotlin/content/area/asgarnia/burthorpe/warriors_guild/Ajjat.kt
+++ b/game/src/main/kotlin/content/area/asgarnia/burthorpe/warriors_guild/Ajjat.kt
@@ -1,0 +1,16 @@
+package content.area.asgarnia.burthorpe.warriors_guild
+
+import content.entity.player.dialogue.Quiz
+import content.entity.player.dialogue.skillcapeMasterDialogue
+import content.entity.player.dialogue.type.player
+import world.gregs.voidps.engine.Script
+import world.gregs.voidps.engine.entity.character.player.skill.Skill
+
+class Ajjat : Script {
+    init {
+        npcOperate("Talk-to", "ajjat") {
+            player<Quiz>("What is that cape you're wearing?")
+            skillcapeMasterDialogue(Skill.Attack, "a master in the fine art of attacking")
+        }
+    }
+}

--- a/game/src/main/kotlin/content/area/asgarnia/burthorpe/warriors_guild/Sloane.kt
+++ b/game/src/main/kotlin/content/area/asgarnia/burthorpe/warriors_guild/Sloane.kt
@@ -1,0 +1,16 @@
+package content.area.asgarnia.burthorpe.warriors_guild
+
+import content.entity.player.dialogue.Quiz
+import content.entity.player.dialogue.skillcapeMasterDialogue
+import content.entity.player.dialogue.type.player
+import world.gregs.voidps.engine.Script
+import world.gregs.voidps.engine.entity.character.player.skill.Skill
+
+class Sloane : Script {
+    init {
+        npcOperate("Talk-to", "sloane,sloane_falador") {
+            player<Quiz>("What is that cape you're wearing?")
+            skillcapeMasterDialogue(Skill.Strength, "as strong as is possible")
+        }
+    }
+}

--- a/game/src/main/kotlin/content/area/asgarnia/falador/EstateAgent.kt
+++ b/game/src/main/kotlin/content/area/asgarnia/falador/EstateAgent.kt
@@ -1,0 +1,17 @@
+package content.area.asgarnia.falador
+
+import content.entity.player.dialogue.Quiz
+import content.entity.player.dialogue.skillcapeMasterDialogue
+import content.entity.player.dialogue.type.player
+import world.gregs.voidps.engine.Script
+import world.gregs.voidps.engine.entity.character.player.skill.Skill
+
+class EstateAgent : Script {
+    init {
+        // TODO house purchase, redecoration and relocation dialogue when construction lands
+        npcOperate("Talk-to", "estate_agent*") {
+            player<Quiz>("What's that cape you are wearing?")
+            skillcapeMasterDialogue(Skill.Construction, "a master home builder")
+        }
+    }
+}

--- a/game/src/main/kotlin/content/area/asgarnia/falador/Gadrin.kt
+++ b/game/src/main/kotlin/content/area/asgarnia/falador/Gadrin.kt
@@ -1,0 +1,16 @@
+package content.area.asgarnia.falador
+
+import content.entity.player.dialogue.Quiz
+import content.entity.player.dialogue.skillcapeMasterDialogue
+import content.entity.player.dialogue.type.player
+import world.gregs.voidps.engine.Script
+import world.gregs.voidps.engine.entity.character.player.skill.Skill
+
+class Gadrin : Script {
+    init {
+        npcOperate("Talk-to", "gadrin") {
+            player<Quiz>("What is that cape you're wearing?")
+            skillcapeMasterDialogue(Skill.Mining, "a master miner")
+        }
+    }
+}

--- a/game/src/main/kotlin/content/area/asgarnia/falador/Wilfred.kt
+++ b/game/src/main/kotlin/content/area/asgarnia/falador/Wilfred.kt
@@ -1,0 +1,16 @@
+package content.area.asgarnia.falador
+
+import content.entity.player.dialogue.Quiz
+import content.entity.player.dialogue.skillcapeMasterDialogue
+import content.entity.player.dialogue.type.player
+import world.gregs.voidps.engine.Script
+import world.gregs.voidps.engine.entity.character.player.skill.Skill
+
+class Wilfred : Script {
+    init {
+        npcOperate("Talk-to", "wilfred_falador") {
+            player<Quiz>("What is that cape you're wearing?")
+            skillcapeMasterDialogue(Skill.Woodcutting, "a master woodsman")
+        }
+    }
+}

--- a/game/src/main/kotlin/content/area/asgarnia/port_sarim/Thurgo.kt
+++ b/game/src/main/kotlin/content/area/asgarnia/port_sarim/Thurgo.kt
@@ -7,6 +7,9 @@ import content.quest.quest
 import net.pearx.kasechange.toSentenceCase
 import world.gregs.voidps.engine.Script
 import world.gregs.voidps.engine.entity.character.player.Player
+import world.gregs.voidps.engine.entity.character.player.skill.Skill
+import world.gregs.voidps.engine.entity.character.player.skill.level.Level
+import world.gregs.voidps.engine.entity.character.player.skill.level.Level.hasMax
 import world.gregs.voidps.engine.entity.item.Item
 import world.gregs.voidps.engine.inv.carriesItem
 import world.gregs.voidps.engine.inv.contains
@@ -204,6 +207,10 @@ class Thurgo : Script {
     suspend fun Player.thatCape() {
         player<Quiz>("What is that cape you're wearing?")
         npc<Happy>("It's a Skillcape of Smithing. It shows that I'm a master blacksmith, but that's only to be expected - after all, my ancestors were the greatest blacksmiths in dwarven history.")
-        npc<Happy>("If you ever achieve level 99 Smithing you'll be able to wear a cape like this, and receive more experience when smelting gold ore.")
+        if (hasMax(Skill.Smithing, Level.MAX_LEVEL)) {
+            skillcapeOffer(Skill.Smithing, "a master blacksmith")
+        } else {
+            npc<Happy>("If you ever achieve level 99 Smithing you'll be able to wear a cape like this, and receive more experience when smelting gold ore.")
+        }
     }
 }

--- a/game/src/main/kotlin/content/area/asgarnia/rimmington/CraftingGuild.kt
+++ b/game/src/main/kotlin/content/area/asgarnia/rimmington/CraftingGuild.kt
@@ -1,6 +1,5 @@
 package content.area.asgarnia.rimmington
 
-import com.github.michaelbull.logging.InlineLogger
 import content.entity.obj.door.enterDoor
 import content.entity.player.dialogue.*
 import content.entity.player.dialogue.type.choice
@@ -8,18 +7,11 @@ import content.entity.player.dialogue.type.npc
 import content.entity.player.dialogue.type.player
 import world.gregs.voidps.engine.Script
 import world.gregs.voidps.engine.entity.character.player.skill.Skill
-import world.gregs.voidps.engine.entity.character.player.skill.level.Level
 import world.gregs.voidps.engine.entity.character.player.skill.level.Level.has
 import world.gregs.voidps.engine.entity.character.player.skill.level.Level.hasMax
 import world.gregs.voidps.engine.inv.equipment
-import world.gregs.voidps.engine.inv.inventory
-import world.gregs.voidps.engine.inv.transact.TransactionError
-import world.gregs.voidps.engine.inv.transact.operation.AddItem.add
-import world.gregs.voidps.engine.inv.transact.operation.RemoveItem.remove
 
 class CraftingGuild : Script {
-
-    val logger = InlineLogger()
 
     init {
         objectOperate("Open", "guild_door_2_closed") { (target) ->
@@ -49,21 +41,7 @@ class CraftingGuild : Script {
                         npc<Idle>("Not at all; there are many other adventurers who would love the opportunity to purchase such a prestigious item! You can find me here if you change your mind.")
                     }
                     option<Idle>("That's fine.") {
-                        inventory.transaction {
-                            val trimmed = Skill.entries.any { it != Skill.Crafting && levels.getMax(it) >= Level.MAX_LEVEL }
-                            remove("coins", 99000)
-                            add("crafting_cape${if (trimmed) "_t" else ""}")
-                            add("crafting_hood")
-                        }
-                        when (inventory.transaction.error) {
-                            is TransactionError.Deficient -> {
-                                player<Sad>("But, unfortunately, I don't have enough money with me.")
-                                npc<Idle>("Well, come back and see me when you do.")
-                            }
-                            is TransactionError.Full -> npc<Quiz>("Unfortunately all Skillcapes are only available with a free hood, it's part of a skill promotion deal; buy one get one free, you know. So you'll need to free up some inventory space before I can sell you one.")
-                            TransactionError.None -> npc<Happy>("Excellent! Wear that cape with pride my friend.")
-                            else -> logger.debug { "Error buying crafting skillcape." }
-                        }
+                        buySkillcape(Skill.Crafting, deficient = "But, unfortunately, I don't have enough money with me.")
                     }
                 }
             } else {

--- a/game/src/main/kotlin/content/area/asgarnia/taverley/Kaqemeex.kt
+++ b/game/src/main/kotlin/content/area/asgarnia/taverley/Kaqemeex.kt
@@ -13,13 +13,9 @@ import world.gregs.voidps.engine.entity.character.player.Player
 import world.gregs.voidps.engine.entity.character.player.name
 import world.gregs.voidps.engine.entity.character.player.skill.Skill
 import world.gregs.voidps.engine.entity.character.player.skill.exp.exp
-import world.gregs.voidps.engine.entity.character.player.skill.level.Level
 import world.gregs.voidps.engine.entity.character.player.skill.level.Level.hasMax
 import world.gregs.voidps.engine.event.AuditLog
 import world.gregs.voidps.engine.inv.inventory
-import world.gregs.voidps.engine.inv.transact.TransactionError
-import world.gregs.voidps.engine.inv.transact.operation.AddItem.add
-import world.gregs.voidps.engine.inv.transact.operation.RemoveItem.remove
 import world.gregs.voidps.engine.queue.longQueue
 
 class Kaqemeex : Script {
@@ -150,22 +146,7 @@ class Kaqemeex : Script {
                             npc<Idle>("Not at all; there are many other adventurers who would love the opportunity to purchase such a prestigious item. You can find me here if you change your mind.")
                         }
                         option<Happy>("Okay, here's 99,000 coins.") {
-                            inventory.transaction {
-                                val trimmed = Skill.entries.any { it != Skill.Herblore && levels.getMax(it) >= Level.MAX_LEVEL }
-                                add("herblore_cape${if (trimmed) "_t" else ""}")
-                                add("herblore_hood")
-                                remove("coins", 99000)
-                            }
-                            when (inventory.transaction.error) {
-                                TransactionError.None -> npc<Happy>("Good luck to you, $name.")
-                                is TransactionError.Deficient -> {
-                                    player<Sad>("But, unfortunately, I was mistaken.")
-                                    npc<Idle>("Well, come back and see me when you do.")
-                                }
-                                is TransactionError.Full, is TransactionError.Invalid -> {
-                                    npc<Sad>("Unfortunately all Skillcapes are only available with a free hood, it's part of a skill promotion deal; buy one get one free, you know. So you'll need to free up some inventory space before I can sell you one.")
-                                }
-                            }
+                            buySkillcape(Skill.Herblore, success = "Good luck to you, $name.")
                         }
                     }
                 }

--- a/game/src/main/kotlin/content/area/asgarnia/taverley/Pikkupstix.kt
+++ b/game/src/main/kotlin/content/area/asgarnia/taverley/Pikkupstix.kt
@@ -6,21 +6,16 @@ import content.entity.player.dialogue.Happy
 import content.entity.player.dialogue.Idle
 import content.entity.player.dialogue.Neutral
 import content.entity.player.dialogue.Quiz
-import content.entity.player.dialogue.Sad
+import content.entity.player.dialogue.buySkillcape
 import content.entity.player.dialogue.type.choice
 import content.entity.player.dialogue.type.npc
-import content.entity.player.dialogue.type.player
 import content.skill.summoning.enchantHeadgear
 import world.gregs.voidps.engine.Script
 import world.gregs.voidps.engine.entity.character.player.Player
 import world.gregs.voidps.engine.entity.character.player.name
 import world.gregs.voidps.engine.entity.character.player.skill.Skill
-import world.gregs.voidps.engine.entity.character.player.skill.level.Level
 import world.gregs.voidps.engine.entity.character.player.skill.level.Level.hasMax
 import world.gregs.voidps.engine.inv.inventory
-import world.gregs.voidps.engine.inv.transact.TransactionError
-import world.gregs.voidps.engine.inv.transact.operation.AddItem.add
-import world.gregs.voidps.engine.inv.transact.operation.RemoveItem.remove
 
 class Pikkupstix : Script {
     init {
@@ -105,20 +100,7 @@ class Pikkupstix : Script {
                 npc<Idle>("Not at all; there are many other adventurers who would love the opportunity to purchase such a prestigious item. You can find me here if you change your mind.")
             }
             option<Happy>("Okay, here's 99,000 coins.") {
-                inventory.transaction {
-                    val trimmed = Skill.entries.any { it != Skill.Summoning && levels.getMax(it) >= Level.MAX_LEVEL }
-                    add("summoning_cape${if (trimmed) "_t" else ""}")
-                    add("summoning_hood")
-                    remove("coins", 99000)
-                }
-                when (inventory.transaction.error) {
-                    TransactionError.None -> npc<Happy>("Good luck to you, $name.")
-                    is TransactionError.Deficient -> {
-                        player<Sad>("But, unfortunately, I was mistaken.")
-                        npc<Idle>("Well, come back and see me when you do.")
-                    }
-                    else -> npc<Sad>("Unfortunately all Skillcapes are only available with a free hood, it's part of a skill promotion deal; buy one get one free, you know. So you'll need to free up some inventory space before I can sell you one.")
-                }
+                buySkillcape(Skill.Summoning, success = "Good luck to you, $name.")
             }
         }
     }

--- a/game/src/main/kotlin/content/area/kandarin/feldip_hills/HuntingExpert.kt
+++ b/game/src/main/kotlin/content/area/kandarin/feldip_hills/HuntingExpert.kt
@@ -1,0 +1,16 @@
+package content.area.kandarin.feldip_hills
+
+import content.entity.player.dialogue.Quiz
+import content.entity.player.dialogue.skillcapeMasterDialogue
+import content.entity.player.dialogue.type.player
+import world.gregs.voidps.engine.Script
+import world.gregs.voidps.engine.entity.character.player.skill.Skill
+
+class HuntingExpert : Script {
+    init {
+        npcOperate("Talk-to", "hunting_expert_feldip_hills") {
+            player<Quiz>("What is that cape you're wearing?")
+            skillcapeMasterDialogue(Skill.Hunter, "a master hunter")
+        }
+    }
+}

--- a/game/src/main/kotlin/content/area/kandarin/fishing_guild/MasterFisher.kt
+++ b/game/src/main/kotlin/content/area/kandarin/fishing_guild/MasterFisher.kt
@@ -1,0 +1,16 @@
+package content.area.kandarin.fishing_guild
+
+import content.entity.player.dialogue.Quiz
+import content.entity.player.dialogue.skillcapeMasterDialogue
+import content.entity.player.dialogue.type.player
+import world.gregs.voidps.engine.Script
+import world.gregs.voidps.engine.entity.character.player.skill.Skill
+
+class MasterFisher : Script {
+    init {
+        npcOperate("Talk-to", "master_fisher") {
+            player<Quiz>("What is that cape you're wearing?")
+            skillcapeMasterDialogue(Skill.Fishing, "a master fisherman")
+        }
+    }
+}

--- a/game/src/main/kotlin/content/area/kandarin/ranging_guild/ArmourSalesman.kt
+++ b/game/src/main/kotlin/content/area/kandarin/ranging_guild/ArmourSalesman.kt
@@ -1,25 +1,15 @@
 package content.area.kandarin.ranging_guild
 
 import content.entity.npc.shop.openShop
+import content.entity.player.dialogue.skillcapeShop
 import world.gregs.voidps.engine.Script
 import world.gregs.voidps.engine.entity.character.player.skill.Skill
-import world.gregs.voidps.engine.entity.character.player.skill.level.Level
 
 class ArmourSalesman : Script {
 
     init {
         npcOperate("Trade", "armour_salesman") {
-            when {
-                Skill.all.any { it != Skill.Ranged && levels.getMax(it) == Level.MAX_LEVEL } -> {
-                    openShop("aarons_archery_appendages_trimmed")
-                }
-                levels.getMax(Skill.Ranged) == Level.MAX_LEVEL -> {
-                    openShop("aarons_archery_appendages_skillcape")
-                }
-                else -> {
-                    openShop("aarons_archery_appendages")
-                }
-            }
+            openShop(skillcapeShop(Skill.Ranged, "aarons_archery_appendages"))
         }
     }
 }

--- a/game/src/main/kotlin/content/area/kandarin/seers_village/Ignatius.kt
+++ b/game/src/main/kotlin/content/area/kandarin/seers_village/Ignatius.kt
@@ -1,23 +1,15 @@
 package content.area.kandarin.seers_village
 
 import content.entity.npc.shop.openShop
+import content.entity.player.dialogue.skillcapeShop
 import world.gregs.voidps.engine.Script
 import world.gregs.voidps.engine.entity.character.player.skill.Skill
-import world.gregs.voidps.engine.entity.character.player.skill.level.Level
 
 class Ignatius : Script {
 
     init {
         npcOperate("Trade", "ignatius") {
-            openShop(
-                "ignatiuss_hot_deals${
-                    when {
-                        Skill.all.any { it != Skill.Firemaking && levels.getMax(it) == Level.MAX_LEVEL } -> "_trimmed"
-                        levels.getMax(Skill.Firemaking) == Level.MAX_LEVEL -> "_skillcape"
-                        else -> ""
-                    }
-                }",
-            )
+            openShop(skillcapeShop(Skill.Firemaking, "ignatiuss_hot_deals"))
         }
     }
 }

--- a/game/src/main/kotlin/content/area/kandarin/yanille/RobeStoreOwner.kt
+++ b/game/src/main/kotlin/content/area/kandarin/yanille/RobeStoreOwner.kt
@@ -1,6 +1,7 @@
-package content.area.kandarin.catherby
+package content.area.kandarin.yanille
 
 import content.entity.npc.shop.openShop
+import content.entity.player.dialogue.Happy
 import content.entity.player.dialogue.Neutral
 import content.entity.player.dialogue.skillcapeShop
 import content.entity.player.dialogue.type.choice
@@ -10,25 +11,25 @@ import world.gregs.voidps.engine.Script
 import world.gregs.voidps.engine.entity.character.player.Player
 import world.gregs.voidps.engine.entity.character.player.skill.Skill
 
-class Hickton : Script {
+class RobeStoreOwner : Script {
 
     init {
-        npcOperate("Trade", "hickton") {
-            openHicktonShop(this)
+        npcOperate("Trade", "robe_store_owner_yanille") {
+            openRobeShop(this)
         }
 
-        npcOperate("Talk-to", "hickton") {
-            npc<Neutral>("Welcome to Hickton's Archery Store. Do you want to see my wares?")
+        npcOperate("Talk-to", "robe_store_owner_yanille") {
+            npc<Neutral>("Welcome to the Magic Guild Store. Do you want to see my wares?")
 
             choice {
                 option("Can you tell me about your cape?") {
                     player<Neutral>("Can you tell me about your cape?")
-                    npc<Neutral>("Certainly! Skillcapes are a symbol of achievement. Only people who have mastered a skill and reached level 99 can get their hands on them and gain the benefits they carry.")
+                    npc<Happy>("Certainly! Skillcapes are a symbol of achievement. Only people who have mastered a skill and reached level 99 can get their hands on them and gain the benefits they carry.")
                     npc<Neutral>("Is there anything else I can help you with?")
 
                     choice {
                         option("I'd like to view your store, please.") {
-                            openHicktonShop(this)
+                            openRobeShop(this)
                         }
                         option("No thank you.") {
                             player<Neutral>("No thank you.")
@@ -37,17 +38,17 @@ class Hickton : Script {
                 }
 
                 option("Yes, please.") {
-                    openHicktonShop(this)
+                    openRobeShop(this)
                 }
 
-                option("No, I prefer to bash things close up.") {
-                    player<Neutral>("No, I prefer to bash things close up.")
+                option("No thank you.") {
+                    player<Neutral>("No thank you.")
                 }
             }
         }
     }
 
-    fun openHicktonShop(player: Player) {
-        player.openShop(player.skillcapeShop(Skill.Fletching, "hicktons_archery_emporium"))
+    fun openRobeShop(player: Player) {
+        player.openShop(player.skillcapeShop(Skill.Magic, "magic_guild_store_mystic_robes"))
     }
 }

--- a/game/src/main/kotlin/content/area/karamja/brimhaven/CapnIzzy.kt
+++ b/game/src/main/kotlin/content/area/karamja/brimhaven/CapnIzzy.kt
@@ -1,0 +1,16 @@
+package content.area.karamja.brimhaven
+
+import content.entity.player.dialogue.Quiz
+import content.entity.player.dialogue.skillcapeMasterDialogue
+import content.entity.player.dialogue.type.player
+import world.gregs.voidps.engine.Script
+import world.gregs.voidps.engine.entity.character.player.skill.Skill
+
+class CapnIzzy : Script {
+    init {
+        npcOperate("Talk-to", "capn_izzy_no_beard_brimhaven") {
+            player<Quiz>("What is that cape you're wearing?")
+            skillcapeMasterDialogue(Skill.Agility, "as agile as possible")
+        }
+    }
+}

--- a/game/src/main/kotlin/content/area/kharidian_desert/al_kharid/duel_arena/SurgeonGeneralTafani.kt
+++ b/game/src/main/kotlin/content/area/kharidian_desert/al_kharid/duel_arena/SurgeonGeneralTafani.kt
@@ -4,12 +4,15 @@ import content.entity.player.dialogue.Confused
 import content.entity.player.dialogue.Happy
 import content.entity.player.dialogue.Idle
 import content.entity.player.dialogue.Quiz
+import content.entity.player.dialogue.skillcapeMastered
+import content.entity.player.dialogue.skillcapeOffer
 import content.entity.player.dialogue.type.choice
 import content.entity.player.dialogue.type.npc
 import content.entity.player.dialogue.type.player
 import world.gregs.voidps.engine.Script
 import world.gregs.voidps.engine.entity.character.npc.NPC
 import world.gregs.voidps.engine.entity.character.player.Player
+import world.gregs.voidps.engine.entity.character.player.skill.Skill
 
 class SurgeonGeneralTafani : Script {
 
@@ -33,6 +36,10 @@ class SurgeonGeneralTafani : Script {
             fighters()
             often()
             option<Quiz>("Can you tell me about your cape?") {
+                if (skillcapeMastered(Skill.Constitution)) {
+                    skillcapeOffer(Skill.Constitution, "as resilient as is possible")
+                    return@option
+                }
                 npc<Happy>("Certainly! Skillcapes are a symbol of achievement. Only people who have mastered a skill and reached level 99 can get their hands on them and gain the benefits they carry.")
                 npc<Idle>("The Cape of Constitution doubles the speed of your constitution replenishing when worn. Is there anything else I can help you with?")
                 menu(target)

--- a/game/src/main/kotlin/content/area/misthalin/draynor_village/Martin.kt
+++ b/game/src/main/kotlin/content/area/misthalin/draynor_village/Martin.kt
@@ -1,28 +1,20 @@
 package content.area.misthalin.draynor_village
 
-import com.github.michaelbull.logging.InlineLogger
 import content.entity.player.dialogue.Happy
-import content.entity.player.dialogue.Idle
 import content.entity.player.dialogue.Neutral
 import content.entity.player.dialogue.Quiz
 import content.entity.player.dialogue.Sad
 import content.entity.player.dialogue.Shifty
+import content.entity.player.dialogue.buySkillcape
 import content.entity.player.dialogue.type.choice
 import content.entity.player.dialogue.type.npc
 import content.entity.player.dialogue.type.player
 import content.quest.questCompleted
 import world.gregs.voidps.engine.Script
 import world.gregs.voidps.engine.entity.character.player.skill.Skill
-import world.gregs.voidps.engine.entity.character.player.skill.level.Level
 import world.gregs.voidps.engine.entity.character.player.skill.level.Level.hasMax
-import world.gregs.voidps.engine.inv.inventory
-import world.gregs.voidps.engine.inv.transact.TransactionError
-import world.gregs.voidps.engine.inv.transact.operation.AddItem.add
-import world.gregs.voidps.engine.inv.transact.operation.RemoveItem.remove
 
 class Martin : Script {
-
-    val logger = InlineLogger()
 
     init {
         npcOperate("Talk-to", "martin_the_master_gardener") { (target) ->
@@ -40,21 +32,7 @@ class Martin : Script {
                             npc<Neutral>("No skin off my teeth, but if you change your mind, the price will still be the same.")
                         }
                         option<Neutral>("Sure, not many people own one.") {
-                            inventory.transaction {
-                                val trimmed = Skill.entries.any { it != Skill.Farming && levels.getMax(it) >= Level.MAX_LEVEL }
-                                remove("coins", 99000)
-                                add("farming_cape${if (trimmed) "_t" else ""}")
-                                add("farming_hood")
-                            }
-                            when (inventory.transaction.error) {
-                                is TransactionError.Deficient -> {
-                                    player<Sad>("But, unfortunately, I don't have enough money with me.")
-                                    npc<Idle>("Well, come back and see me when you do.")
-                                }
-                                is TransactionError.Full -> npc<Quiz>("Unfortunately all Skillcapes are only available with a free hood, it's part of a skill promotion deal; buy one get one free, you know. So you'll need to free up some inventory space before I can sell you one.")
-                                TransactionError.None -> npc<Happy>("That's true; us Master Farmers are a unique breed.")
-                                else -> logger.debug { "Error buying farming skillcape." }
-                            }
+                            buySkillcape(Skill.Farming, success = "That's true; us Master Farmers are a unique breed.", deficient = "But, unfortunately, I don't have enough money with me.")
                         }
                     }
                 }

--- a/game/src/main/kotlin/content/area/misthalin/edgeville/monastery/BrotherJared.kt
+++ b/game/src/main/kotlin/content/area/misthalin/edgeville/monastery/BrotherJared.kt
@@ -1,18 +1,13 @@
 package content.area.misthalin.edgeville.monastery
 
-import com.github.michaelbull.logging.InlineLogger
 import content.entity.player.dialogue.*
 import content.entity.player.dialogue.type.*
 import world.gregs.voidps.engine.Script
 import world.gregs.voidps.engine.entity.character.player.Player
 import world.gregs.voidps.engine.entity.character.player.skill.Skill
-import world.gregs.voidps.engine.entity.character.player.skill.level.Level
 import world.gregs.voidps.engine.entity.character.player.skill.level.Level.hasMax
 import world.gregs.voidps.engine.inv.inventory
 import world.gregs.voidps.engine.inv.replace
-import world.gregs.voidps.engine.inv.transact.TransactionError
-import world.gregs.voidps.engine.inv.transact.operation.AddItem.add
-import world.gregs.voidps.engine.inv.transact.operation.RemoveItem.remove
 
 class BrotherJared : Script {
     init {
@@ -25,8 +20,6 @@ class BrotherJared : Script {
             }
         }
     }
-
-    private val logger = InlineLogger()
 
     private fun ChoiceOption.bold() {
         option<Quiz>("What can you do to help a bold adventurer like myself?") {
@@ -75,21 +68,7 @@ class BrotherJared : Script {
                         noThanks()
                     }
                     option<Happy>("I am always happy to contribute towards the monastery's upkeep.") {
-                        inventory.transaction {
-                            val trimmed = Skill.entries.any { it != Skill.Prayer && levels.getMax(it) >= Level.MAX_LEVEL }
-                            remove("coins", 99_000)
-                            add("prayer_cape${if (trimmed) "_t" else ""}")
-                            add("prayer_hood")
-                        }
-                        when (inventory.transaction.error) {
-                            is TransactionError.Deficient -> {
-                                player<Sad>("But, unfortunately, I don't have enough money with me.")
-                                npc<Idle>("Well, come back and see me when you do.")
-                            }
-                            is TransactionError.Full -> npc<Quiz>("Unfortunately all Skillcapes are only available with a free hood, it's part of a skill promotion deal; buy one get one free, you know. So you'll need to free up some inventory space before I can sell you one.")
-                            TransactionError.None -> npc<Happy>("Excellent! Wear that cape with pride my friend.")
-                            else -> logger.debug { "Error buying prayer skillcape: ${inventory.transaction.error}." }
-                        }
+                        buySkillcape(Skill.Prayer, deficient = "But, unfortunately, I don't have enough money with me.")
                     }
                 }
             }

--- a/game/src/main/kotlin/content/area/misthalin/lumbridge/combat_hall/MeleeTutor.kt
+++ b/game/src/main/kotlin/content/area/misthalin/lumbridge/combat_hall/MeleeTutor.kt
@@ -11,9 +11,6 @@ import world.gregs.voidps.engine.entity.character.player.skill.Skill
 import world.gregs.voidps.engine.entity.character.player.skill.level.Level
 import world.gregs.voidps.engine.inv.add
 import world.gregs.voidps.engine.inv.inventory
-import world.gregs.voidps.engine.inv.transact.TransactionError
-import world.gregs.voidps.engine.inv.transact.operation.AddItem.add
-import world.gregs.voidps.engine.inv.transact.operation.RemoveItem.remove
 
 class MeleeTutor : Script {
 
@@ -123,22 +120,7 @@ class MeleeTutor : Script {
             }
             option("I think I have the money right here, actually.") {
                 player<Happy>("I think I have the money right here, actually.")
-                inventory.transaction {
-                    remove("coins", 99000)
-                    add("defence_hood")
-                    val trimmed = Skill.entries.any { it != Skill.Defence && levels.getMax(it) >= Level.MAX_LEVEL }
-                    add("defence_skillcape${if (trimmed) "_t" else ""}")
-                }
-                when (inventory.transaction.error) {
-                    TransactionError.None -> npc<Happy>("Excellent! Wear that cape with pride my friend.")
-                    is TransactionError.Deficient -> {
-                        player<Sad>("But, unfortunately, I was mistaken.")
-                        npc<Idle>("Well, come back and see me when you do.")
-                    }
-                    is TransactionError.Full, is TransactionError.Invalid -> {
-                        npc<Sad>("Unfortunately all Skillcapes are only available with a free hood, it's part of a skill promotion deal; buy one get one free, you know. So you'll need to free up some inventory space before I can sell you one.")
-                    }
-                }
+                buySkillcape(Skill.Defence)
             }
         }
     }

--- a/game/src/main/kotlin/content/area/misthalin/varrock/Aubury.kt
+++ b/game/src/main/kotlin/content/area/misthalin/varrock/Aubury.kt
@@ -11,6 +11,8 @@ import content.skill.runecrafting.EssenceMine
 import world.gregs.voidps.engine.Script
 import world.gregs.voidps.engine.entity.character.npc.NPC
 import world.gregs.voidps.engine.entity.character.player.Player
+import world.gregs.voidps.engine.entity.character.player.skill.Skill
+import world.gregs.voidps.engine.entity.character.player.skill.level.Level
 import world.gregs.voidps.engine.inv.add
 import world.gregs.voidps.engine.inv.inventory
 import world.gregs.voidps.engine.inv.remove
@@ -125,7 +127,13 @@ class Aubury : Script {
         npc<Idle>("The Cape of Runecrafting has been upgraded with each talisman, allowing you to access all Runecrafting altars. Is there anything else I can help you with?")
         choice {
             option<Happy>("I'd like to view your store please.") {
-                openShop("runecrafting_skillcape")
+                openShop(
+                    when {
+                        levels.getMax(Skill.Runecrafting) < Level.MAX_LEVEL -> "auburys_rune_shop"
+                        otherSkillMaxed(Skill.Runecrafting) -> "runecrafting_skillcape_trimmed"
+                        else -> "runecrafting_skillcape"
+                    },
+                )
             }
             noThanks("No thank you.")
         }

--- a/game/src/main/kotlin/content/area/misthalin/varrock/cooks_guild/HeadChef.kt
+++ b/game/src/main/kotlin/content/area/misthalin/varrock/cooks_guild/HeadChef.kt
@@ -3,17 +3,12 @@ package content.area.misthalin.varrock.cooks_guild
 import content.entity.player.dialogue.Happy
 import content.entity.player.dialogue.Neutral
 import content.entity.player.dialogue.Quiz
-import content.entity.player.dialogue.Sad
+import content.entity.player.dialogue.buySkillcape
 import content.entity.player.dialogue.type.choice
 import content.entity.player.dialogue.type.npc
 import content.entity.player.dialogue.type.player
 import world.gregs.voidps.engine.Script
 import world.gregs.voidps.engine.entity.character.player.skill.Skill
-import world.gregs.voidps.engine.entity.character.player.skill.level.Level
-import world.gregs.voidps.engine.inv.inventory
-import world.gregs.voidps.engine.inv.transact.TransactionError
-import world.gregs.voidps.engine.inv.transact.operation.AddItem.add
-import world.gregs.voidps.engine.inv.transact.operation.RemoveItem.remove
 
 class HeadChef : Script {
     init {
@@ -29,21 +24,7 @@ class HeadChef : Script {
                         choice {
                             option("That's much too expensive.")
                             option<Happy>("Sure") {
-                                inventory.transaction {
-                                    val trimmed = Skill.entries.any { it != Skill.Cooking && levels.getMax(it) >= Level.MAX_LEVEL }
-                                    remove("coins", 99000)
-                                    add("cooking_cape${if (trimmed) "_t" else ""}")
-                                    add("cooking_hood")
-                                }
-                                when (inventory.transaction.error) {
-                                    is TransactionError.Deficient -> {
-                                        player<Sad>("But, unfortunately, I don't have enough coins.")
-                                        npc<Neutral>("Well, come back and see me when you do.")
-                                    }
-                                    is TransactionError.Full -> npc<Sad>("Unfortunately all skillcapes are only available with a free hood, it's part of a skill promotion deal; buy one get one free, you know. So you'll need to free up some backpack space before I can sell you one.")
-                                    TransactionError.None -> npc<Happy>("Now you can use the title Master Chef.")
-                                    else -> {}
-                                }
+                                buySkillcape(Skill.Cooking, success = "Now you can use the title Master Chef.", deficient = "But, unfortunately, I don't have enough coins.")
                             }
                         }
                     }

--- a/game/src/main/kotlin/content/area/wilderness/daemonheim/Thok.kt
+++ b/game/src/main/kotlin/content/area/wilderness/daemonheim/Thok.kt
@@ -8,6 +8,7 @@ import content.entity.player.dialogue.Quiz
 import content.entity.player.dialogue.Sad
 import content.entity.player.dialogue.Shock
 import content.entity.player.dialogue.Teary
+import content.entity.player.dialogue.buySkillcape
 import content.entity.player.dialogue.type.ChoiceOption
 import content.entity.player.dialogue.type.choice
 import content.entity.player.dialogue.type.npc
@@ -16,12 +17,7 @@ import world.gregs.voidps.engine.Script
 import world.gregs.voidps.engine.entity.character.player.Player
 import world.gregs.voidps.engine.entity.character.player.name
 import world.gregs.voidps.engine.entity.character.player.skill.Skill
-import world.gregs.voidps.engine.entity.character.player.skill.level.Level
 import world.gregs.voidps.engine.entity.character.player.skill.level.Level.has
-import world.gregs.voidps.engine.inv.inventory
-import world.gregs.voidps.engine.inv.transact.TransactionError
-import world.gregs.voidps.engine.inv.transact.operation.AddItem.add
-import world.gregs.voidps.engine.inv.transact.operation.RemoveItem.remove
 
 class Thok : Script {
     init {
@@ -61,22 +57,7 @@ class Thok : Script {
                 choice {
                     option("No, that's too much.")
                     option<Pleased>("Okay, that seems reasonable.") {
-                        inventory.transaction {
-                            val trimmed = Skill.entries.any { it != Skill.Dungeoneering && levels.getMax(it) >= Level.MAX_LEVEL }
-                            add("dungeoneering_cape${if (trimmed) "_t" else ""}")
-                            add("dungeoneering_hood")
-                            remove("coins", 99000)
-                        }
-                        when (inventory.transaction.error) {
-                            TransactionError.None -> npc<Happy>("Here go, great warrior. Thok will sing songs of your battles.")
-                            is TransactionError.Deficient -> {
-                                // TODO proper message
-                            }
-                            is TransactionError.Full, is TransactionError.Invalid -> {
-                                // TODO proper message
-                                npc<Sad>("Unfortunately all Skillcapes are only available with a free hood, it's part of a skill promotion deal; buy one get one free, you know. So you'll need to free up some inventory space before I can sell you one.")
-                            }
-                        }
+                        buySkillcape(Skill.Dungeoneering, success = "Here go, great warrior. Thok will sing songs of your battles.")
                     }
                 }
             }

--- a/game/src/main/kotlin/content/entity/player/dialogue/Skillcape.kt
+++ b/game/src/main/kotlin/content/entity/player/dialogue/Skillcape.kt
@@ -1,0 +1,102 @@
+package content.entity.player.dialogue
+
+import content.entity.player.dialogue.type.choice
+import content.entity.player.dialogue.type.npc
+import content.entity.player.dialogue.type.player
+import world.gregs.voidps.engine.entity.character.jingle
+import world.gregs.voidps.engine.entity.character.player.Player
+import world.gregs.voidps.engine.entity.character.player.skill.Skill
+import world.gregs.voidps.engine.entity.character.player.skill.level.Level
+import world.gregs.voidps.engine.inv.inventory
+import world.gregs.voidps.engine.inv.transact.TransactionError
+import world.gregs.voidps.engine.inv.transact.operation.AddItem.add
+import world.gregs.voidps.engine.inv.transact.operation.RemoveItem.remove
+
+// Constitution's max level is in life points (990 at level 99), not 1-99 like every other skill.
+private fun masteryLevel(skill: Skill) = if (skill == Skill.Constitution) 990 else Level.MAX_LEVEL
+
+fun Player.skillcapeMastered(skill: Skill): Boolean = levels.getMax(skill) >= masteryLevel(skill)
+
+fun Player.otherSkillMaxed(skill: Skill): Boolean = Skill.entries.any { it != skill && skillcapeMastered(it) }
+
+/**
+ * The shop variant a skill master should open: the base [shop] until the player has 99 in
+ * [skill], then the skillcape variant, trimmed once a second skill is also mastered.
+ */
+fun Player.skillcapeShop(skill: Skill, shop: String): String = when {
+    !skillcapeMastered(skill) -> shop
+    otherSkillMaxed(skill) -> "${shop}_trimmed"
+    else -> "${shop}_skillcape"
+}
+
+suspend fun Player.buySkillcape(
+    skill: Skill,
+    success: String = "Excellent! Wear that cape with pride my friend.",
+    deficient: String = "But, unfortunately, I was mistaken.",
+) {
+    val id = skill.name.lowercase()
+    inventory.transaction {
+        remove("coins", 99_000)
+        add("${id}_cape${if (otherSkillMaxed(skill)) "_t" else ""}")
+        add("${id}_hood")
+    }
+    when (inventory.transaction.error) {
+        TransactionError.None -> {
+            jingle("buy_skillcape")
+            npc<Happy>(success)
+        }
+        is TransactionError.Deficient -> {
+            player<Sad>(deficient)
+            npc<Idle>("Well, come back and see me when you do.")
+        }
+        else -> npc<Sad>("Unfortunately all Skillcapes are only available with a free hood, it's part of a skill promotion deal; buy one get one free, you know. So you'll need to free up some inventory space before I can sell you one.")
+    }
+}
+
+suspend fun Player.skillcapeOffer(
+    skill: Skill,
+    mastery: String,
+    success: String = "Excellent! Wear that cape with pride my friend.",
+) {
+    npc<Neutral>("Ah, but I see you are already $mastery, perhaps you have come to me to purchase a Skillcape of ${skill.name}, and thus join the elite few who have mastered this exacting skill?")
+    choice {
+        option("Yes, I'd like to buy one please.") {
+            player<Happy>("Yes, I'd like to buy one please.")
+            npc<Neutral>("Most certainly; unfortunately being such a prestigious item, they are appropriately expensive. I'm afraid I must ask you for 99,000 gold.")
+            choice {
+                option<Quiz>("99,000 coins? That's much too expensive.") {
+                    npc<Idle>("Not at all; there are many other adventurers who would love the opportunity to purchase such a prestigious item! You can find me here if you change your mind.")
+                }
+                option("I think I have the money right here, actually.") {
+                    player<Happy>("I think I have the money right here, actually.")
+                    buySkillcape(skill, success)
+                }
+            }
+        }
+        option<Neutral>("Nevermind.") {
+            npc<Neutral>("No problem; there are many other adventurers who would love the opportunity to purchase such a prestigious item! You can find me here if you change your mind.")
+        }
+    }
+}
+
+suspend fun Player.skillcapeMasterDialogue(
+    skill: Skill,
+    mastery: String,
+    success: String = "Excellent! Wear that cape with pride my friend.",
+) {
+    npc<Happy>("Ah, this is a Skillcape of ${skill.name}. I have mastered the art of ${skill.name.lowercase()} and wear it proudly to show others.")
+    player<Quiz>("Hmm, interesting.")
+    if (skillcapeMastered(skill)) {
+        skillcapeOffer(skill, mastery, success)
+    } else {
+        choice {
+            option("Please tell me more about skillcapes.") {
+                player<Happy>("Please tell me more about skillcapes.")
+                npc<Neutral>("Of course. Skillcapes are a symbol of achievement. Only people who have mastered a skill and reached level 99 can get their hands on them and gain the benefits they carry.")
+            }
+            option<Neutral>("Bye.") {
+                npc<Neutral>("Bye.")
+            }
+        }
+    }
+}

--- a/game/src/main/kotlin/content/skill/Skillcapes.kt
+++ b/game/src/main/kotlin/content/skill/Skillcapes.kt
@@ -1,0 +1,16 @@
+package content.skill
+
+import world.gregs.voidps.engine.Script
+import world.gregs.voidps.engine.entity.character.jingle
+import world.gregs.voidps.engine.inv.add
+import world.gregs.voidps.engine.inv.inventory
+
+class Skillcapes : Script {
+    init {
+        // Skillcapes sold through shops come with a free hood, like the dialogue-sold capes.
+        bought("ranged_cape,ranged_cape_t,firemaking_cape,firemaking_cape_t,fletching_cape,fletching_cape_t,runecrafting_cape,runecrafting_cape_t,thieving_cape,thieving_cape_t,magic_cape,magic_cape_t") { item ->
+            inventory.add("${item.id.removeSuffix("_t").removeSuffix("_cape")}_hood")
+            jingle("buy_skillcape")
+        }
+    }
+}

--- a/game/src/main/kotlin/content/skill/slayer/master/SlayerMaster.kt
+++ b/game/src/main/kotlin/content/skill/slayer/master/SlayerMaster.kt
@@ -13,6 +13,7 @@ import world.gregs.voidps.engine.client.ui.open
 import world.gregs.voidps.engine.data.definition.Tables
 import world.gregs.voidps.engine.entity.character.player.Player
 import world.gregs.voidps.engine.entity.character.player.combatLevel
+import world.gregs.voidps.engine.entity.character.player.skill.Skill
 import world.gregs.voidps.engine.inv.add
 import world.gregs.voidps.engine.inv.inventory
 
@@ -93,6 +94,11 @@ internal suspend fun Player.slayerMasterChat(master: String) {
         }
         if (master == "turael" && questCompleted("animal_magnetism")) {
             option<Neutral>("I'm here about blessed axes again.")
+        }
+        if (master == "kuradal") {
+            option<Quiz>("What is that cape you're wearing?") {
+                skillcapeMasterDialogue(Skill.Slayer, "an incredible student")
+            }
         }
         option<Neutral>("Er...nothing... ")
     }

--- a/game/src/test/kotlin/content/area/asgarnia/burthorpe/rogues_den/MartinThwaitTest.kt
+++ b/game/src/test/kotlin/content/area/asgarnia/burthorpe/rogues_den/MartinThwaitTest.kt
@@ -1,0 +1,56 @@
+package content.area.asgarnia.burthorpe.rogues_den
+
+import WorldTest
+import content.entity.npc.shop.shop
+import dialogueContinue
+import dialogueOption
+import npcOption
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import world.gregs.voidps.engine.entity.character.player.skill.Skill
+
+internal class MartinThwaitTest : WorldTest() {
+
+    @Test
+    fun `Shop refused below 50 thieving`() {
+        val player = createPlayer(emptyTile, "amateur")
+        val martin = createNPC("martin_thwait", emptyTile.addY(1))
+
+        player.npcOption(martin, "Talk-to")
+        tick()
+        player.dialogueContinue()
+        player.dialogueOption(1)
+
+        assertEquals("", player.shop())
+    }
+
+    @Test
+    fun `Shop refused below 50 agility`() {
+        val player = createPlayer(emptyTile, "clumsy")
+        player.levels.set(Skill.Thieving, 50)
+        val martin = createNPC("martin_thwait", emptyTile.addY(1))
+
+        player.npcOption(martin, "Talk-to")
+        tick()
+        player.dialogueContinue()
+        player.dialogueOption(1)
+
+        assertEquals("", player.shop())
+    }
+
+    @Test
+    fun `Shop opens with 50 thieving and 50 agility`() {
+        val player = createPlayer(emptyTile, "rogue")
+        player.levels.set(Skill.Thieving, 50)
+        player.levels.set(Skill.Agility, 50)
+        val martin = createNPC("martin_thwait", emptyTile.addY(1))
+
+        player.npcOption(martin, "Talk-to")
+        tick()
+        player.dialogueContinue()
+        player.dialogueOption(1)
+        tick(4)
+
+        assertEquals("martin_thwaits_lost_and_found", player.shop())
+    }
+}

--- a/game/src/test/kotlin/content/area/asgarnia/burthorpe/warriors_guild/AjjatTest.kt
+++ b/game/src/test/kotlin/content/area/asgarnia/burthorpe/warriors_guild/AjjatTest.kt
@@ -1,0 +1,91 @@
+package content.area.asgarnia.burthorpe.warriors_guild
+
+import WorldTest
+import dialogueContinue
+import dialogueOption
+import npcOption
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import world.gregs.voidps.engine.entity.character.player.skill.Skill
+import world.gregs.voidps.engine.inv.add
+import world.gregs.voidps.engine.inv.inventory
+
+internal class AjjatTest : WorldTest() {
+
+    @Test
+    fun `Buy a skillcape of attack with a free hood`() {
+        val player = createPlayer(emptyTile, "buyer")
+        player.experience.set(Skill.Attack, 14_000_000.0)
+        player.inventory.add("coins", 99_000)
+        val ajjat = createNPC("ajjat", emptyTile.addY(1))
+
+        player.npcOption(ajjat, "Talk-to")
+        tick()
+        player.dialogueContinue(4)
+        player.dialogueOption(1)
+        player.dialogueContinue(2)
+        player.dialogueOption(2)
+        player.dialogueContinue(2)
+
+        println("DEBUG inv: " + player.inventory.items.filter { it.id.isNotEmpty() })
+        println("DEBUG max: " + Skill.entries.associateWith { player.levels.getMax(it) })
+
+        assertEquals(1, player.inventory.count("attack_cape"))
+        assertEquals(1, player.inventory.count("attack_hood"))
+        assertEquals(0, player.inventory.count("coins"))
+    }
+
+    @Test
+    fun `Cape is trimmed with a second level 99 skill`() {
+        val player = createPlayer(emptyTile, "trimmed")
+        player.experience.set(Skill.Attack, 14_000_000.0)
+        player.experience.set(Skill.Strength, 14_000_000.0)
+        player.inventory.add("coins", 99_000)
+        val ajjat = createNPC("ajjat", emptyTile.addY(1))
+
+        player.npcOption(ajjat, "Talk-to")
+        tick()
+        player.dialogueContinue(4)
+        player.dialogueOption(1)
+        player.dialogueContinue(2)
+        player.dialogueOption(2)
+        player.dialogueContinue(2)
+
+        assertEquals(1, player.inventory.count("attack_cape_t"))
+        assertEquals(1, player.inventory.count("attack_hood"))
+    }
+
+    @Test
+    fun `No cape offer below level 99`() {
+        val player = createPlayer(emptyTile, "novice")
+        player.inventory.add("coins", 99_000)
+        val ajjat = createNPC("ajjat", emptyTile.addY(1))
+
+        player.npcOption(ajjat, "Talk-to")
+        tick()
+        player.dialogueContinue(3)
+        player.dialogueOption(1)
+        player.dialogueContinue(2)
+
+        assertEquals(0, player.inventory.count("attack_cape"))
+        assertEquals(99_000, player.inventory.count("coins"))
+    }
+
+    @Test
+    fun `No cape without enough coins`() {
+        val player = createPlayer(emptyTile, "broke")
+        player.experience.set(Skill.Attack, 14_000_000.0)
+        val ajjat = createNPC("ajjat", emptyTile.addY(1))
+
+        player.npcOption(ajjat, "Talk-to")
+        tick()
+        player.dialogueContinue(4)
+        player.dialogueOption(1)
+        player.dialogueContinue(2)
+        player.dialogueOption(2)
+        player.dialogueContinue(2)
+
+        assertEquals(0, player.inventory.count("attack_cape"))
+        assertEquals(0, player.inventory.count("attack_hood"))
+    }
+}

--- a/game/src/test/kotlin/content/area/asgarnia/burthorpe/warriors_guild/AjjatTest.kt
+++ b/game/src/test/kotlin/content/area/asgarnia/burthorpe/warriors_guild/AjjatTest.kt
@@ -27,9 +27,6 @@ internal class AjjatTest : WorldTest() {
         player.dialogueOption(2)
         player.dialogueContinue(2)
 
-        println("DEBUG inv: " + player.inventory.items.filter { it.id.isNotEmpty() })
-        println("DEBUG max: " + Skill.entries.associateWith { player.levels.getMax(it) })
-
         assertEquals(1, player.inventory.count("attack_cape"))
         assertEquals(1, player.inventory.count("attack_hood"))
         assertEquals(0, player.inventory.count("coins"))

--- a/game/src/test/kotlin/content/area/asgarnia/falador/GadrinTest.kt
+++ b/game/src/test/kotlin/content/area/asgarnia/falador/GadrinTest.kt
@@ -1,0 +1,47 @@
+package content.area.asgarnia.falador
+
+import WorldTest
+import dialogueContinue
+import dialogueOption
+import npcOption
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import world.gregs.voidps.engine.client.ui.dialogue
+import world.gregs.voidps.engine.entity.character.player.skill.Skill
+import world.gregs.voidps.engine.inv.add
+import world.gregs.voidps.engine.inv.inventory
+import kotlin.test.assertTrue
+
+internal class GadrinTest : WorldTest() {
+
+    @Test
+    fun `Talk-to opens the skillcape dialogue`() {
+        val player = createPlayer(emptyTile, "curious")
+        val gadrin = createNPC("gadrin", emptyTile.addY(1))
+
+        player.npcOption(gadrin, "Talk-to")
+        tick()
+
+        assertTrue(player.dialogue != null, "the skillcape dialogue opens")
+    }
+
+    @Test
+    fun `Buy a skillcape of mining with a free hood`() {
+        val player = createPlayer(emptyTile, "miner")
+        player.experience.set(Skill.Mining, 14_000_000.0)
+        player.inventory.add("coins", 99_000)
+        val gadrin = createNPC("gadrin", emptyTile.addY(1))
+
+        player.npcOption(gadrin, "Talk-to")
+        tick()
+        player.dialogueContinue(4)
+        player.dialogueOption(1)
+        player.dialogueContinue(2)
+        player.dialogueOption(2)
+        player.dialogueContinue(2)
+
+        assertEquals(1, player.inventory.count("mining_cape"))
+        assertEquals(1, player.inventory.count("mining_hood"))
+        assertEquals(0, player.inventory.count("coins"))
+    }
+}

--- a/game/src/test/kotlin/content/area/kandarin/yanille/RobeStoreOwnerTest.kt
+++ b/game/src/test/kotlin/content/area/kandarin/yanille/RobeStoreOwnerTest.kt
@@ -1,0 +1,51 @@
+package content.area.kandarin.yanille
+
+import WorldTest
+import content.entity.npc.shop.shop
+import npcOption
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import world.gregs.voidps.engine.entity.character.player.skill.Skill
+
+internal class RobeStoreOwnerTest : WorldTest() {
+
+    @Test
+    fun `Base shop below 99 magic`() {
+        val player = createPlayer(emptyTile, "base")
+        val owner = createNPC("robe_store_owner_yanille", emptyTile.addY(1))
+        player.npcOption(owner, "Trade")
+        tick(4)
+        assertEquals("magic_guild_store_mystic_robes", player.shop())
+    }
+
+    @Test
+    fun `Skillcape shop with 99 magic`() {
+        val player = createPlayer(emptyTile, "mage")
+        player.experience.set(Skill.Magic, 14_000_000.0)
+        val owner = createNPC("robe_store_owner_yanille", emptyTile.addY(1))
+        player.npcOption(owner, "Trade")
+        tick(4)
+        assertEquals("magic_guild_store_mystic_robes_skillcape", player.shop())
+    }
+
+    @Test
+    fun `Trimmed shop with a second 99 skill`() {
+        val player = createPlayer(emptyTile, "maxed")
+        player.experience.set(Skill.Magic, 14_000_000.0)
+        player.experience.set(Skill.Cooking, 14_000_000.0)
+        val owner = createNPC("robe_store_owner_yanille", emptyTile.addY(1))
+        player.npcOption(owner, "Trade")
+        tick(4)
+        assertEquals("magic_guild_store_mystic_robes_trimmed", player.shop())
+    }
+
+    @Test
+    fun `Base shop with another 99 but not magic`() {
+        val player = createPlayer(emptyTile, "chef")
+        player.experience.set(Skill.Cooking, 14_000_000.0)
+        val owner = createNPC("robe_store_owner_yanille", emptyTile.addY(1))
+        player.npcOption(owner, "Trade")
+        tick(4)
+        assertEquals("magic_guild_store_mystic_robes", player.shop())
+    }
+}

--- a/game/src/test/kotlin/content/skill/SkillcapesTest.kt
+++ b/game/src/test/kotlin/content/skill/SkillcapesTest.kt
@@ -1,0 +1,58 @@
+package content.skill
+
+import WorldTest
+import content.entity.npc.shop.shop
+import dialogueContinue
+import dialogueOption
+import interfaceOption
+import npcOption
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import world.gregs.voidps.engine.entity.character.player.skill.Skill
+import world.gregs.voidps.engine.entity.item.Item
+import world.gregs.voidps.engine.inv.add
+import world.gregs.voidps.engine.inv.inventory
+
+internal class SkillcapesTest : WorldTest() {
+
+    @Test
+    fun `Buying a thieving cape from Martin Thwait grants a free hood`() {
+        val player = createPlayer(emptyTile, "thief")
+        player.experience.set(Skill.Thieving, 14_000_000.0)
+        player.inventory.add("coins", 99_000)
+        val martin = createNPC("martin_thwait", emptyTile.addY(1))
+
+        player.npcOption(martin, "Talk-to")
+        tick()
+        player.dialogueContinue()
+        player.dialogueOption(1)
+        tick(4)
+        assertEquals("martin_thwaits_lost_and_found_skillcape", player.shop())
+
+        player.interfaceOption("shop", "stock", "Buy-1", item = Item("thieving_cape"), slot = 11 * 6)
+        tick()
+
+        assertEquals(1, player.inventory.count("thieving_cape"))
+        assertEquals(1, player.inventory.count("thieving_hood"))
+        assertEquals(0, player.inventory.count("coins"))
+    }
+
+    @Test
+    fun `Buying a trimmed fletching cape from Hickton grants a free hood`() {
+        val player = createPlayer(emptyTile, "fletcher")
+        player.experience.set(Skill.Fletching, 14_000_000.0)
+        player.experience.set(Skill.Cooking, 14_000_000.0)
+        player.inventory.add("coins", 99_000)
+        val hickton = createNPC("hickton", emptyTile.addY(1))
+
+        player.npcOption(hickton, "Trade")
+        tick(4)
+        assertEquals("hicktons_archery_emporium_trimmed", player.shop())
+
+        player.interfaceOption("shop", "stock", "Buy-1", item = Item("fletching_cape_t"), slot = 28 * 6)
+        tick()
+
+        assertEquals(1, player.inventory.count("fletching_cape_t"))
+        assertEquals(1, player.inventory.count("fletching_hood"))
+    }
+}


### PR DESCRIPTION
Adds skillcape purchase dialogue for all remaining skill masters so every Cape of Accomplishment is obtainable ([wiki reference](https://runescape.wiki/w/Capes_of_Accomplishment?oldid=4631184)).

## New masters
- Ajjat (Attack), Sloane (Strength) — Warriors' Guild
- Cap'n Izzy No-Beard (Agility), Master fisher (Fishing), Wilfred (Woodcutting)
- Gadrin (Mining), Estate agent (Construction), Hunting expert (Hunter)
- Robe store owner (Magic) — wires up the existing but orphaned Yanille skillcape shops

## Extended existing NPCs
- Kuradal (Slayer), Thurgo (Smithing), Surgeon General Tafani (Constitution)
- Martin Thwait (Thieving) — now opens the skillcape/trimmed shop variants and enforces the 50 Thieving/50 Agility requirements ([transcript](https://oldschool.runescape.wiki/w/Transcript:Martin_Thwait))

## Refactor
The purchase transaction copy-pasted across eight existing masters (MeleeTutor, BrotherJared, HeadChef, CraftingGuild, Kaqemeex, Pikkupstix, Martin, Thok) is extracted into shared `buySkillcape`/`skillcapeOffer`/`skillcapeMasterDialogue` helpers in `content/entity/player/dialogue/Skillcape.kt`, keeping each NPC's bespoke lines. Also resolves Thok's `// TODO proper message` branches.

## Bug fixes
- **Everyone received trimmed capes**: the trim check compared Constitution's max level (life points — 100 at level 10) against 99, so a "second 99" was always found.
- Hickton's `bought("fletching_cape_(t)")` hook used a non-existent item id — trimmed cape buyers got no hood.
- Shop-sold capes (Ranged, Firemaking, Fletching, Runecrafting, Thieving, Magic) now grant the free hood via a central `bought()` hook.
- Skillcape shop selection opened the trimmed variant for players without 99 in the shop's own skill; Aubury's cape shop option was ungated and never opened the trimmed variant.
- The `buy_skillcape` jingle (defined but unused) now plays on every cape purchase.

## Tests
`AjjatTest` (purchase/trimmed/gating/insufficient coins), `GadrinTest`, `RobeStoreOwnerTest` (shop gating), `MartinThwaitTest` (skill requirements), `SkillcapesTest` (free hood hook incl. trimmed Hickton regression). Full suite passes.