### PR TITLE
Fix slayer assignment names and silent mausoleum gates

### DIFF
--- a/data/entity/obj/door/door.sounds.toml
+++ b/data/entity/obj/door/door.sounds.toml
@@ -22,5 +22,8 @@ id = 66
 [gate_open]
 id = 67
 
+[grate_close]
+id = 68
+
 [grate_open]
 id = 69

--- a/data/quest/members/priest_in_peril/priest_in_peril.objs.toml
+++ b/data/quest/members/priest_in_peril/priest_in_peril.objs.toml
@@ -14,10 +14,12 @@ examine = ""
 
 [pip_underground_door2_opened]
 id = 3446
+material = "grate"
 examine = ""
 
 [pip_underground_door1_opened]
 id = 3446
+material = "grate"
 examine = ""
 
 [pip_prisondoor_closed]

--- a/engine/src/main/kotlin/world/gregs/voidps/engine/entity/obj/GameObjects.kt
+++ b/engine/src/main/kotlin/world/gregs/voidps/engine/entity/obj/GameObjects.kt
@@ -194,21 +194,24 @@ object GameObjects : ZoneBatchUpdates.Sender {
         rotation: Int = original.rotation,
         ticks: Int = NEVER,
         collision: Boolean = true,
+        onRevert: (() -> Unit)? = null,
     ): GameObject {
         val replacement = GameObject(ObjectDefinitions.get(id).id, tile, shape, rotation)
-        replace(original, replacement, ticks, collision)
+        replace(original, replacement, ticks, collision, onRevert)
         return replacement
     }
 
     /**
      * Replaces [original] object with [replacement], optionally reverting after [ticks]
+     * and calling [onRevert] once reverted
      */
-    fun replace(original: GameObject, replacement: GameObject, ticks: Int = NEVER, collision: Boolean = true) {
+    fun replace(original: GameObject, replacement: GameObject, ticks: Int = NEVER, collision: Boolean = true, onRevert: (() -> Unit)? = null) {
         remove(original, collision)
         add(replacement, collision)
         timers.add(setOf(original, replacement), ticks) {
             remove(replacement, collision)
             add(original, collision)
+            onRevert?.invoke()
         }
     }
 
@@ -424,7 +427,7 @@ object GameObjects : ZoneBatchUpdates.Sender {
  * Replaces an existing map objects with [id] [tile] [shape] and [rotation], modifying [collision] and
  * optionally removed after [ticks]
  */
-fun GameObject.replace(id: String, tile: Tile = this.tile, shape: Int = this.shape, rotation: Int = this.rotation, ticks: Int = -1, collision: Boolean = true): GameObject = GameObjects.replace(this, id, tile, shape, rotation, ticks, collision)
+fun GameObject.replace(id: String, tile: Tile = this.tile, shape: Int = this.shape, rotation: Int = this.rotation, ticks: Int = -1, collision: Boolean = true, onRevert: (() -> Unit)? = null): GameObject = GameObjects.replace(this, id, tile, shape, rotation, ticks, collision, onRevert)
 
 /**
  * Removes an existing map [GameObject] and its [collision], optionally reverted after [ticks]

--- a/game/src/main/kotlin/content/entity/obj/Replace.kt
+++ b/game/src/main/kotlin/content/entity/obj/Replace.kt
@@ -22,6 +22,7 @@ object Replace {
         secondRotation: Int,
         ticks: Int,
         collision: Boolean = true,
+        onRevert: (() -> Unit)? = null,
     ) {
         val firstId = ObjectDefinitions.get(firstReplacement).id
         val secondId = ObjectDefinitions.get(secondReplacement).id
@@ -39,6 +40,7 @@ object Replace {
             GameObjects.remove(second, collision)
             GameObjects.add(firstOriginal, collision)
             GameObjects.add(secondOriginal, collision)
+            onRevert?.invoke()
         }
     }
 }

--- a/game/src/main/kotlin/content/entity/obj/door/Door.kt
+++ b/game/src/main/kotlin/content/entity/obj/door/Door.kt
@@ -11,6 +11,7 @@ import world.gregs.voidps.engine.client.variable.remaining
 import world.gregs.voidps.engine.client.variable.start
 import world.gregs.voidps.engine.data.Settings
 import world.gregs.voidps.engine.data.definition.SoundDefinitions
+import world.gregs.voidps.engine.entity.character.areaSound
 import world.gregs.voidps.engine.entity.character.player.Player
 import world.gregs.voidps.engine.entity.character.sound
 import world.gregs.voidps.engine.entity.obj.GameObject
@@ -47,21 +48,21 @@ object Door {
      */
     fun closeDoor(player: Player, door: GameObject, def: ObjectDefinition = door.def, ticks: Int = doorResetDelay, collision: Boolean = true): Boolean {
         val double = DoubleDoor.get(player, door, def, 1)
+        // The revert plays the sound for us, otherwise it'd play twice
         if (resetExisting(door, double)) {
-            sound(player, def, "close")
             return true
         }
 
         // Single door
         if (double == null && door.id.endsWith("_opened")) {
-            replace(door, def, "_opened", "_closed", 0, 3, ticks, collision)
+            replace(door, def, "_opened", "_closed", 0, 3, ticks, collision, revert(def, door, "open"))
             sound(player, def, "close")
             return true
         }
 
         // Double doors
         if (double != null && door.id.endsWith("_opened") && double.id.endsWith("_opened")) {
-            DoubleDoor.close(player, door, def, double, ticks, collision)
+            DoubleDoor.close(player, door, def, double, ticks, collision, revert(def, door, "open"))
             sound(player, def, "close")
             return true
         }
@@ -74,21 +75,21 @@ object Door {
      */
     fun openDoor(player: Player, door: GameObject, def: ObjectDefinition = door.def, ticks: Int = doorResetDelay, collision: Boolean = true): Boolean {
         val double = DoubleDoor.get(player, door, def, 0)
+        // The revert plays the sound for us, otherwise it'd play twice
         if (resetExisting(door, double)) {
-            sound(player, def, "open")
             return true
         }
 
         // Single door
         if (double == null && def.stringId.endsWith("_closed")) {
-            replace(door, def, "_closed", "_opened", 1, 1, ticks, collision)
+            replace(door, def, "_closed", "_opened", 1, 1, ticks, collision, revert(def, door, "close"))
             sound(player, def, "open")
             return true
         }
 
         // Double doors
         if (double != null && def.stringId.endsWith("_closed") && double.def(player).stringId.endsWith("_closed")) {
-            DoubleDoor.open(player, door, def, double, ticks, collision)
+            DoubleDoor.open(player, door, def, double, ticks, collision, revert(def, door, "close"))
             sound(player, def, "open")
             return true
         }
@@ -97,22 +98,30 @@ object Door {
     }
 
     private fun sound(player: Player, definition: ObjectDefinition, suffix: String) {
+        player.sound(soundName(definition, suffix))
+    }
+
+    /**
+     * Plays [suffix] to everyone nearby once a temporary door reverts to its original state
+     */
+    private fun revert(definition: ObjectDefinition, obj: GameObject, suffix: String): () -> Unit = {
+        areaSound(soundName(definition, suffix), obj.tile)
+    }
+
+    private fun soundName(definition: ObjectDefinition, suffix: String): String {
         val type = if (definition.isGate()) "gate" else "door"
         val material = definition["material", ""]
         if (material.isEmpty()) {
-            player.sound("${type}_$suffix")
-            return
+            return "${type}_$suffix"
         }
         // Materials are named after either the door type ("iron_door_open") or the sound
         // itself ("grate_open"), fall back to the generic sound rather than playing nothing
         val sounds: SoundDefinitions = get()
-        player.sound(
-            when {
-                sounds.contains("${material}_${type}_$suffix") -> "${material}_${type}_$suffix"
-                sounds.contains("${material}_$suffix") -> "${material}_$suffix"
-                else -> "${type}_$suffix"
-            },
-        )
+        return when {
+            sounds.contains("${material}_${type}_$suffix") -> "${material}_${type}_$suffix"
+            sounds.contains("${material}_$suffix") -> "${material}_$suffix"
+            else -> "${type}_$suffix"
+        }
     }
 
     private fun resetExisting(obj: GameObject, double: GameObject?): Boolean {
@@ -126,7 +135,7 @@ object Door {
     /**
      * Replace door [obj] with [next] for [ticks]
      */
-    private fun replace(obj: GameObject, def: ObjectDefinition, current: String, next: String, tileRotation: Int, objRotation: Int, ticks: Int, collision: Boolean = true) {
+    private fun replace(obj: GameObject, def: ObjectDefinition, current: String, next: String, tileRotation: Int, objRotation: Int, ticks: Int, collision: Boolean = true, onRevert: (() -> Unit)? = null) {
         val hinged = !def.stringId.contains("single")
         obj.replace(
             id = def.stringId.replace(current, next),
@@ -134,6 +143,7 @@ object Door {
             rotation = if (hinged) obj.rotation(objRotation) else obj.rotation,
             ticks = ticks,
             collision = collision,
+            onRevert = onRevert,
         )
     }
 

--- a/game/src/main/kotlin/content/entity/obj/door/Door.kt
+++ b/game/src/main/kotlin/content/entity/obj/door/Door.kt
@@ -10,12 +10,14 @@ import world.gregs.voidps.engine.client.variable.hasClock
 import world.gregs.voidps.engine.client.variable.remaining
 import world.gregs.voidps.engine.client.variable.start
 import world.gregs.voidps.engine.data.Settings
+import world.gregs.voidps.engine.data.definition.SoundDefinitions
 import world.gregs.voidps.engine.entity.character.player.Player
 import world.gregs.voidps.engine.entity.character.sound
 import world.gregs.voidps.engine.entity.obj.GameObject
 import world.gregs.voidps.engine.entity.obj.GameObjects
 import world.gregs.voidps.engine.entity.obj.ObjectShape
 import world.gregs.voidps.engine.entity.obj.replace
+import world.gregs.voidps.engine.get
 import world.gregs.voidps.engine.timer.epochSeconds
 import world.gregs.voidps.engine.timer.toTicks
 import world.gregs.voidps.type.Direction
@@ -95,8 +97,22 @@ object Door {
     }
 
     private fun sound(player: Player, definition: ObjectDefinition, suffix: String) {
-        val material = if (definition.contains("material")) "${definition["material", ""]}_" else ""
-        player.sound(if (definition.isGate()) "${material}gate_$suffix" else "${material}door_$suffix")
+        val type = if (definition.isGate()) "gate" else "door"
+        val material = definition["material", ""]
+        if (material.isEmpty()) {
+            player.sound("${type}_$suffix")
+            return
+        }
+        // Materials are named after either the door type ("iron_door_open") or the sound
+        // itself ("grate_open"), fall back to the generic sound rather than playing nothing
+        val sounds: SoundDefinitions = get()
+        player.sound(
+            when {
+                sounds.contains("${material}_${type}_$suffix") -> "${material}_${type}_$suffix"
+                sounds.contains("${material}_$suffix") -> "${material}_$suffix"
+                else -> "${type}_$suffix"
+            },
+        )
     }
 
     private fun resetExisting(obj: GameObject, double: GameObject?): Boolean {

--- a/game/src/main/kotlin/content/entity/obj/door/DoubleDoor.kt
+++ b/game/src/main/kotlin/content/entity/obj/door/DoubleDoor.kt
@@ -43,18 +43,19 @@ object DoubleDoor {
     /**
      * Open a pair of double doors [obj] and [double]
      */
-    fun open(player: Player, obj: GameObject, def: ObjectDefinition, double: GameObject, ticks: Int, collision: Boolean = true) {
+    fun open(player: Player, obj: GameObject, def: ObjectDefinition, double: GameObject, ticks: Int, collision: Boolean = true, onRevert: (() -> Unit)? = null) {
         val delta = obj.tile.delta(double.tile)
         val dir = Direction.cardinal[obj.rotation]
         val flip = dir.delta.equals(delta.x.coerceIn(-1, 1), delta.y.coerceIn(-1, 1))
         if (def.isGate()) {
-            Gate.replace(player, obj, double, flip, ticks, collision, "_closed", "_opened", 3, 1, 1)
+            Gate.replace(player, obj, double, flip, ticks, collision, "_closed", "_opened", 3, 1, 1, onRevert)
         } else {
             Replace.objects(
                 obj, def.stringId.replace("_closed", "_opened"), Door.tile(obj, 1), obj.rotation(if (flip) 1 else 3),
                 double, double.def(player).stringId.replace("_closed", "_opened"), Door.tile(double, 1), double.rotation(if (flip) 3 else 1),
                 ticks,
                 collision,
+                onRevert,
             )
         }
     }
@@ -62,12 +63,12 @@ object DoubleDoor {
     /**
      * Close a pair of double doors [obj] and [double]
      */
-    fun close(player: Player, obj: GameObject, def: ObjectDefinition, double: GameObject, ticks: Int, collision: Boolean = true) {
+    fun close(player: Player, obj: GameObject, def: ObjectDefinition, double: GameObject, ticks: Int, collision: Boolean = true, onRevert: (() -> Unit)? = null) {
         val delta = obj.tile.delta(double.tile)
         val dir = Direction.cardinal[obj.rotation]
         val flip = dir.delta.equals(delta.x.coerceIn(-1, 1), delta.y.coerceIn(-1, 1))
         if (def.isGate()) {
-            Gate.replace(player, obj, double, flip, ticks, collision, "_opened", "_closed", 1, 2, 3)
+            Gate.replace(player, obj, double, flip, ticks, collision, "_opened", "_closed", 1, 2, 3, onRevert)
         } else {
             val mirror = def.mirrored
             Replace.objects(
@@ -81,6 +82,7 @@ object DoubleDoor {
                 double.rotation(if (flip || mirror) 3 else 1),
                 ticks,
                 collision,
+                onRevert,
             )
         }
     }

--- a/game/src/main/kotlin/content/entity/obj/door/Gate.kt
+++ b/game/src/main/kotlin/content/entity/obj/door/Gate.kt
@@ -22,6 +22,7 @@ object Gate {
         objRotation: Int,
         hingeTileRotation: Int,
         tileRotation: Int,
+        onRevert: (() -> Unit)? = null,
     ) {
         val first = if (flip) double else obj
         val second = if (flip) obj else double
@@ -37,6 +38,7 @@ object Gate {
             second.rotation(objRotation),
             ticks,
             collision = collision,
+            onRevert = onRevert,
         )
     }
 

--- a/game/src/main/kotlin/content/skill/slayer/EnchantedGem.kt
+++ b/game/src/main/kotlin/content/skill/slayer/EnchantedGem.kt
@@ -33,7 +33,7 @@ class EnchantedGem : Script {
             if (slayerTask == "nothing") {
                 message("You need something new to hunt; return to a Slayer master.")
             } else {
-                message("Your current assignment is: ${slayerTask.lowercase()}; only $slayerTaskRemaining more to go.")
+                message("Your current assignment is: ${slayerTask.toLowerSpaceCase()}; only $slayerTaskRemaining more to go.")
             }
         }
     }

--- a/game/src/main/kotlin/content/skill/slayer/SlayerAssignment.kt
+++ b/game/src/main/kotlin/content/skill/slayer/SlayerAssignment.kt
@@ -80,13 +80,13 @@ class SlayerAssignment : Script {
             }
             player.interfaces.sendText(id, "text_$i", player["blocked_task_$i", "nothing"].toSentenceCase())
         }
-        val assignment = player["slayer_assignment", ""]
-        if (assignment.isEmpty()) {
+        val assignment = player.slayerTask
+        if (assignment == "nothing") {
             player.interfaces.sendText(id, "reassign_text", "You must have an assignment to use this.")
             player.interfaces.sendText(id, "block_text", "You must have an assignment to use this.")
         } else {
-            player.interfaces.sendText(id, "reassign_text", "Cancel task of $assignment.")
-            player.interfaces.sendText(id, "block_text", "Never assign $assignment again.")
+            player.interfaces.sendText(id, "reassign_text", "Cancel task of ${assignment.toSentenceCase()}.")
+            player.interfaces.sendText(id, "block_text", "Never assign ${assignment.toSentenceCase()} again.")
         }
         player.interfaces.sendColour(id, "reassign_text", if (points < 30) Colours.RED else Colours.ORANGE)
         player.interfaces.sendColour(id, "reassign_points", if (points < 30) Colours.RED else Colours.ORANGE)

--- a/game/src/test/kotlin/content/entity/obj/door/DoorSoundTest.kt
+++ b/game/src/test/kotlin/content/entity/obj/door/DoorSoundTest.kt
@@ -1,0 +1,42 @@
+package content.entity.obj.door
+
+import WorldTest
+import io.mockk.mockkObject
+import io.mockk.unmockkObject
+import io.mockk.verify
+import objectOption
+import org.junit.jupiter.api.Test
+import world.gregs.voidps.engine.client.update.batch.ZoneBatchUpdates
+import world.gregs.voidps.engine.entity.obj.GameObjects
+import world.gregs.voidps.network.login.protocol.encode.zone.SoundAddition
+import world.gregs.voidps.network.login.protocol.encode.zone.ZoneUpdate
+import world.gregs.voidps.type.Tile
+import world.gregs.voidps.type.Zone
+import kotlin.test.assertEquals
+
+class DoorSoundTest : WorldTest() {
+
+    /**
+     * The first gate under the Paterdomus mausoleum, the only "grate" material door.
+     * There's no `grate_gate_open` sound for it to resolve to, and reverting a
+     * temporary object used to play nothing at all.
+     */
+    @Test
+    fun `Mausoleum gate plays a grate sound when it shuts behind you`() {
+        val player = createPlayer(Tile(3405, 9894))
+        player["priest_in_peril"] = "go_back"
+        val gate = GameObjects.find(Tile(3405, 9895), "pip_underground_door1_closed")
+        mockkObject(ZoneBatchUpdates)
+        try {
+            player.objectOption(gate, "Open")
+            tick(6)
+
+            val updates = mutableListOf<ZoneUpdate>()
+            verify { ZoneBatchUpdates.add(any<Zone>(), capture(updates)) }
+            val sounds = updates.filterIsInstance<SoundAddition>()
+            assertEquals(listOf(68), sounds.map { it.id }) // grate_close
+        } finally {
+            unmockkObject(ZoneBatchUpdates)
+        }
+    }
+}


### PR DESCRIPTION
Fixes two reported bugs.

## Slayer assignment names showing underscores (#1153)

The enchanted gem and ring of slaying "Kills-left" option printed `slayerTask.lowercase()`, which is the raw variable key, so the message read "moss_giants". Uses `toLowerSpaceCase()` now, the same conversion the slayer master dialogue already applies.

While in there: the reassign/block panel of the slayer rewards interface read `slayer_assignment`, a key nothing writes, so both lines always showed "You must have an assignment to use this." even with a task active. It reads `slayerTask` now and formats with `toSentenceCase()`, matching the blocked task list above it.

## No gate sound in the mausoleum (#1140)

Two problems, both silent.

**The sound name never existed.** `Door.sound` builds `${material}_${gate|door}_${suffix}`, so the two gates below the mausoleum (objects 3444 and 3445, `material = "grate"`, named "Gate") asked for `grate_gate_open`. Nothing defines that, and `Character.sound` returns silently on an unknown id.

Material names follow two conventions: some name the door type (`iron_door_open`, `barrows_door_open`), others name the sound itself (`grate_open`). The lookup falls back through `${material}_${type}_$suffix`, `${material}_$suffix`, then the generic `${type}_$suffix`, so a material without a dedicated sound plays the plain door or gate sound instead of nothing. Only `grate` changes behaviour; `iron` and `barrows` already resolved on the first candidate.

Also adds the missing `grate_close`, sfx 68, next to the existing `grate_open` 67, and sets the material on the opened variants of both gates so closing matches opening.

**Reverting a temporary object played nothing.** Doors opened by `enterDoor` revert after a few ticks, and the 5 minute reset does the same for doors left open, so the gate was silent again the moment the player stepped past it.

`GameObjects.replace` and `Replace.objects` take an optional `onRevert` callback, invoked once the original objects are back. `Door` passes the opposite sound to whichever transition it made, as an area sound at the door tile so anyone nearby hears it rather than only the player who opened it. Threaded through `DoubleDoor` and `Gate` so double doors behave the same.

`resetExisting` fires that same timer early when a player manually closes a door that was going to reset on its own, so the explicit sound in that branch is dropped; the revert plays it now, and keeping both would play it twice.

Sfx ids verified against the rev 634 sound table (GRATE_CLOSE 68, GRATE_OPEN 69).

## Testing

`DoorSoundTest` walks a player through the first mausoleum gate and asserts a `grate_close` zone sound lands once the gate reverts. Full `./gradlew test` passes.

Closes #1153
Closes #1140
