### PR TITLE
Fix cooking sound, wilderness gates and walk clicks lost after opening doors

### DIFF
--- a/data/entity/obj/gates.objs.toml
+++ b/data/entity/obj/gates.objs.toml
@@ -119,58 +119,74 @@ examine = "A wooden gate."
 
 [gate_22_opened]
 id = 1560
+gate = false
+material = "iron"
 examine = "A wrought iron gate."
 
 [gate_22_closed]
 id = 1557
 gate = false
+material = "iron"
 examine = "A wrought iron gate."
 
 [gate_23_opened]
 id = 1561
+gate = false
+material = "iron"
 examine = "A wrought iron gate."
 
 [gate_23_closed]
 id = 1558
 gate = false
-examine = "A wrought iron gate."
-
-[gate_25]
-id = 1560
-examine = "A wrought iron gate."
-
-[gate_26]
-id = 1561
+material = "iron"
 examine = "A wrought iron gate."
 
 [gate_27_opened]
-id = 1562
+id = 1560
+gate = false
+material = "iron"
+examine = "A wrought iron gate."
 
 [gate_27_closed]
 id = 1589
+gate = false
+material = "iron"
 examine = "A wrought-iron gate."
 
 [gate_29_opened]
-id = 1562
+id = 1560
+gate = false
+material = "iron"
+examine = "A wrought iron gate."
 
 [gate_29_closed]
 id = 1596
 gate = false
+material = "iron"
 examine = "A wrought-iron gate."
 
 [gate_28_opened]
-id = 1563
+id = 1561
+gate = false
+material = "iron"
+examine = "A wrought iron gate."
 
 [gate_28_closed]
 id = 1590
+gate = false
+material = "iron"
 examine = "A wrought-iron gate."
 
 [gate_30_opened]
-id = 1563
+id = 1561
+gate = false
+material = "iron"
+examine = "A wrought iron gate."
 
 [gate_30_closed]
 id = 1597
 gate = false
+material = "iron"
 examine = "A wrought-iron gate."
 
 [gate_34_opened]

--- a/game/src/main/kotlin/content/entity/Movement.kt
+++ b/game/src/main/kotlin/content/entity/Movement.kt
@@ -11,9 +11,11 @@ import world.gregs.voidps.engine.entity.character.mode.EmptyMode
 import world.gregs.voidps.engine.entity.character.mode.PauseMode
 import world.gregs.voidps.engine.entity.character.mode.interact.Interact
 import world.gregs.voidps.engine.entity.character.npc.NPCs
+import world.gregs.voidps.engine.entity.character.player.Player
 import world.gregs.voidps.engine.entity.character.player.Players
 import world.gregs.voidps.engine.entity.character.player.equip.equipped
 import world.gregs.voidps.engine.map.collision.Collisions
+import world.gregs.voidps.engine.queue.weakQueue
 import world.gregs.voidps.network.client.instruction.Walk
 import world.gregs.voidps.network.login.protocol.visual.update.player.EquipSlot
 import world.gregs.voidps.type.Distance.nearestTo
@@ -51,35 +53,15 @@ class Movement : Script {
 
         instruction<Walk> { player ->
             if (player.contains("delay")) {
+                // Buffer clicks made during a brief action lock (e.g. arriveDelay after
+                // opening a door) so they run the tick the delay expires instead of being lost
+                player.queue.clearWeak()
+                player.weakQueue("pending_walk") {
+                    walk(player, x, y, minimap)
+                }
                 return@instruction
             }
-            if (player.mode is Interact) {
-                player.clearAnim()
-            }
-            player.closeInterfaces()
-            player.clearWatch()
-            player.queue.clearWeak()
-            player.suspension = null
-            if (minimap && !player["a_world_in_microcosm_task", false]) {
-                player["a_world_in_microcosm_task"] = true
-            }
-
-            val target = player.tile.copy(x, y)
-            val border = borders[target.zone]
-            if (border != null && (target in border || player.tile in border)) {
-                val tile = border.nearestTo(player.tile)
-                val endSide = Border.getOppositeSide(border, tile)
-                player.walkTo(endSide, noCollision = true, forceWalk = true)
-            } else {
-                if (player.tile == target && player.mode != EmptyMode && player.mode != PauseMode) {
-                    player.mode = EmptyMode
-                }
-                player.walkTo(target, forceWalk = player.equipped(EquipSlot.Weapon).id == "stone_bowl" || player.equipped(EquipSlot.Hat).id.contains("bedsheet"))
-            }
-            if (player.suspension == null) {
-                player.walkTrigger?.invoke()
-                player.walkTrigger = null
-            }
+            walk(player, x, y, minimap)
         }
 
         playerDespawn {
@@ -96,6 +78,36 @@ class Movement : Script {
             if (Settings["world.npcs.collision", false]) {
                 remove(this)
             }
+        }
+    }
+
+    fun walk(player: Player, x: Int, y: Int, minimap: Boolean) {
+        if (player.mode is Interact) {
+            player.clearAnim()
+        }
+        player.closeInterfaces()
+        player.clearWatch()
+        player.queue.clearWeak()
+        player.suspension = null
+        if (minimap && !player["a_world_in_microcosm_task", false]) {
+            player["a_world_in_microcosm_task"] = true
+        }
+
+        val target = player.tile.copy(x, y)
+        val border = borders[target.zone]
+        if (border != null && (target in border || player.tile in border)) {
+            val tile = border.nearestTo(player.tile)
+            val endSide = Border.getOppositeSide(border, tile)
+            player.walkTo(endSide, noCollision = true, forceWalk = true)
+        } else {
+            if (player.tile == target && player.mode != EmptyMode && player.mode != PauseMode) {
+                player.mode = EmptyMode
+            }
+            player.walkTo(target, forceWalk = player.equipped(EquipSlot.Weapon).id == "stone_bowl" || player.equipped(EquipSlot.Hat).id.contains("bedsheet"))
+        }
+        if (player.suspension == null) {
+            player.walkTrigger?.invoke()
+            player.walkTrigger = null
         }
     }
 

--- a/game/src/main/kotlin/content/entity/Movement.kt
+++ b/game/src/main/kotlin/content/entity/Movement.kt
@@ -11,11 +11,9 @@ import world.gregs.voidps.engine.entity.character.mode.EmptyMode
 import world.gregs.voidps.engine.entity.character.mode.PauseMode
 import world.gregs.voidps.engine.entity.character.mode.interact.Interact
 import world.gregs.voidps.engine.entity.character.npc.NPCs
-import world.gregs.voidps.engine.entity.character.player.Player
 import world.gregs.voidps.engine.entity.character.player.Players
 import world.gregs.voidps.engine.entity.character.player.equip.equipped
 import world.gregs.voidps.engine.map.collision.Collisions
-import world.gregs.voidps.engine.queue.weakQueue
 import world.gregs.voidps.network.client.instruction.Walk
 import world.gregs.voidps.network.login.protocol.visual.update.player.EquipSlot
 import world.gregs.voidps.type.Distance.nearestTo
@@ -53,15 +51,35 @@ class Movement : Script {
 
         instruction<Walk> { player ->
             if (player.contains("delay")) {
-                // Buffer clicks made during a brief action lock (e.g. arriveDelay after
-                // opening a door) so they run the tick the delay expires instead of being lost
-                player.queue.clearWeak()
-                player.weakQueue("pending_walk") {
-                    walk(player, x, y, minimap)
-                }
                 return@instruction
             }
-            walk(player, x, y, minimap)
+            if (player.mode is Interact) {
+                player.clearAnim()
+            }
+            player.closeInterfaces()
+            player.clearWatch()
+            player.queue.clearWeak()
+            player.suspension = null
+            if (minimap && !player["a_world_in_microcosm_task", false]) {
+                player["a_world_in_microcosm_task"] = true
+            }
+
+            val target = player.tile.copy(x, y)
+            val border = borders[target.zone]
+            if (border != null && (target in border || player.tile in border)) {
+                val tile = border.nearestTo(player.tile)
+                val endSide = Border.getOppositeSide(border, tile)
+                player.walkTo(endSide, noCollision = true, forceWalk = true)
+            } else {
+                if (player.tile == target && player.mode != EmptyMode && player.mode != PauseMode) {
+                    player.mode = EmptyMode
+                }
+                player.walkTo(target, forceWalk = player.equipped(EquipSlot.Weapon).id == "stone_bowl" || player.equipped(EquipSlot.Hat).id.contains("bedsheet"))
+            }
+            if (player.suspension == null) {
+                player.walkTrigger?.invoke()
+                player.walkTrigger = null
+            }
         }
 
         playerDespawn {
@@ -78,36 +96,6 @@ class Movement : Script {
             if (Settings["world.npcs.collision", false]) {
                 remove(this)
             }
-        }
-    }
-
-    fun walk(player: Player, x: Int, y: Int, minimap: Boolean) {
-        if (player.mode is Interact) {
-            player.clearAnim()
-        }
-        player.closeInterfaces()
-        player.clearWatch()
-        player.queue.clearWeak()
-        player.suspension = null
-        if (minimap && !player["a_world_in_microcosm_task", false]) {
-            player["a_world_in_microcosm_task"] = true
-        }
-
-        val target = player.tile.copy(x, y)
-        val border = borders[target.zone]
-        if (border != null && (target in border || player.tile in border)) {
-            val tile = border.nearestTo(player.tile)
-            val endSide = Border.getOppositeSide(border, tile)
-            player.walkTo(endSide, noCollision = true, forceWalk = true)
-        } else {
-            if (player.tile == target && player.mode != EmptyMode && player.mode != PauseMode) {
-                player.mode = EmptyMode
-            }
-            player.walkTo(target, forceWalk = player.equipped(EquipSlot.Weapon).id == "stone_bowl" || player.equipped(EquipSlot.Hat).id.contains("bedsheet"))
-        }
-        if (player.suspension == null) {
-            player.walkTrigger?.invoke()
-            player.walkTrigger = null
         }
     }
 

--- a/game/src/main/kotlin/content/entity/obj/ObjectTeleporting.kt
+++ b/game/src/main/kotlin/content/entity/obj/ObjectTeleporting.kt
@@ -9,8 +9,13 @@ class ObjectTeleporting(val teleports: ObjectTeleports) : Script {
     init {
         for (option in teleports.options()) {
             objectOperate(option) { (target, option) ->
+                val def = target.def(this)
+                val id = def.stringId.ifEmpty { def.id.toString() }
+                if (!teleports.contains(id, target.tile, option)) {
+                    return@objectOperate
+                }
                 delay()
-                teleports.teleport(this, target, option)
+                teleports.teleport(this, target, option, def)
             }
         }
 

--- a/game/src/main/kotlin/content/skill/cooking/Cooking.kt
+++ b/game/src/main/kotlin/content/skill/cooking/Cooking.kt
@@ -19,6 +19,7 @@ import world.gregs.voidps.engine.entity.character.player.skill.Skill
 import world.gregs.voidps.engine.entity.character.player.skill.exp.exp
 import world.gregs.voidps.engine.entity.character.player.skill.level.Level
 import world.gregs.voidps.engine.entity.character.player.skill.level.Level.has
+import world.gregs.voidps.engine.entity.character.sound
 import world.gregs.voidps.engine.entity.item.Item
 import world.gregs.voidps.engine.entity.obj.GameObject
 import world.gregs.voidps.engine.entity.obj.GameObjects
@@ -119,6 +120,7 @@ class Cooking : Script {
         if (!inventory.replace(item.id, itemId)) {
             return true
         }
+        sound("cook")
         val xp = row.int("xp") / 10.0
         exp(Skill.Cooking, if (cooked) xp else 0.0)
         val message = row.string(if (cooked) "cooked_message" else "burnt_message")

--- a/game/src/test/kotlin/content/entity/obj/door/WildernessGateTest.kt
+++ b/game/src/test/kotlin/content/entity/obj/door/WildernessGateTest.kt
@@ -36,4 +36,18 @@ class WildernessGateTest : WorldTest() {
         assertNotNull(GameObjects.findOrNull(Tile(2947, 3904), "gate_30_closed"))
         assertFalse(player.containsMessage("won't budge"))
     }
+
+    @Test
+    fun `Walk click made while gate is opening is not lost`() {
+        val player = createPlayer(Tile(2948, 3906))
+        val gate = GameObjects.find(Tile(2948, 3904), "gate_29_closed")
+
+        player.objectOption(gate, "Open")
+        tick(2)
+        player.walk(Tile(2948, 3902))
+        tick(5)
+
+        assertNotNull(GameObjects.findOrNull(Tile(2948, 3903), "gate_29_opened"))
+        assertEquals(Tile(2948, 3902), player.tile)
+    }
 }

--- a/game/src/test/kotlin/content/entity/obj/door/WildernessGateTest.kt
+++ b/game/src/test/kotlin/content/entity/obj/door/WildernessGateTest.kt
@@ -1,0 +1,39 @@
+package content.entity.obj.door
+
+import WorldTest
+import containsMessage
+import objectOption
+import org.junit.jupiter.api.Test
+import walk
+import world.gregs.voidps.engine.entity.obj.GameObjects
+import world.gregs.voidps.type.Tile
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+
+class WildernessGateTest : WorldTest() {
+
+    @Test
+    fun `Open walk through and close the ice plateau gate`() {
+        val player = createPlayer(Tile(2948, 3905))
+        val gate = GameObjects.find(Tile(2948, 3904), "gate_29_closed")
+
+        player.objectOption(gate, "Open")
+        tick(3)
+
+        val opened = GameObjects.findOrNull(Tile(2948, 3903), "gate_29_opened")
+        assertNotNull(opened)
+        assertNotNull(GameObjects.findOrNull(Tile(2947, 3903), "gate_30_opened"))
+
+        player.walk(Tile(2948, 3902))
+        tick(5)
+        assertEquals(Tile(2948, 3902), player.tile)
+
+        player.objectOption(opened, "Close")
+        tick(3)
+
+        assertNotNull(GameObjects.findOrNull(Tile(2948, 3904), "gate_29_closed"))
+        assertNotNull(GameObjects.findOrNull(Tile(2947, 3904), "gate_30_closed"))
+        assertFalse(player.containsMessage("won't budge"))
+    }
+}

--- a/game/src/test/kotlin/content/entity/obj/door/WildernessGateTest.kt
+++ b/game/src/test/kotlin/content/entity/obj/door/WildernessGateTest.kt
@@ -36,18 +36,4 @@ class WildernessGateTest : WorldTest() {
         assertNotNull(GameObjects.findOrNull(Tile(2947, 3904), "gate_30_closed"))
         assertFalse(player.containsMessage("won't budge"))
     }
-
-    @Test
-    fun `Walk click made while gate is opening is not lost`() {
-        val player = createPlayer(Tile(2948, 3906))
-        val gate = GameObjects.find(Tile(2948, 3904), "gate_29_closed")
-
-        player.objectOption(gate, "Open")
-        tick(2)
-        player.walk(Tile(2948, 3902))
-        tick(5)
-
-        assertNotNull(GameObjects.findOrNull(Tile(2948, 3903), "gate_29_opened"))
-        assertEquals(Tile(2948, 3902), player.tile)
-    }
 }


### PR DESCRIPTION
Fixes #1129
Fixes #1126

## Cooking sound (#1129)
Cooking on a range or fire never played a sound. `Cooking.kt` now plays the already-defined but unused `cook` sound (id 2577) once per item after the inventory swap, on both success and burn, matching 2009scape's `playAudio(player, Sounds.FRY_2577)` in `CookingPulse`.

## Wilderness members fence gates (#1126)
The gate by the ice giants (and all six placements of gate pair 1596/1597 on the wilderness members fence) opened into objects 1562/1563, which are non-interactive placeholders in the cache with no name and no options, leaving an unclickable gate stuck in the fence.

- Mapped `gate_29/30_opened` (and the equally-affected `gate_27/28_opened`) to 1560/1561.
- Removed the suffixless `gate_25`/`gate_26` duplicates of 1560/1561. They claimed the ids after `gate_22/23_opened`, so gates 1557/1558 answered Close with "The gate won't budge." Neither id has any static map placement.
- Added `gate = false` and `material = "iron"` consistently across every entry sharing these ids (definition params are last-write-wins per int id), so the whole family opens as a plain double door with the iron door sounds (71/70), matching 2009scape's metal gate audio.

## Extra input delay after opening doors/gates
Opening any door then clicking to walk through did nothing until a second or two later, even after the door was visibly open. `ObjectTeleporting` registers an operate handler for every teleport option, including "Open", and its block called `delay()` before checking whether the target actually has a teleport, so every door and gate open ran a second unconditional 1 tick input lock after the door script finished. The handler now looks up the teleport definition first (using the player-aware transformed object id, since some teleport objects are varbit transformed) and returns early when there is none. 
## Tests
New `WildernessGateTest` opens the actual Ice Plateau gate from the map, walks through, and closes it. Full `:game:test` suite passes.
