### PR TITLE
Fix zone batch update sync causing floor item ghosting

### DIFF
--- a/engine/src/main/kotlin/world/gregs/voidps/engine/client/update/CharacterUpdateTask.kt
+++ b/engine/src/main/kotlin/world/gregs/voidps/engine/client/update/CharacterUpdateTask.kt
@@ -17,7 +17,7 @@ class CharacterUpdateTask(
     override fun predicate(character: Player): Boolean = character.networked
 
     override fun run(character: Player) {
-        ZoneBatchUpdates.run(character)
+        ZoneBatchUpdates.send(character)
         playerUpdating.run(character)
         npcUpdating.run(character)
         character.viewport!!.shift()

--- a/engine/src/main/kotlin/world/gregs/voidps/engine/client/update/batch/ZoneBatchUpdates.kt
+++ b/engine/src/main/kotlin/world/gregs/voidps/engine/client/update/batch/ZoneBatchUpdates.kt
@@ -11,6 +11,7 @@ import world.gregs.voidps.network.login.protocol.encode.clearZone
 import world.gregs.voidps.network.login.protocol.encode.encodeBatch
 import world.gregs.voidps.network.login.protocol.encode.send
 import world.gregs.voidps.network.login.protocol.encode.sendBatch
+import world.gregs.voidps.network.login.protocol.encode.updateZone
 import world.gregs.voidps.network.login.protocol.encode.zone.ZoneUpdate
 import world.gregs.voidps.type.Zone
 
@@ -55,25 +56,41 @@ object ZoneBatchUpdates : Runnable {
      */
     override fun run() {
         for ((zone, updates) in batches) {
-            encoded[zone] = encodeBatch(updates.filter { !it.private })
+            val batched = updates.filter { !it.private }
+            if (batched.isNotEmpty()) {
+                encoded[zone] = encodeBatch(batched)
+            }
         }
     }
 
     /**
-     * Also send updates each batch zone change
+     * Send zone changes and batched updates relative to the last sent zone
      */
     fun send(player: Player) {
         val viewport = player.viewport!!
+        if (!viewport.loaded) { // Zone updates are lost while the client is loading a new map
+            return
+        }
         val from = viewport.lastBatchZone
         send(player, from)
         viewport.lastBatchZone = player.tile.zone
     }
 
     /**
-     * Send updates each zone change
+     * Resend the contents of all zones in view after a map reload clears the client's entities
      */
-    fun run(player: Player) {
-        send(player, player.steps.previous.zone)
+    fun refresh(player: Player) {
+        val viewport = player.viewport ?: return
+        for (zone in player.tile.zone.toRectangle(radius = viewport.localRadius).toZonesReversed(player.tile.level)) {
+            if (!inViewport(viewport, zone)) {
+                continue
+            }
+            player.clearZone(zone)
+            for (sender in senders) {
+                sender.send(player, zone)
+            }
+        }
+        viewport.lastBatchZone = player.tile.zone
     }
 
     /**
@@ -84,6 +101,9 @@ object ZoneBatchUpdates : Runnable {
         val to = player.tile.zone
         val previous = from.toRectangle(radius = viewport.localRadius).toZones(from.level).toSet()
         for (zone in to.toRectangle(radius = viewport.localRadius).toZonesReversed(player.tile.level)) {
+            if (!inViewport(viewport, zone)) {
+                continue
+            }
             val entered = !previous.contains(zone)
             if (entered) { // Clear and resend raw data for newly entered areas
                 player.clearZone(zone)
@@ -94,6 +114,9 @@ object ZoneBatchUpdates : Runnable {
             val updates = batches[zone.id]?.filter { it.private && it.visible(player.name) } ?: continue
             if (!entered) { // Send batched updates for current regions
                 player.sendBatch(zone)
+            }
+            if (updates.isNotEmpty()) { // Individual updates are relative to the client's active zone
+                player.updateZone(zone)
             }
             for (update in updates) { // Send private updates separately
                 player.client?.send(update)
@@ -106,6 +129,7 @@ object ZoneBatchUpdates : Runnable {
             pool.recycle(value)
         }
         batches.clear()
+        encoded.clear()
     }
 
     private fun Player.sendBatch(zone: Zone) {
@@ -122,6 +146,19 @@ object ZoneBatchUpdates : Runnable {
     private fun getZoneOffset(viewport: Viewport, zone: Zone): Zone {
         val base = viewport.lastLoadZone.safeMinus(viewport.zoneRadius, viewport.zoneRadius)
         return zone.safeMinus(base)
+    }
+
+    /**
+     * Whether [zone] is inside the map area the client last loaded
+     */
+    private fun inViewport(viewport: Viewport, zone: Zone): Boolean {
+        val base = viewport.lastLoadZone.safeMinus(viewport.zoneRadius, viewport.zoneRadius)
+        return zone.x - base.x in 0 until viewport.zoneArea && zone.y - base.y in 0 until viewport.zoneArea
+    }
+
+    private fun Player.updateZone(zone: Zone) {
+        val zoneOffset = getZoneOffset(viewport!!, zone)
+        client?.updateZone(zoneOffset.x, zoneOffset.y, zone.level)
     }
 
     private fun Player.clearZone(zone: Zone) {

--- a/engine/src/main/kotlin/world/gregs/voidps/engine/client/update/view/Viewport.kt
+++ b/engine/src/main/kotlin/world/gregs/voidps/engine/client/update/view/Viewport.kt
@@ -24,6 +24,9 @@ class Viewport {
     var lastBatchZone: Zone = Zone.EMPTY
     var loaded: Boolean = false
     var dynamic: Boolean = false
+
+    // The DynamicZones.version the last region update was sent with
+    var dynamicVersion: Int = -1
     var size: Int = 0
     val tileSize: Int
         get() = VIEWPORT_SIZES[size]

--- a/engine/src/main/kotlin/world/gregs/voidps/engine/map/zone/DynamicZones.kt
+++ b/engine/src/main/kotlin/world/gregs/voidps/engine/map/zone/DynamicZones.kt
@@ -24,6 +24,10 @@ class DynamicZones(
     // All recent region changes (including clearing)
     private var update = false
 
+    // Incremented on every change to detect stale player region updates
+    var version: Int = 0
+        private set
+
     fun dynamic(region: Region) = regions.contains(region.id)
 
     fun dynamicUpdate(region: Region) = refresh.contains(region.id)
@@ -43,6 +47,7 @@ class DynamicZones(
             regions.add(region.id)
             refresh.add(region.id)
         }
+        version++
         update = true
     }
 
@@ -70,6 +75,7 @@ class DynamicZones(
                 regions.remove(region.id)
             }
         }
+        version++
         update = true
     }
 
@@ -86,6 +92,7 @@ class DynamicZones(
             }
         }
         if (regions.remove(region.id)) {
+            version++
             update = true
         }
     }

--- a/engine/src/test/kotlin/world/gregs/voidps/engine/map/zone/ZoneBatchUpdatesTest.kt
+++ b/engine/src/test/kotlin/world/gregs/voidps/engine/map/zone/ZoneBatchUpdatesTest.kt
@@ -46,6 +46,7 @@ internal class ZoneBatchUpdatesTest : KoinMock() {
         player["logged_in"] = false
         player.viewport = Viewport()
         player.viewport!!.size = 0
+        player.viewport!!.loaded = true
     }
 
     @Test

--- a/game/src/main/kotlin/content/entity/world/RegionLoading.kt
+++ b/game/src/main/kotlin/content/entity/world/RegionLoading.kt
@@ -41,6 +41,8 @@ class RegionLoading(val dynamicZones: DynamicZones) : Script {
 
         instruction<FinishRegionLoad> { player ->
             player.viewport?.loaded = true
+            // The client clears all zones on map load; resend contents now it can receive updates again
+            ZoneBatchUpdates.refresh(player)
         }
 
         moved { from ->
@@ -80,14 +82,8 @@ class RegionLoading(val dynamicZones: DynamicZones) : Script {
         if (!player.networked) {
             return
         }
-        val viewport = player.viewport!!
         if (needsRegionChange(player)) {
-            // default radius = 4
             updateRegion(player, false, crossedDynamicBoarder(player))
-        }
-        if (viewport.lastBatchZone.level != player.tile.level || !inViewOfZone(player, viewport.lastBatchZone, viewport.localRadius - 1)) {
-            // default radius = 2
-            ZoneBatchUpdates.send(player)
         }
     }
 
@@ -104,7 +100,8 @@ class RegionLoading(val dynamicZones: DynamicZones) : Script {
         return Distance.within(player.tile.region.x, player.tile.region.y, region.x, region.y, radius)
     }
 
-    fun crossedDynamicBoarder(player: Player) = player.viewport!!.dynamic != inDynamicView(player) || dynamicZones.dynamicUpdate(player.tile.region)
+    fun crossedDynamicBoarder(player: Player) = player.viewport!!.dynamic != inDynamicView(player) ||
+        (dynamicZones.dynamicUpdate(player.tile.region) && player.viewport!!.dynamicVersion != dynamicZones.version)
 
     fun inDynamicView(player: Player): Boolean = dynamicZones.dynamic(player.tile.region)
 
@@ -124,7 +121,7 @@ class RegionLoading(val dynamicZones: DynamicZones) : Script {
             viewport.loaded = false
         }
         viewport.lastLoadZone = player.tile.zone
-        ZoneBatchUpdates.send(player)
+        viewport.dynamicVersion = dynamicZones.version
     }
 
     fun update(player: Player, initial: Boolean, force: Boolean) {

--- a/network/src/main/kotlin/world/gregs/voidps/network/login/protocol/encode/ZoneEncoders.kt
+++ b/network/src/main/kotlin/world/gregs/voidps/network/login/protocol/encode/ZoneEncoders.kt
@@ -31,7 +31,7 @@ fun Client.updateZone(
     yOffset: Int,
     level: Int,
 ) = send(Protocol.UPDATE_ZONE) {
-    writeByteInverse(xOffset)
+    writeByteInverse(yOffset)
     writeByteAdd(level)
-    writeByteAdd(yOffset)
+    writeByteAdd(xOffset)
 }

--- a/network/src/test/resources/encoder-packets.csv
+++ b/network/src/test/resources/encoder-packets.csv
@@ -64,5 +64,5 @@ varp small, -6, 48, 57, 123
 varp large, 31, 0, 0, -46, 4, 48, -71
 weight, 78, 48, 57
 clear zone, 20, -116, 22, -123
-update zone, 28, -123, -116, 106
+update zone, 28, 22, -116, -5
 arrow hint, 56, 34, 3, 2, 0, 100, 0, 123, 50, 0, 2, 4, -46


### PR DESCRIPTION
Closes #1000, #1087

Root cause is a set of sync gaps in the zone batch update pipeline rather than floor items specifically, items were just the visible symptom since spawns constantly re-queue additions.

[Screencast_20260805_143328.webm](https://github.com/user-attachments/assets/10d0d7ed-76a2-494a-a2c4-a137f096bb17)


## Problems

1. **Private updates applied to the wrong zone.** All floor item packets are `private` and sent as bare single packets, which the client applies relative to its active zone, set by whatever `clearZone`/batch header happened to come last. When that pointer pointed at a neighbouring zone, the item rendered one zone (8 tiles) off in the direction of travel.
2. **Out-of-map offsets clamped instead of skipped.** `getZoneOffset` used `safeMinus`, so zones south/west of the loaded map base clamped to offset 0 and rendered 8 tiles north/east of their true tile (reproducible with the logs at 3155 in zone `389,394` after logging in at `3114,3209`).
3. **Stale batch replay.** The `encoded` map was never cleared, so mid-tick sends (region change/batch zone change) replayed the previous tick's batch, re-applying object add/removes (door flicker on the Wizards' Tower bridge) and duplicating item additions. This affects objects just the same as items, as you noted — items only made it visible.
4. **Updates lost during map load.** `updateRegion` sent zone contents immediately after the map region packet, but the client loads maps asynchronously and drops zone updates in the window before `FinishRegionLoad`, `viewport.loaded` was tracked but never gated anything, so items vanished after every region reload.
5. **Duplicate region updates per tick.** `checkReload` and `DynamicZones.reloadCallback` could both call `updateRegion` in the same tick with no in-progress check, and two send paths with different anchors (`lastBatchZone` vs `steps.previous.zone`) cleared and resent the same entered zones twice per tick.

## Changes

- Send the active zone (`UPDATE_ZONE`) before individual private updates so they always apply to the correct zone (matches partial-follows behaviour before each bare update)
- Skip zones outside the loaded map instead of clamping their offsets
- Clear `encoded` alongside `batches` each tick and skip encoding empty batches (also fixes unbounded growth)
- Single tick-end send path anchored on `lastBatchZone`; removed the `steps.previous`-anchored duplicate
- Full zone content resend moved to the `FinishRegionLoad` handler, with sends gated on `viewport.loaded` so nothing is fired into the load window
- `DynamicZones.version` stamped on the viewport per region update so `crossedDynamicBoarder` no longer force-reloads players already updated for the current dynamic state