### PR TITLE
Add economy monitoring for dupe and abuse detection

### DIFF
--- a/database/src/main/kotlin/world/gregs/voidps/storage/DatabaseStorage.kt
+++ b/database/src/main/kotlin/world/gregs/voidps/storage/DatabaseStorage.kt
@@ -4,8 +4,11 @@ import com.zaxxer.hikari.HikariConfig
 import com.zaxxer.hikari.HikariDataSource
 import org.jetbrains.exposed.sql.*
 import org.jetbrains.exposed.sql.SqlExpressionBuilder.inList
+import org.jetbrains.exposed.sql.SqlExpressionBuilder.less
 import org.jetbrains.exposed.sql.transactions.transaction
 import world.gregs.voidps.engine.data.AbuseReport
+import world.gregs.voidps.engine.data.CensusSnapshot
+import world.gregs.voidps.engine.data.EconomyFlag
 import world.gregs.voidps.engine.data.PlayerSave
 import world.gregs.voidps.engine.data.Storage
 import world.gregs.voidps.engine.data.config.AccountDefinition
@@ -212,6 +215,34 @@ class DatabaseStorage : Storage {
             it[time] = report.time
             it[evidence] = report.evidence
         }
+    }
+
+    override fun saveEconomyFlags(flags: List<EconomyFlag>): Unit = transaction {
+        EconomyFlagsTable.batchInsert(flags, shouldReturnGeneratedValues = false) { flag ->
+            this[EconomyFlagsTable.type] = flag.type
+            this[EconomyFlagsTable.timestamp] = flag.timestamp
+            this[EconomyFlagsTable.tick] = flag.tick
+            this[EconomyFlagsTable.sourceName] = flag.source
+            this[EconomyFlagsTable.targetName] = flag.target
+            this[EconomyFlagsTable.item] = flag.item
+            this[EconomyFlagsTable.value] = flag.value
+            this[EconomyFlagsTable.details] = flag.details
+        }
+    }
+
+    override fun saveCensusSnapshots(snapshots: List<CensusSnapshot>): Unit = transaction {
+        EconomyCensusTable.batchInsert(snapshots, shouldReturnGeneratedValues = false) { snapshot ->
+            this[EconomyCensusTable.timestamp] = snapshot.timestamp
+            this[EconomyCensusTable.item] = snapshot.item
+            this[EconomyCensusTable.players] = snapshot.players
+            this[EconomyCensusTable.floor] = snapshot.floor
+            this[EconomyCensusTable.exchange] = snapshot.exchange
+        }
+    }
+
+    override fun pruneEconomy(before: Long): Unit = transaction {
+        EconomyFlagsTable.deleteWhere { timestamp less before }
+        EconomyCensusTable.deleteWhere { timestamp less before }
     }
 
     override fun exists(accountName: String): Boolean = transaction {
@@ -584,7 +615,7 @@ class DatabaseStorage : Storage {
             }
         }
 
-        internal val tables = arrayOf(AccountsTable, ExperienceTable, LevelsTable, VariablesTable, InventoriesTable, OffersTable, ActiveOffersTable, PlayerHistoryTable, ClaimsTable, ItemHistoryTable, ReportsTable)
+        internal val tables = arrayOf(AccountsTable, ExperienceTable, LevelsTable, VariablesTable, InventoriesTable, OffersTable, ActiveOffersTable, PlayerHistoryTable, ClaimsTable, ItemHistoryTable, ReportsTable, EconomyFlagsTable, EconomyCensusTable)
 
         private const val TYPE_STRING = 0.toByte()
         private const val TYPE_INT = 1.toByte()

--- a/database/src/main/kotlin/world/gregs/voidps/storage/Tables.kt
+++ b/database/src/main/kotlin/world/gregs/voidps/storage/Tables.kt
@@ -173,6 +173,32 @@ internal object ReportsTable : Table("abuse_reports") {
     override val primaryKey = PrimaryKey(id, name = "pk_report_id")
 }
 
+internal object EconomyFlagsTable : Table("economy_flags") {
+    val id = integer("id").autoIncrement().uniqueIndex()
+    val type = varchar("type", 32).index()
+    val timestamp = long("timestamp").index()
+    val tick = integer("tick")
+    val sourceName = varchar("source", 12).nullable().default(null)
+    val targetName = varchar("target", 12).nullable().default(null)
+    val item = text("item").nullable().default(null)
+    val value = long("value").default(0)
+    val details = text("details").nullable().default(null)
+
+    override val primaryKey = PrimaryKey(id, name = "pk_economy_flag_id")
+}
+
+internal object EconomyCensusTable : Table("economy_census") {
+    val timestamp = long("timestamp").index()
+    val item = text("item")
+    val players = long("players")
+    val floor = long("floor")
+    val exchange = long("exchange")
+
+    init {
+        index(false, item, timestamp)
+    }
+}
+
 internal object ItemHistoryTable : Table("grand_exchange_item_history") {
     val item = text("item")
     val timestamp = long("timestamp")

--- a/database/src/test/kotlin/world/gregs/voidps/storage/DatabaseStorageTest.kt
+++ b/database/src/test/kotlin/world/gregs/voidps/storage/DatabaseStorageTest.kt
@@ -6,6 +6,9 @@ import org.jetbrains.exposed.sql.transactions.transaction
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import world.gregs.voidps.engine.data.AbuseReport
+import world.gregs.voidps.engine.data.CensusSnapshot
+import world.gregs.voidps.engine.data.EconomyFlag
+import java.util.concurrent.TimeUnit
 import kotlin.test.assertEquals
 
 class DatabaseStorageTest : StorageTest(), DatabaseTest {
@@ -37,6 +40,84 @@ class DatabaseStorageTest : StorageTest(), DatabaseTest {
             assertEquals(report.suggestion, row[ReportsTable.suggestion])
             assertEquals(report.time, row[ReportsTable.time])
             assertEquals(report.evidence, row[ReportsTable.evidence])
+        }
+    }
+
+    @Test
+    fun `Store economy flags`() {
+        val flag = EconomyFlag(
+            type = "trade_value",
+            timestamp = 1234567890123,
+            tick = 4242,
+            source = "durial321",
+            target = "cow1337killa",
+            item = null,
+            value = 25_000_000,
+            details = "requester=25000000 acceptor=0",
+        )
+
+        storage.saveEconomyFlags(listOf(flag, flag.copy(type = "price_anomaly", source = null, target = null, item = "party_hat", details = null)))
+
+        transaction {
+            val rows = EconomyFlagsTable.selectAll().orderBy(EconomyFlagsTable.id).toList()
+            assertEquals(2, rows.size)
+            assertEquals(flag.type, rows[0][EconomyFlagsTable.type])
+            assertEquals(flag.timestamp, rows[0][EconomyFlagsTable.timestamp])
+            assertEquals(flag.tick, rows[0][EconomyFlagsTable.tick])
+            assertEquals(flag.source, rows[0][EconomyFlagsTable.sourceName])
+            assertEquals(flag.target, rows[0][EconomyFlagsTable.targetName])
+            assertEquals(null, rows[0][EconomyFlagsTable.item])
+            assertEquals(flag.value, rows[0][EconomyFlagsTable.value])
+            assertEquals(flag.details, rows[0][EconomyFlagsTable.details])
+            assertEquals("party_hat", rows[1][EconomyFlagsTable.item])
+            assertEquals(null, rows[1][EconomyFlagsTable.sourceName])
+        }
+    }
+
+    @Test
+    fun `Store census snapshots`() {
+        val snapshot = CensusSnapshot(
+            timestamp = 1234567890123,
+            item = "coins",
+            players = 2_147_483_648,
+            floor = 1000,
+            exchange = 500_000,
+        )
+
+        storage.saveCensusSnapshots(listOf(snapshot))
+
+        transaction {
+            val row = EconomyCensusTable.selectAll().single()
+            assertEquals(snapshot.timestamp, row[EconomyCensusTable.timestamp])
+            assertEquals(snapshot.item, row[EconomyCensusTable.item])
+            assertEquals(snapshot.players, row[EconomyCensusTable.players])
+            assertEquals(snapshot.floor, row[EconomyCensusTable.floor])
+            assertEquals(snapshot.exchange, row[EconomyCensusTable.exchange])
+        }
+    }
+
+    @Test
+    fun `Prune old economy rows`() {
+        val now = 1234567890123
+        val old = now - TimeUnit.DAYS.toMillis(91)
+        storage.saveEconomyFlags(
+            listOf(
+                EconomyFlag(type = "trade_value", timestamp = now, tick = 1),
+                EconomyFlag(type = "trade_value", timestamp = old, tick = 0),
+            ),
+        )
+        storage.saveCensusSnapshots(
+            listOf(
+                CensusSnapshot(timestamp = now, item = "coins", players = 1, floor = 0, exchange = 0),
+                CensusSnapshot(timestamp = old, item = "coins", players = 2, floor = 0, exchange = 0),
+            ),
+        )
+
+        storage.pruneEconomy(now - TimeUnit.DAYS.toMillis(90))
+
+        transaction {
+            assertEquals(now, EconomyFlagsTable.selectAll().single()[EconomyFlagsTable.timestamp])
+            assertEquals(now, EconomyCensusTable.selectAll().single()[EconomyCensusTable.timestamp])
         }
     }
 

--- a/engine/src/main/kotlin/world/gregs/voidps/engine/data/CensusSnapshot.kt
+++ b/engine/src/main/kotlin/world/gregs/voidps/engine/data/CensusSnapshot.kt
@@ -1,0 +1,17 @@
+package world.gregs.voidps.engine.data
+
+/**
+ * A point-in-time count of a watched item across the game economy
+ * @param timestamp Epoch millisecond timestamp the snapshot was taken
+ * @param item Canonical item id
+ * @param players Count across all player inventories, online and offline
+ * @param floor Count in items on the floor
+ * @param exchange Count escrowed in open grand exchange offers
+ */
+data class CensusSnapshot(
+    val timestamp: Long,
+    val item: String,
+    val players: Long,
+    val floor: Long,
+    val exchange: Long,
+)

--- a/engine/src/main/kotlin/world/gregs/voidps/engine/data/EconomyFlag.kt
+++ b/engine/src/main/kotlin/world/gregs/voidps/engine/data/EconomyFlag.kt
@@ -1,0 +1,23 @@
+package world.gregs.voidps.engine.data
+
+/**
+ * A suspicious economy event flagged by a monitor for moderator review
+ * @param type Flag identifier: "trade_value", "trade_pair", "price_anomaly" or "census_drift"
+ * @param timestamp Epoch millisecond timestamp the flag was raised
+ * @param tick Game tick the flag was raised
+ * @param source Account name of the initiating player, if any
+ * @param target Account name of the other player involved, if any
+ * @param item Canonical item id involved, if any
+ * @param value Primary coin or quantity value of the event
+ * @param details Additional key=value context matching the audit log line
+ */
+data class EconomyFlag(
+    val type: String,
+    val timestamp: Long,
+    val tick: Int,
+    val source: String? = null,
+    val target: String? = null,
+    val item: String? = null,
+    val value: Long = 0,
+    val details: String? = null,
+)

--- a/engine/src/main/kotlin/world/gregs/voidps/engine/data/Storage.kt
+++ b/engine/src/main/kotlin/world/gregs/voidps/engine/data/Storage.kt
@@ -62,6 +62,21 @@ interface Storage {
     fun saveReport(report: AbuseReport)
 
     /**
+     * Batch saves economy monitor flags; no-op unless the backend supports history
+     */
+    fun saveEconomyFlags(flags: List<EconomyFlag>) {}
+
+    /**
+     * Batch saves item census snapshots; no-op unless the backend supports history
+     */
+    fun saveCensusSnapshots(snapshots: List<CensusSnapshot>) {}
+
+    /**
+     * Deletes economy flags and census snapshots with timestamps before [before] milliseconds
+     */
+    fun pruneEconomy(before: Long) {}
+
+    /**
      * Checks if an account exists
      */
     fun exists(accountName: String): Boolean

--- a/game/src/main/kotlin/content/social/trade/TradeConfirm.kt
+++ b/game/src/main/kotlin/content/social/trade/TradeConfirm.kt
@@ -3,6 +3,7 @@ package content.social.trade
 import com.github.michaelbull.logging.InlineLogger
 import content.social.trade.Trade.getPartner
 import content.social.trade.lend.Loan
+import content.social.trade.monitor.TradeFlags
 import world.gregs.voidps.engine.Script
 import world.gregs.voidps.engine.client.message
 import world.gregs.voidps.engine.client.ui.chat.Colours
@@ -52,6 +53,8 @@ class TradeConfirm : Script {
             request(partner, "confirm_trade") { requester, acceptor ->
                 val requesterLoan = requester.loan[0]
                 val acceptorLoan = acceptor.loan[0]
+                val requesterValue = requester.offer.calculateValue()
+                val acceptorValue = acceptor.offer.calculateValue()
                 val success = acceptor.offer.transaction {
                     moveAll(requester.inventory)
                     link(requester.offer).moveAll(acceptor.inventory)
@@ -69,6 +72,7 @@ class TradeConfirm : Script {
                 loanItem(acceptor, requesterLoan, requester)
                 requester.closeMenu()
                 log(requester, acceptor)
+                TradeFlags.check(requester, acceptor, requesterValue, acceptorValue)
             }
         }
     }

--- a/game/src/main/kotlin/content/social/trade/exchange/history/ExchangeHistory.kt
+++ b/game/src/main/kotlin/content/social/trade/exchange/history/ExchangeHistory.kt
@@ -19,11 +19,15 @@ import kotlin.collections.set
  */
 class ExchangeHistory(val history: MutableMap<String, PriceHistory> = mutableMapOf()) {
     private val marketPrices = mutableMapOf<String, Int>()
+    val listeners = mutableListOf<(item: String, amount: Int, price: Int) -> Unit>()
 
     fun record(item: String, amount: Int, price: Int) {
         val history = history.getOrPut(item) { PriceHistory() }
         val timestamp = epochMilliseconds()
         history.record(timestamp, price, amount)
+        for (listener in listeners) {
+            listener(item, amount, price)
+        }
     }
 
     fun clean() {

--- a/game/src/main/kotlin/content/social/trade/monitor/CensusStore.kt
+++ b/game/src/main/kotlin/content/social/trade/monitor/CensusStore.kt
@@ -1,0 +1,46 @@
+package content.social.trade.monitor
+
+import world.gregs.config.Config
+import world.gregs.config.writePair
+import world.gregs.config.writeSection
+import world.gregs.voidps.engine.data.Settings
+import java.io.File
+
+/**
+ * Persists item census player-bucket counts between server restarts.
+ * Floor and exchange buckets are transient - the floor is rebuilt from
+ * spawn events and exchange counts are recomputed from open offers.
+ */
+object CensusStore {
+
+    fun file(): File = File(Settings["storage.players.path"]).resolve("economy/census.toml")
+
+    fun save(counts: List<ItemCensus.Count>, file: File = file()) {
+        file.parentFile.mkdirs()
+        Config.fileWriter(file) {
+            writeSection("players")
+            for (count in counts) {
+                if (count.players != 0L) {
+                    writePair(count.item, count.players)
+                }
+            }
+        }
+    }
+
+    fun load(file: File = file()): Map<String, Long> {
+        if (!file.exists()) {
+            return emptyMap()
+        }
+        val counts = mutableMapOf<String, Long>()
+        Config.fileReader(file) {
+            while (nextSection()) {
+                when (section()) {
+                    "players" -> while (nextPair()) {
+                        counts[key()] = long()
+                    }
+                }
+            }
+        }
+        return counts
+    }
+}

--- a/game/src/main/kotlin/content/social/trade/monitor/EconomySink.kt
+++ b/game/src/main/kotlin/content/social/trade/monitor/EconomySink.kt
@@ -1,0 +1,80 @@
+package content.social.trade.monitor
+
+import com.github.michaelbull.logging.InlineLogger
+import world.gregs.voidps.engine.GameLoop
+import world.gregs.voidps.engine.data.CensusSnapshot
+import world.gregs.voidps.engine.data.EconomyFlag
+
+/**
+ * Buffers economy monitor flags and census snapshots for database persistence.
+ * Rows buffered between flushes are lost on a hard crash - the AuditLog TSV
+ * remains the durable record; the database is the queryable copy.
+ * Note: not thread safe; only use within game thread. [EconomySinkFlush]
+ * drains via list swap, transferring ownership to the IO coroutine.
+ */
+object EconomySink {
+
+    private const val MAX_BUFFER = 10_000
+    private val logger = InlineLogger()
+
+    var enabled = false
+
+    private var flags = mutableListOf<EconomyFlag>()
+    private var census = mutableListOf<CensusSnapshot>()
+    private var warned = false
+
+    fun flag(type: String, source: String? = null, target: String? = null, item: String? = null, value: Long = 0, details: String? = null) {
+        if (!enabled) {
+            return
+        }
+        if (flags.size >= MAX_BUFFER) {
+            warn()
+            return
+        }
+        flags.add(EconomyFlag(type, System.currentTimeMillis(), GameLoop.tick, source, target, item, value, details))
+    }
+
+    fun census(counts: List<ItemCensus.Count>) {
+        if (!enabled) {
+            return
+        }
+        val timestamp = System.currentTimeMillis()
+        for (count in counts) {
+            if (count.total == 0L) {
+                continue
+            }
+            if (census.size >= MAX_BUFFER) {
+                warn()
+                return
+            }
+            census.add(CensusSnapshot(timestamp, count.item, count.players, count.floor, count.exchange))
+        }
+    }
+
+    private fun warn() {
+        if (!warned) {
+            warned = true
+            logger.warn { "Economy sink buffer full; dropping rows until next flush." }
+        }
+    }
+
+    fun drainFlags(): List<EconomyFlag> {
+        val drained = flags
+        flags = mutableListOf()
+        warned = false
+        return drained
+    }
+
+    fun drainCensus(): List<CensusSnapshot> {
+        val drained = census
+        census = mutableListOf()
+        return drained
+    }
+
+    fun clear() {
+        flags = mutableListOf()
+        census = mutableListOf()
+        enabled = false
+        warned = false
+    }
+}

--- a/game/src/main/kotlin/content/social/trade/monitor/EconomySinkFlush.kt
+++ b/game/src/main/kotlin/content/social/trade/monitor/EconomySinkFlush.kt
@@ -1,0 +1,96 @@
+package content.social.trade.monitor
+
+import com.github.michaelbull.logging.InlineLogger
+import kotlinx.coroutines.CoroutineExceptionHandler
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.NonCancellable
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import world.gregs.voidps.engine.Script
+import world.gregs.voidps.engine.data.Settings
+import world.gregs.voidps.engine.data.Storage
+import world.gregs.voidps.engine.entity.World
+import world.gregs.voidps.engine.timer.Timer
+import world.gregs.voidps.engine.timer.toTicks
+import java.util.concurrent.TimeUnit
+
+/**
+ * Periodically drains [EconomySink] to database storage and prunes rows
+ * older than the retention window. Only active when the storage backend is
+ * a database; file installs rely on the AuditLog TSVs alone.
+ */
+class EconomySinkFlush(private val storage: Storage) : Script {
+
+    private val logger = InlineLogger()
+    private val scope = CoroutineScope(Dispatchers.IO)
+    private val handler = CoroutineExceptionHandler { _, exception ->
+        logger.error(exception) { "Error saving economy monitor rows!" }
+    }
+    private var lastPrune = 0L
+
+    init {
+        worldSpawn {
+            reload()
+            if (EconomySink.enabled) {
+                World.timers.start("economy_sink_flush")
+            }
+        }
+
+        worldTimerStart("economy_sink_flush") { TimeUnit.MINUTES.toTicks(Settings["economy.monitor.flushMinutes", 1]) }
+        worldTimerTick("economy_sink_flush") {
+            if (!EconomySink.enabled) {
+                return@worldTimerTick Timer.CANCEL
+            }
+            flush()
+            TimeUnit.MINUTES.toTicks(Settings["economy.monitor.flushMinutes", 1])
+        }
+        worldTimerStop("economy_sink_flush") { shutdown ->
+            if (shutdown) {
+                flush()
+            }
+        }
+
+        settingsReload {
+            reload()
+            if (EconomySink.enabled) {
+                World.timers.start("economy_sink_flush", restart = true)
+            } else {
+                World.timers.stop("economy_sink_flush")
+            }
+        }
+    }
+
+    private fun reload() {
+        EconomySink.enabled = Settings["storage.type", "files"] == "database" &&
+            Settings["economy.monitor.enabled", false] &&
+            !Settings["storage.disabled", false]
+    }
+
+    private fun flush() {
+        val flags = EconomySink.drainFlags()
+        val census = EconomySink.drainCensus()
+        val now = System.currentTimeMillis()
+        val prune = now - lastPrune >= TimeUnit.HOURS.toMillis(1)
+        if (prune) {
+            lastPrune = now
+        }
+        if (flags.isEmpty() && census.isEmpty() && !prune) {
+            return
+        }
+        val before = now - TimeUnit.DAYS.toMillis(Settings["economy.monitor.retentionDays", 90].toLong())
+        scope.launch(handler) {
+            withContext(NonCancellable) {
+                if (flags.isNotEmpty()) {
+                    storage.saveEconomyFlags(flags)
+                }
+                if (census.isNotEmpty()) {
+                    storage.saveCensusSnapshots(census)
+                }
+                if (prune) {
+                    storage.pruneEconomy(before)
+                }
+            }
+        }
+    }
+}

--- a/game/src/main/kotlin/content/social/trade/monitor/ItemCensus.kt
+++ b/game/src/main/kotlin/content/social/trade/monitor/ItemCensus.kt
@@ -1,0 +1,158 @@
+package content.social.trade.monitor
+
+import it.unimi.dsi.fastutil.objects.Object2LongOpenHashMap
+import world.gregs.voidps.engine.data.Settings
+import world.gregs.voidps.engine.data.definition.ItemDefinitions
+import world.gregs.voidps.engine.data.exchange.OpenOffers
+import world.gregs.voidps.engine.entity.item.Item
+import world.gregs.voidps.engine.entity.item.floor.FloorItem
+import world.gregs.voidps.engine.event.AuditLog
+import world.gregs.voidps.engine.inv.InventorySlotChanged
+
+/**
+ * Tracks how many of each watched item exist in the economy, split into
+ * three buckets: player inventories (all accounts, online and offline),
+ * floor items and open grand exchange sell offers.
+ * Container moves are net-zero; a dupe shows as unexplained total growth
+ * between snapshots, exposed by periodic `CENSUS` audit lines and verified
+ * by reconciliation scans against player saves (`CENSUS_DRIFT`).
+ */
+object ItemCensus {
+
+    private val watched = mutableSetOf<String>()
+    private val players = Object2LongOpenHashMap<String>()
+    private val floor = Object2LongOpenHashMap<String>()
+
+    var enabled = false
+        private set
+
+    fun reload() {
+        enabled = Settings["economy.monitor.enabled", false] && Settings["economy.monitor.census.enabled", false]
+        watched.clear()
+        if (!enabled) {
+            return
+        }
+        val threshold = Settings["economy.monitor.census.valueThreshold", 1_000_000]
+        for ((id, index) in ItemDefinitions.ids) {
+            if (id.endsWith("_noted")) {
+                continue
+            }
+            if (ItemDefinitions.get(index).cost >= threshold) {
+                watched.add(id)
+            }
+        }
+        for (id in Settings["economy.monitor.census.items", ""].split(",")) {
+            if (id.isNotBlank()) {
+                watched.add(id.trim())
+            }
+        }
+    }
+
+    fun watched(): Set<String> = watched
+
+    fun canonical(id: String): String = id.removeSuffix("_noted")
+
+    fun change(change: InventorySlotChanged) {
+        count(players, change.fromItem, -1)
+        count(players, change.item, +1)
+    }
+
+    fun spawn(item: FloorItem) {
+        count(floor, item.id, item.amount.toLong())
+    }
+
+    fun despawn(item: FloorItem) {
+        count(floor, item.id, -item.amount.toLong())
+    }
+
+    private fun count(bucket: Object2LongOpenHashMap<String>, item: Item, sign: Int) {
+        if (item.isEmpty() || item.amount <= 0) {
+            return
+        }
+        count(bucket, item.id, sign * item.amount.toLong())
+    }
+
+    private fun count(bucket: Object2LongOpenHashMap<String>, id: String, delta: Long) {
+        val canonical = canonical(id)
+        if (canonical !in watched) {
+            return
+        }
+        bucket.addTo(canonical, delta)
+    }
+
+    /**
+     * Counts of watched items escrowed in open grand exchange offers:
+     * remaining items in sell offers, plus coins escrowed in buy offers.
+     */
+    fun exchange(offers: OpenOffers): Map<String, Long> {
+        val counts = Object2LongOpenHashMap<String>()
+        for (item in watched) {
+            var total = 0L
+            for (list in offers.selling(item).values) {
+                for (offer in list) {
+                    total += offer.remaining
+                }
+            }
+            if (total > 0) {
+                counts.addTo(item, total)
+            }
+        }
+        if ("coins" in watched) {
+            for (offersByPrice in offers.buyByItem.values) {
+                for ((price, list) in offersByPrice) {
+                    for (offer in list) {
+                        counts.addTo("coins", price.toLong() * offer.remaining)
+                    }
+                }
+            }
+        }
+        return counts
+    }
+
+    fun snapshot(offers: OpenOffers): List<Count> {
+        val exchange = exchange(offers)
+        return watched.map { item ->
+            Count(item, players.getLong(item), floor.getLong(item), exchange[item] ?: 0L)
+        }
+    }
+
+    /**
+     * Overwrite the live player-bucket counters with [actual] counts from a
+     * reconciliation scan, logging any items that drifted beyond tolerance.
+     */
+    fun apply(actual: Map<String, Long>) {
+        val tolerance = Settings["economy.monitor.census.driftPercent", 0.01]
+        for (item in watched) {
+            val expected = players.getLong(item)
+            val count = actual[item] ?: 0L
+            if (expected != count) {
+                val drift = Math.abs(expected - count)
+                if (drift > tolerance * maxOf(count, 1L)) {
+                    AuditLog.info("CENSUS_DRIFT\t$item\texpected=$expected\tactual=$count")
+                    EconomySink.flag("census_drift", item = item, value = count, details = "expected=$expected")
+                }
+                players.put(item, count)
+            }
+        }
+    }
+
+    fun restore(counts: Map<String, Long>) {
+        for ((item, count) in counts) {
+            if (item in watched) {
+                players.put(item, count)
+            }
+        }
+    }
+
+    fun clear() {
+        watched.clear()
+        players.clear()
+        floor.clear()
+        enabled = false
+    }
+
+    data class Count(val item: String, val players: Long, val floor: Long, val exchange: Long) {
+        val total: Long
+            get() = players + floor + exchange
+    }
+}

--- a/game/src/main/kotlin/content/social/trade/monitor/ItemCensusMonitor.kt
+++ b/game/src/main/kotlin/content/social/trade/monitor/ItemCensusMonitor.kt
@@ -1,0 +1,189 @@
+package content.social.trade.monitor
+
+import it.unimi.dsi.fastutil.objects.Object2LongOpenHashMap
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import world.gregs.voidps.engine.Script
+import world.gregs.voidps.engine.data.Settings
+import world.gregs.voidps.engine.data.Storage
+import world.gregs.voidps.engine.data.definition.InventoryDefinitions
+import world.gregs.voidps.engine.data.exchange.OpenOffers
+import world.gregs.voidps.engine.entity.World
+import world.gregs.voidps.engine.entity.character.player.Players
+import world.gregs.voidps.engine.event.AuditLog
+import world.gregs.voidps.engine.timer.Timer
+import world.gregs.voidps.engine.timer.toTicks
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicReference
+
+/**
+ * Maintains the live [ItemCensus] counters, logs and persists periodic
+ * snapshots, and drift-corrects the player bucket with reconciliation scans
+ * of every account save. All flags go to [AuditLog] only.
+ */
+class ItemCensusMonitor(
+    private val offers: OpenOffers,
+    private val storage: Storage,
+) : Script {
+
+    private val scope = CoroutineScope(Dispatchers.IO)
+    private val scanned = AtomicReference<Map<String, Long>?>(null)
+
+    init {
+        worldSpawn {
+            ItemCensus.reload()
+            if (!ItemCensus.enabled) {
+                return@worldSpawn
+            }
+            ItemCensus.restore(CensusStore.load())
+            World.timers.start("economy_census_snapshot")
+            if (Settings["economy.monitor.census.reconcileHours", 6] > 0) {
+                World.timers.start("economy_census_reconcile")
+            }
+            reconcile()
+        }
+
+        slotChanged("*") { change ->
+            if (!ItemCensus.enabled) {
+                return@slotChanged
+            }
+            if (change.inventory.startsWith("_") || InventoryDefinitions.get(change.inventory)["shop", false]) {
+                return@slotChanged
+            }
+            ItemCensus.change(change)
+        }
+
+        floorItemSpawn {
+            if (ItemCensus.enabled) {
+                ItemCensus.spawn(this)
+            }
+        }
+
+        floorItemDespawn {
+            if (ItemCensus.enabled) {
+                ItemCensus.despawn(this)
+            }
+        }
+
+        worldTimerStart("economy_census_snapshot") { TimeUnit.MINUTES.toTicks(Settings["economy.monitor.census.snapshotMinutes", 30]) }
+        worldTimerTick("economy_census_snapshot") {
+            if (!ItemCensus.enabled) {
+                return@worldTimerTick Timer.CANCEL
+            }
+            snapshot()
+            TimeUnit.MINUTES.toTicks(Settings["economy.monitor.census.snapshotMinutes", 30])
+        }
+
+        worldTimerStart("economy_census_reconcile") { TimeUnit.HOURS.toTicks(Settings["economy.monitor.census.reconcileHours", 6]) }
+        worldTimerTick("economy_census_reconcile") {
+            val hours = Settings["economy.monitor.census.reconcileHours", 6]
+            if (!ItemCensus.enabled || hours <= 0) {
+                return@worldTimerTick Timer.CANCEL
+            }
+            reconcile()
+            TimeUnit.HOURS.toTicks(hours)
+        }
+
+        // Polls for the async reconciliation result so it is applied on the game thread
+        worldTimerStart("economy_census_apply") { APPLY_POLL_TICKS }
+        worldTimerTick("economy_census_apply") {
+            val result = scanned.getAndSet(null)
+            if (result != null) {
+                ItemCensus.apply(result)
+                return@worldTimerTick Timer.CANCEL
+            }
+            APPLY_POLL_TICKS
+        }
+
+        settingsReload {
+            ItemCensus.reload()
+            if (ItemCensus.enabled) {
+                World.timers.start("economy_census_snapshot", restart = true)
+                if (Settings["economy.monitor.census.reconcileHours", 6] > 0) {
+                    World.timers.start("economy_census_reconcile", restart = true)
+                }
+            } else {
+                World.timers.stop("economy_census_snapshot")
+                World.timers.stop("economy_census_reconcile")
+            }
+        }
+
+        worldTimerStop("economy_census_snapshot") { shutdown ->
+            if (shutdown && ItemCensus.enabled) {
+                CensusStore.save(ItemCensus.snapshot(offers))
+            }
+        }
+    }
+
+    private fun snapshot() {
+        val counts = ItemCensus.snapshot(offers)
+        for (count in counts) {
+            if (count.total != 0L) {
+                AuditLog.info("CENSUS\t${count.item}\tplayers=${count.players}\tfloor=${count.floor}\texchange=${count.exchange}\ttotal=${count.total}")
+            }
+        }
+        CensusStore.save(counts)
+        EconomySink.census(counts)
+    }
+
+    /**
+     * Counts watched items across every account: online players from live
+     * inventories on the game thread, offline accounts from saves on the IO
+     * dispatcher. Logins or trades during the scan cause small false drift,
+     * covered by the driftPercent tolerance.
+     */
+    private fun reconcile() {
+        val watched = ItemCensus.watched().toSet()
+        if (watched.isEmpty()) {
+            return
+        }
+        val counts = Object2LongOpenHashMap<String>()
+        val online = mutableSetOf<String>()
+        for (player in Players) {
+            online.add(player.accountName.lowercase())
+            for ((id, inventory) in player.inventories.instances) {
+                if (skip(id)) {
+                    continue
+                }
+                for (item in inventory.items) {
+                    count(counts, watched, item.id, item.amount)
+                }
+            }
+        }
+        scope.launch {
+            for (definition in storage.names().values) {
+                if (definition.accountName.lowercase() in online) {
+                    continue
+                }
+                val save = storage.load(definition.accountName) ?: continue
+                for ((id, items) in save.inventories) {
+                    if (skip(id)) {
+                        continue
+                    }
+                    for (item in items) {
+                        count(counts, watched, item.id, item.amount)
+                    }
+                }
+            }
+            scanned.set(counts)
+        }
+        World.timers.start("economy_census_apply", restart = true)
+    }
+
+    private fun count(counts: Object2LongOpenHashMap<String>, watched: Set<String>, id: String, amount: Int) {
+        if (id.isBlank() || amount <= 0) {
+            return
+        }
+        val canonical = ItemCensus.canonical(id)
+        if (canonical in watched) {
+            counts.addTo(canonical, amount.toLong())
+        }
+    }
+
+    private fun skip(inventory: String): Boolean = inventory.startsWith("_") || InventoryDefinitions.get(inventory)["shop", false]
+
+    companion object {
+        private const val APPLY_POLL_TICKS = 10
+    }
+}

--- a/game/src/main/kotlin/content/social/trade/monitor/PriceAnomaly.kt
+++ b/game/src/main/kotlin/content/social/trade/monitor/PriceAnomaly.kt
@@ -1,0 +1,24 @@
+package content.social.trade.monitor
+
+import kotlin.math.abs
+
+/**
+ * Detects grand exchange trades executing far from market price -
+ * sudden crashes or spikes often signal duped goods flooding the market.
+ */
+object PriceAnomaly {
+
+    fun deviation(price: Int, market: Int): Double {
+        if (market <= 0) {
+            return 0.0
+        }
+        return abs(price - market) / market.toDouble()
+    }
+
+    fun flagged(price: Int, amount: Int, market: Int, minValue: Long, threshold: Double): Boolean {
+        if (price.toLong() * amount < minValue) {
+            return false
+        }
+        return deviation(price, market) >= threshold
+    }
+}

--- a/game/src/main/kotlin/content/social/trade/monitor/PriceAnomalyMonitor.kt
+++ b/game/src/main/kotlin/content/social/trade/monitor/PriceAnomalyMonitor.kt
@@ -1,0 +1,43 @@
+package content.social.trade.monitor
+
+import content.social.trade.exchange.history.ExchangeHistory
+import world.gregs.voidps.engine.GameLoop
+import world.gregs.voidps.engine.Script
+import world.gregs.voidps.engine.data.Settings
+import world.gregs.voidps.engine.event.AuditLog
+import world.gregs.voidps.engine.timer.toTicks
+import java.util.concurrent.TimeUnit
+
+/**
+ * Flags grand exchange trades that deviate too far from market price.
+ * Runs per matched exchange on the game thread; writes to [AuditLog] only.
+ */
+class PriceAnomalyMonitor(private val history: ExchangeHistory) : Script {
+
+    private val flagged = mutableMapOf<String, Int>()
+
+    init {
+        history.listeners.add(::exchanged)
+    }
+
+    private fun exchanged(item: String, amount: Int, price: Int) {
+        if (!Settings["economy.monitor.enabled", false] || !Settings["economy.monitor.price.enabled", false]) {
+            return
+        }
+        val market = history.marketPrice(item)
+        val minValue = Settings["economy.monitor.price.minValue", 100_000L]
+        val threshold = Settings["economy.monitor.price.deviation", 0.3]
+        if (!PriceAnomaly.flagged(price, amount, market, minValue, threshold)) {
+            return
+        }
+        val cooldown = TimeUnit.MINUTES.toTicks(Settings["economy.monitor.price.cooldownMinutes", 10])
+        val last = flagged[item]
+        if (last != null && GameLoop.tick - last < cooldown) {
+            return
+        }
+        flagged[item] = GameLoop.tick
+        val deviation = PriceAnomaly.deviation(price, market)
+        AuditLog.info("PRICE_ANOMALY\t$item\tprice=$price\tmarket=$market\tamount=$amount\tdeviation=${"%.3f".format(deviation)}")
+        EconomySink.flag("price_anomaly", item = item, value = price.toLong(), details = "market=$market amount=$amount deviation=${"%.3f".format(deviation)}")
+    }
+}

--- a/game/src/main/kotlin/content/social/trade/monitor/TradeFlags.kt
+++ b/game/src/main/kotlin/content/social/trade/monitor/TradeFlags.kt
@@ -1,0 +1,56 @@
+package content.social.trade.monitor
+
+import world.gregs.voidps.engine.GameLoop
+import world.gregs.voidps.engine.data.Settings
+import world.gregs.voidps.engine.entity.character.player.Player
+import world.gregs.voidps.engine.event.AuditLog
+import world.gregs.voidps.engine.timer.toTicks
+import java.util.concurrent.TimeUnit
+
+/**
+ * Flags suspicious player-to-player trades for moderator investigation:
+ * single trades over [economy.monitor.trade.valueThreshold] coins and repeated
+ * large trades between the same pair of accounts within a sliding window.
+ * Flags are written to [AuditLog] only.
+ */
+object TradeFlags {
+
+    private val pairs = mutableMapOf<String, ArrayDeque<Int>>()
+
+    fun check(requester: Player, acceptor: Player, requesterValue: Long, acceptorValue: Long, tick: Int = GameLoop.tick) {
+        if (!Settings["economy.monitor.enabled", false] || !Settings["economy.monitor.trade.enabled", false]) {
+            return
+        }
+        val valueThreshold = Settings["economy.monitor.trade.valueThreshold", 10_000_000L]
+        if (maxOf(requesterValue, acceptorValue) >= valueThreshold) {
+            AuditLog.event(requester, "trade_flag_value", acceptor, requesterValue, acceptorValue)
+            EconomySink.flag("trade_value", requester.accountName, acceptor.accountName, value = maxOf(requesterValue, acceptorValue), details = "requester=$requesterValue acceptor=$acceptorValue")
+        }
+        val pairThreshold = Settings["economy.monitor.trade.pair.valueThreshold", 1_000_000L]
+        if (requesterValue + acceptorValue < pairThreshold) {
+            return
+        }
+        val window = TimeUnit.MINUTES.toTicks(Settings["economy.monitor.trade.pair.windowMinutes", 60])
+        val key = pairKey(requester, acceptor)
+        val trades = pairs.getOrPut(key) { ArrayDeque() }
+        while (trades.isNotEmpty() && tick - trades.first() > window) {
+            trades.removeFirst()
+        }
+        trades.addLast(tick)
+        if (trades.size >= Settings["economy.monitor.trade.pair.count", 5]) {
+            AuditLog.event(requester, "trade_flag_pair", acceptor, trades.size, requesterValue + acceptorValue)
+            EconomySink.flag("trade_pair", requester.accountName, acceptor.accountName, value = requesterValue + acceptorValue, details = "count=${trades.size}")
+            pairs.remove(key)
+        }
+    }
+
+    private fun pairKey(one: Player, two: Player): String = if (one.accountName < two.accountName) {
+        "${one.accountName}|${two.accountName}"
+    } else {
+        "${two.accountName}|${one.accountName}"
+    }
+
+    fun clear() {
+        pairs.clear()
+    }
+}

--- a/game/src/main/resources/game.properties
+++ b/game/src/main/resources/game.properties
@@ -291,6 +291,60 @@ grandExchange.instantSellUnderMarketPrice=0.0
 #   -1.0 = -100% - allows buying anything at any price over 1gp.
 grandExchange.instantBuyOverMarketPrice=0.0
 
+# Whether economy monitoring (dupe/abuse detection) is enabled; individual monitors below also require this
+economy.monitor.enabled=true
+
+# Days of economy flag and census history kept in the database before pruning
+economy.monitor.retentionDays=90
+
+# Minutes between database flushes of buffered economy flags and census rows
+economy.monitor.flushMinutes=1
+
+# Flag grand exchange trades that deviate from market price (signal of duped goods flooding the market)
+economy.monitor.price.enabled=true
+
+# Fractional deviation from market price to flag, e.g. 0.3 = 30% above or below
+economy.monitor.price.deviation=0.3
+
+# Minimum total value (price * amount) of an exchange before it can be flagged
+economy.monitor.price.minValue=100000
+
+# Minutes before the same item can be flagged again
+economy.monitor.price.cooldownMinutes=10
+
+# Track total counts of watched items across player inventories, floor and grand exchange
+economy.monitor.census.enabled=true
+
+# Watch all items with a value of at least this amount
+economy.monitor.census.valueThreshold=1000000
+
+# Comma separated list of additional item ids to watch regardless of value
+economy.monitor.census.items=coins
+
+# Minutes between logging and persisting census snapshots
+economy.monitor.census.snapshotMinutes=30
+
+# Hours between full reconciliation scans of all player saves (0 = startup only)
+economy.monitor.census.reconcileHours=6
+
+# Fractional difference between live counters and a reconciliation scan before drift is logged, e.g. 0.01 = 1%
+economy.monitor.census.driftPercent=0.01
+
+# Flag suspicious player-to-player trades
+economy.monitor.trade.enabled=true
+
+# Flag trades where either side's offer is worth at least this many coins
+economy.monitor.trade.valueThreshold=10000000
+
+# Count trades worth at least this many coins towards repeated trades between the same pair of accounts
+economy.monitor.trade.pair.valueThreshold=1000000
+
+# Number of large trades between the same pair of accounts within the window before flagging
+economy.monitor.trade.pair.count=5
+
+# Window of time large trades between the same pair of accounts are counted over
+economy.monitor.trade.pair.windowMinutes=60
+
 # Wave to start all fight caves on (63 for jad)
 fightCave.startWave = 1
 

--- a/game/src/test/kotlin/SettingsTest.kt
+++ b/game/src/test/kotlin/SettingsTest.kt
@@ -12,5 +12,6 @@ internal class SettingsTest {
         assertTrue(Settings["world.npcs.aggression", false])
         assertTrue(Settings["world.npcs.collision", false])
         assertEquals(30, Settings["bots.count", 0])
+        assertTrue(Settings["economy.monitor.enabled", false])
     }
 }

--- a/game/src/test/kotlin/WorldTest.kt
+++ b/game/src/test/kotlin/WorldTest.kt
@@ -307,6 +307,7 @@ abstract class WorldTest : KoinTest {
             properties["storage.autoSave.minutes"] = 0
             properties["storage.disabled"] = true
             properties["events.randomEvents.active"] = false
+            properties["economy.monitor.enabled"] = "false"
             properties["bots.count"] = 0
             properties.remove("world.id")
             properties.remove("world.name")

--- a/game/src/test/kotlin/content/social/trade/monitor/EconomySinkTest.kt
+++ b/game/src/test/kotlin/content/social/trade/monitor/EconomySinkTest.kt
@@ -1,0 +1,69 @@
+package content.social.trade.monitor
+
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+internal class EconomySinkTest {
+
+    @AfterEach
+    fun teardown() {
+        EconomySink.clear()
+    }
+
+    @Test
+    fun `Disabled sink captures nothing`() {
+        EconomySink.flag("trade_value", "sender", "receiver", value = 100)
+        EconomySink.census(listOf(ItemCensus.Count("coins", 1, 0, 0)))
+        assertTrue(EconomySink.drainFlags().isEmpty())
+        assertTrue(EconomySink.drainCensus().isEmpty())
+    }
+
+    @Test
+    fun `Enabled sink captures flag fields`() {
+        EconomySink.enabled = true
+        EconomySink.flag("price_anomaly", item = "party_hat", value = 1000, details = "market=100")
+        val flags = EconomySink.drainFlags()
+        assertEquals(1, flags.size)
+        assertEquals("price_anomaly", flags[0].type)
+        assertEquals("party_hat", flags[0].item)
+        assertEquals(1000L, flags[0].value)
+        assertEquals("market=100", flags[0].details)
+        assertEquals(null, flags[0].source)
+    }
+
+    @Test
+    fun `Drain resets the buffer`() {
+        EconomySink.enabled = true
+        EconomySink.flag("trade_value")
+        assertEquals(1, EconomySink.drainFlags().size)
+        assertTrue(EconomySink.drainFlags().isEmpty())
+    }
+
+    @Test
+    fun `Census skips zero total counts`() {
+        EconomySink.enabled = true
+        EconomySink.census(
+            listOf(
+                ItemCensus.Count("coins", 100, 5, 10),
+                ItemCensus.Count("party_hat", 0, 0, 0),
+            ),
+        )
+        val census = EconomySink.drainCensus()
+        assertEquals(1, census.size)
+        assertEquals("coins", census[0].item)
+        assertEquals(100L, census[0].players)
+        assertEquals(5L, census[0].floor)
+        assertEquals(10L, census[0].exchange)
+    }
+
+    @Test
+    fun `Buffer cap drops excess flags`() {
+        EconomySink.enabled = true
+        for (i in 0 until 10_001) {
+            EconomySink.flag("trade_value", value = i.toLong())
+        }
+        assertEquals(10_000, EconomySink.drainFlags().size)
+    }
+}

--- a/game/src/test/kotlin/content/social/trade/monitor/ItemCensusTest.kt
+++ b/game/src/test/kotlin/content/social/trade/monitor/ItemCensusTest.kt
@@ -1,0 +1,110 @@
+package content.social.trade.monitor
+
+import WorldTest
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import world.gregs.voidps.engine.data.Settings
+import world.gregs.voidps.engine.data.exchange.OpenOffers
+import world.gregs.voidps.engine.entity.item.floor.FloorItems
+import world.gregs.voidps.engine.event.AuditLog
+import world.gregs.voidps.engine.inv.add
+import world.gregs.voidps.engine.inv.inventory
+import java.io.File
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+internal class ItemCensusTest : WorldTest() {
+
+    private val offers = OpenOffers()
+
+    @BeforeEach
+    fun setup() {
+        Settings.load(
+            mapOf(
+                "economy.monitor.enabled" to "true",
+                "economy.monitor.census.enabled" to "true",
+                "economy.monitor.census.valueThreshold" to "2000000000",
+                "economy.monitor.census.items" to "coins,rune_longsword",
+                "economy.monitor.census.driftPercent" to "0.01",
+            ),
+        )
+        ItemCensus.clear()
+        ItemCensus.reload()
+        AuditLog.logs.clear()
+    }
+
+    @AfterEach
+    fun teardown() {
+        ItemCensus.clear()
+    }
+
+    @Test
+    fun `Items added to player inventories are counted`() {
+        val player = createPlayer(emptyTile, "census_add")
+        player.inventory.add("rune_longsword")
+        player.inventory.add("coins", 500)
+        val counts = ItemCensus.snapshot(offers).associateBy { it.item }
+        assertEquals(1L, counts["rune_longsword"]?.players)
+        assertEquals(500L, counts["coins"]?.players)
+    }
+
+    @Test
+    fun `Noted items count towards the base item`() {
+        val player = createPlayer(emptyTile, "census_noted")
+        player.inventory.add("rune_longsword_noted", 5)
+        val counts = ItemCensus.snapshot(offers).associateBy { it.item }
+        assertEquals(5L, counts["rune_longsword"]?.players)
+    }
+
+    @Test
+    fun `Floor items are tracked in a separate bucket`() {
+        val item = createFloorItem("rune_longsword", emptyTile)
+        tick()
+        var counts = ItemCensus.snapshot(offers).associateBy { it.item }
+        assertEquals(1L, counts["rune_longsword"]?.floor)
+        assertEquals(1L, counts["rune_longsword"]?.total)
+        FloorItems.remove(item)
+        tick()
+        counts = ItemCensus.snapshot(offers).associateBy { it.item }
+        assertEquals(0L, counts["rune_longsword"]?.floor)
+    }
+
+    @Test
+    fun `Mirror inventories are ignored`() {
+        val player = createPlayer(emptyTile, "census_mirror")
+        player.inventories.inventory("trade_offer", secondary = true).add("rune_longsword")
+        val counts = ItemCensus.snapshot(offers).associateBy { it.item }
+        assertEquals(0L, counts["rune_longsword"]?.players)
+    }
+
+    @Test
+    fun `Snapshot round trips through the census store`() {
+        val player = createPlayer(emptyTile, "census_store")
+        player.inventory.add("coins", 1234)
+        val file = File(Settings["storage.players.path"]).resolve("economy/census.toml")
+        CensusStore.save(ItemCensus.snapshot(offers), file)
+        val loaded = CensusStore.load(file)
+        assertEquals(1234L, loaded["coins"])
+    }
+
+    @Test
+    fun `Reconciliation overwrites drifted counters and logs`() {
+        val player = createPlayer(emptyTile, "census_drift")
+        player.inventory.add("coins", 1000)
+        ItemCensus.apply(mapOf("coins" to 500L))
+        assertTrue(AuditLog.logs.any { it.contains("CENSUS_DRIFT") && it.contains("expected=1000") && it.contains("actual=500") })
+        val counts = ItemCensus.snapshot(offers).associateBy { it.item }
+        assertEquals(500L, counts["coins"]?.players)
+    }
+
+    @Test
+    fun `Drift within tolerance is corrected silently`() {
+        val player = createPlayer(emptyTile, "census_tolerance")
+        player.inventory.add("coins", 1000)
+        ItemCensus.apply(mapOf("coins" to 995L))
+        assertTrue(AuditLog.logs.none { it.contains("CENSUS_DRIFT") })
+        val counts = ItemCensus.snapshot(offers).associateBy { it.item }
+        assertEquals(995L, counts["coins"]?.players)
+    }
+}

--- a/game/src/test/kotlin/content/social/trade/monitor/PriceAnomalyMonitorTest.kt
+++ b/game/src/test/kotlin/content/social/trade/monitor/PriceAnomalyMonitorTest.kt
@@ -1,0 +1,54 @@
+package content.social.trade.monitor
+
+import WorldTest
+import content.social.trade.exchange.history.ExchangeHistory
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.koin.test.get
+import world.gregs.voidps.engine.data.Settings
+import world.gregs.voidps.engine.event.AuditLog
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+internal class PriceAnomalyMonitorTest : WorldTest() {
+
+    @BeforeEach
+    fun setup() {
+        Settings.load(
+            mapOf(
+                "economy.monitor.enabled" to "true",
+                "economy.monitor.price.enabled" to "true",
+                "economy.monitor.price.deviation" to "0.3",
+                "economy.monitor.price.minValue" to "1000",
+                "economy.monitor.price.cooldownMinutes" to "10",
+            ),
+        )
+        AuditLog.logs.clear()
+    }
+
+    @Test
+    fun `Exchange far from market price is flagged`() {
+        val history: ExchangeHistory = get()
+        val market = history.marketPrice("rune_longsword")
+        history.record("rune_longsword", 10, market * 2)
+        assertTrue(AuditLog.logs.any { it.contains("PRICE_ANOMALY") && it.contains("rune_longsword") })
+    }
+
+    @Test
+    fun `Exchange at market price is not flagged`() {
+        val history: ExchangeHistory = get()
+        val market = history.marketPrice("rune_scimitar")
+        history.record("rune_scimitar", 10, market)
+        assertFalse(AuditLog.logs.any { it.contains("PRICE_ANOMALY") })
+    }
+
+    @Test
+    fun `Repeat flags for the same item are suppressed by cooldown`() {
+        val history: ExchangeHistory = get()
+        val market = history.marketPrice("rune_battleaxe")
+        history.record("rune_battleaxe", 10, market * 2)
+        history.record("rune_battleaxe", 10, market * 2)
+        assertEquals(1, AuditLog.logs.count { it.contains("PRICE_ANOMALY") && it.contains("rune_battleaxe") })
+    }
+}

--- a/game/src/test/kotlin/content/social/trade/monitor/PriceAnomalyTest.kt
+++ b/game/src/test/kotlin/content/social/trade/monitor/PriceAnomalyTest.kt
@@ -1,0 +1,38 @@
+package content.social.trade.monitor
+
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+internal class PriceAnomalyTest {
+
+    @Test
+    fun `Deviation is fractional difference from market`() {
+        assertEquals(0.5, PriceAnomaly.deviation(150, 100))
+        assertEquals(0.5, PriceAnomaly.deviation(50, 100))
+        assertEquals(0.0, PriceAnomaly.deviation(100, 100))
+    }
+
+    @Test
+    fun `No deviation without a market price`() {
+        assertEquals(0.0, PriceAnomaly.deviation(100, 0))
+        assertEquals(0.0, PriceAnomaly.deviation(100, -1))
+    }
+
+    @Test
+    fun `Flags at or over threshold`() {
+        assertTrue(PriceAnomaly.flagged(price = 130, amount = 1000, market = 100, minValue = 100_000, threshold = 0.3))
+        assertFalse(PriceAnomaly.flagged(price = 129, amount = 1000, market = 100, minValue = 100_000, threshold = 0.3))
+    }
+
+    @Test
+    fun `Low value trades are ignored`() {
+        assertFalse(PriceAnomaly.flagged(price = 200, amount = 1, market = 100, minValue = 100_000, threshold = 0.3))
+    }
+
+    @Test
+    fun `Large amounts overflow safely`() {
+        assertTrue(PriceAnomaly.flagged(price = Int.MAX_VALUE, amount = Int.MAX_VALUE, market = 100, minValue = 100_000, threshold = 0.3))
+    }
+}

--- a/game/src/test/kotlin/content/social/trade/monitor/TradeFlagsMonitorTest.kt
+++ b/game/src/test/kotlin/content/social/trade/monitor/TradeFlagsMonitorTest.kt
@@ -1,0 +1,67 @@
+package content.social.trade.monitor
+
+import WorldTest
+import interfaceOption
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import playerOption
+import world.gregs.voidps.engine.data.Settings
+import world.gregs.voidps.engine.entity.character.player.Player
+import world.gregs.voidps.engine.entity.item.Item
+import world.gregs.voidps.engine.event.AuditLog
+import world.gregs.voidps.engine.inv.add
+import world.gregs.voidps.engine.inv.inventory
+import kotlin.test.assertTrue
+
+internal class TradeFlagsMonitorTest : WorldTest() {
+
+    @BeforeEach
+    fun setup() {
+        Settings.load(
+            mapOf(
+                "economy.monitor.enabled" to "true",
+                "economy.monitor.trade.enabled" to "true",
+                "economy.monitor.trade.valueThreshold" to "5",
+                "economy.monitor.trade.pair.valueThreshold" to "5",
+                "economy.monitor.trade.pair.count" to "1",
+                "economy.monitor.trade.pair.windowMinutes" to "60",
+            ),
+        )
+        AuditLog.logs.clear()
+        TradeFlags.clear()
+    }
+
+    @Test
+    fun `Completed trade over threshold is flagged with non-zero value`() {
+        val (sender, receiver) = setupTradeWithOffer("value_sender", "value_receiver")
+        completeTrade(sender, receiver)
+        assertTrue(AuditLog.logs.any { it.contains("TRADE_FLAG_VALUE") && it.contains("\t10") })
+    }
+
+    @Test
+    fun `Large trades between a pair of accounts are flagged`() {
+        val (sender, receiver) = setupTradeWithOffer("pair_sender", "pair_receiver")
+        completeTrade(sender, receiver)
+        assertTrue(AuditLog.logs.any { it.contains("TRADE_FLAG_PAIR") })
+    }
+
+    private fun completeTrade(sender: Player, receiver: Player) {
+        sender.interfaceOption("trade_main", "accept", "Accept")
+        receiver.interfaceOption("trade_main", "accept", "Accept")
+        tick()
+        sender.interfaceOption("trade_confirm", "accept", "Accept")
+        receiver.interfaceOption("trade_confirm", "accept", "Accept")
+        tick()
+    }
+
+    private fun setupTradeWithOffer(senderName: String, receiverName: String): Pair<Player, Player> {
+        val sender = createPlayer(emptyTile, senderName)
+        val receiver = createPlayer(emptyTile.addY(1), receiverName)
+        sender.inventory.add("coins", 1000)
+        sender.playerOption(receiver, "Trade with")
+        receiver.playerOption(sender, "Trade with")
+        tick()
+        sender.interfaceOption("trade_side", "offer", "Offer-10", item = Item("coins"), slot = 0)
+        return Pair(sender, receiver)
+    }
+}

--- a/game/src/test/kotlin/content/social/trade/monitor/TradeFlagsTest.kt
+++ b/game/src/test/kotlin/content/social/trade/monitor/TradeFlagsTest.kt
@@ -1,0 +1,87 @@
+package content.social.trade.monitor
+
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import world.gregs.voidps.engine.data.Settings
+import world.gregs.voidps.engine.entity.character.player.Player
+import world.gregs.voidps.engine.event.AuditLog
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+internal class TradeFlagsTest {
+
+    private val requester = Player(accountName = "requester")
+    private val acceptor = Player(accountName = "acceptor")
+
+    @BeforeEach
+    fun setup() {
+        AuditLog.logs.clear()
+        TradeFlags.clear()
+        Settings.load(
+            mapOf(
+                "economy.monitor.enabled" to "true",
+                "economy.monitor.trade.enabled" to "true",
+                "economy.monitor.trade.valueThreshold" to "10000000",
+                "economy.monitor.trade.pair.valueThreshold" to "1000000",
+                "economy.monitor.trade.pair.count" to "3",
+                "economy.monitor.trade.pair.windowMinutes" to "60",
+            ),
+        )
+    }
+
+    @AfterEach
+    fun teardown() {
+        Settings.clear()
+        AuditLog.logs.clear()
+        TradeFlags.clear()
+    }
+
+    @Test
+    fun `Trade over value threshold is flagged`() {
+        TradeFlags.check(requester, acceptor, 10_000_000, 0, tick = 0)
+        assertTrue(AuditLog.logs.any { it.contains("TRADE_FLAG_VALUE") })
+    }
+
+    @Test
+    fun `Trade under value threshold is not flagged`() {
+        TradeFlags.check(requester, acceptor, 9_999_999, 500, tick = 0)
+        assertFalse(AuditLog.logs.any { it.contains("TRADE_FLAG_VALUE") })
+    }
+
+    @Test
+    fun `Repeated large trades between the same pair are flagged`() {
+        TradeFlags.check(requester, acceptor, 1_000_000, 0, tick = 0)
+        TradeFlags.check(acceptor, requester, 1_000_000, 0, tick = 10)
+        assertFalse(AuditLog.logs.any { it.contains("TRADE_FLAG_PAIR") })
+        TradeFlags.check(requester, acceptor, 500_000, 500_000, tick = 20)
+        assertTrue(AuditLog.logs.any { it.contains("TRADE_FLAG_PAIR") })
+    }
+
+    @Test
+    fun `Trades outside the window are pruned`() {
+        val window = 6000 // 60 minutes in ticks
+        TradeFlags.check(requester, acceptor, 1_000_000, 0, tick = 0)
+        TradeFlags.check(requester, acceptor, 1_000_000, 0, tick = 10)
+        TradeFlags.check(requester, acceptor, 1_000_000, 0, tick = window + 11)
+        assertFalse(AuditLog.logs.any { it.contains("TRADE_FLAG_PAIR") })
+    }
+
+    @Test
+    fun `Pair flag re-arms after flagging`() {
+        for (tick in 0 until 3) {
+            TradeFlags.check(requester, acceptor, 2_000_000, 0, tick = tick)
+        }
+        assertEquals(1, AuditLog.logs.count { it.contains("TRADE_FLAG_PAIR") })
+        TradeFlags.check(requester, acceptor, 2_000_000, 0, tick = 10)
+        assertEquals(1, AuditLog.logs.count { it.contains("TRADE_FLAG_PAIR") })
+    }
+
+    @Test
+    fun `Disabled monitor flags nothing`() {
+        Settings.load(mapOf("economy.monitor.enabled" to "false"))
+        TradeFlags.check(requester, acceptor, 100_000_000, 0, tick = 0)
+        assertTrue(AuditLog.logs.isEmpty())
+    }
+}


### PR DESCRIPTION
## Summary

Adds configurable economy monitoring (`economy.monitor.*` in game.properties) to catch item duplication and bug abuse, modeled on how Jagex monitors the GE economy:

- **Trade flagging**: flags single trades over a value threshold (`TRADE_FLAG_VALUE`) and repeated large trades between the same account pair within a sliding window (`TRADE_FLAG_PAIR`). Hooks the existing `TradeConfirm` accept flow, valuing offers with `Inventory.calculateValue()` before the exchange transaction.
- **GE price anomaly detection**: flags matched exchanges deviating from `ExchangeHistory.marketPrice()` beyond a configurable threshold (`PRICE_ANOMALY`), with a per-item cooldown. Single choke point: a listener list on `ExchangeHistory.record()`.
- **Item census**: tracks total counts of watched items (value threshold + explicit watchlist) across three buckets: player inventories (via `slotChanged("*")`, skipping `_`-mirror and shop inventories), floor items (spawn/despawn events) and open GE offers (computed from `OpenOffers`). Periodic snapshots are logged (`CENSUS`) and persisted; an async reconciliation scan over player saves corrects drift (`CENSUS_DRIFT`) without blocking the game thread.

All flags write to the existing `AuditLog` TSVs, so `::logs` searches them. When `storage.type=database`, flags and census snapshots are additionally buffered and flushed to two new append-only tables (`economy_flags`, `economy_census`, auto-created by `SchemaUtils.create`, pruned after `economy.monitor.retentionDays`) via new default-body `Storage` methods, `FileStorage`/`SafeStorage` untouched.

Everything is content-space except the engine data classes and `Storage` default methods; zero overhead when disabled (single cached boolean per inventory event). Disabled in WorldTest; hot-reloadable via `::reload settings`.

## Front-end Preview

### Flags
<img width="1906" height="668" alt="image" src="https://github.com/user-attachments/assets/7e3c0003-7787-4980-b625-d33ae529c90b" />

### Economy Report
<img width="1906" height="911" alt="image" src="https://github.com/user-attachments/assets/137fc956-7f7b-4442-a940-54e30f0ae04a" />


## Test plan

- Unit: `TradeFlagsTest`, `PriceAnomalyTest`, `EconomySinkTest`
- WorldTest: `TradeFlagsMonitorTest`, `PriceAnomalyMonitorTest`, `ItemCensusTest`
- Database (testcontainers): flags/census round-trip + retention prune in `DatabaseStorageTest`
- Full `engine:test`, `game:test`, `database:test` green; `spotlessApply` clean