### PR TITLE
Fix magic dart damage and two unreachable object interactions

### DIFF
--- a/data/area/morytania/burgh_de_rott/burgh_de_rott.anims.toml
+++ b/data/area/morytania/burgh_de_rott/burgh_de_rott.anims.toml
@@ -1,0 +1,2 @@
+[low_fence_jump]
+id = 11574

--- a/data/area/morytania/burgh_de_rott/burgh_de_rott.objs.toml
+++ b/data/area/morytania/burgh_de_rott/burgh_de_rott.objs.toml
@@ -17,3 +17,7 @@ examine = "A wooden gate."
 [burgh_de_rott_gate_east_closed]
 id = 12816
 examine = "A wooden gate."
+
+[burgh_de_rott_low_fence]
+id = 12776
+examine = "Looks slightly lower than the rest, perhaps you can jump it?"

--- a/data/area/morytania/burgh_de_rott/burgh_de_rott.objs.toml
+++ b/data/area/morytania/burgh_de_rott/burgh_de_rott.objs.toml
@@ -1,3 +1,19 @@
 [bank_booth_burgh_de_rott]
 id = 12798
 examine = "The bank teller will serve you from here."
+
+[burgh_de_rott_gate_west_opened]
+id = 12819
+examine = "A wooden gate."
+
+[burgh_de_rott_gate_west_closed]
+id = 12817
+examine = "A wooden gate."
+
+[burgh_de_rott_gate_east_opened]
+id = 12818
+examine = "A wooden gate."
+
+[burgh_de_rott_gate_east_closed]
+id = 12816
+examine = "A wooden gate."

--- a/data/area/morytania/meiyerditch/meiyerditch.objs.toml
+++ b/data/area/morytania/meiyerditch/meiyerditch.objs.toml
@@ -1,0 +1,2 @@
+[meiyerditch_broken_fence]
+id = 18411

--- a/data/area/morytania/meiyerditch/meiyerditch.objs.toml
+++ b/data/area/morytania/meiyerditch/meiyerditch.objs.toml
@@ -1,2 +1,3 @@
 [meiyerditch_broken_fence]
 id = 18411
+examine = "This bit of fence has fallen down."

--- a/data/area/morytania/meiyerditch/meiyerditch.objs.toml
+++ b/data/area/morytania/meiyerditch/meiyerditch.objs.toml
@@ -1,0 +1,3 @@
+[meiyerditch_broken_fence]
+id = 18411
+examine = "This bit of fence has fallen down."

--- a/data/skill/magic/spells.tables.toml
+++ b/data/skill/magic/spells.tables.toml
@@ -1,5 +1,6 @@
 [spells]
 xp = "int"
+# -1 marks a spell which never deals damage, so it produces no hitsplat at all
 max_hit = "int"
 max_heal = "int"
 animation = "anim"
@@ -352,7 +353,7 @@ animation = "iban_blast"
 graphic = "iban_blast_cast"
 
 [.magic_dart]
-max_hit = -1
+# No max_hit, it scales with magic level; see Damage.maximum
 xp = 300
 animation = "magic_dart"
 graphic = "magic_dart_cast"

--- a/data/skill/magic/spells.tables.toml
+++ b/data/skill/magic/spells.tables.toml
@@ -3,6 +3,8 @@ xp = "int"
 # -1 marks a spell which never deals damage, so it produces no hitsplat at all
 max_hit = "int"
 max_heal = "int"
+# Magic level comes from the spellbook interface, only spells needing a second skill list one
+slayer_level = "int"
 animation = "anim"
 animation_staff = "anim"
 graphic = "gfx"
@@ -355,6 +357,7 @@ graphic = "iban_blast_cast"
 [.magic_dart]
 # No max_hit, it scales with magic level; see Damage.maximum
 xp = 300
+slayer_level = 55
 animation = "magic_dart"
 graphic = "magic_dart_cast"
 

--- a/game/src/main/kotlin/content/area/morytania/burgh_de_rott/BurghDeRottGate.kt
+++ b/game/src/main/kotlin/content/area/morytania/burgh_de_rott/BurghDeRottGate.kt
@@ -1,0 +1,13 @@
+package content.area.morytania.burgh_de_rott
+
+import content.entity.obj.door.enterDoor
+import world.gregs.voidps.engine.Script
+
+class BurghDeRottGate : Script {
+
+    init {
+        objectOperate("Open", "burgh_de_rott_gate_*_closed") { (target) ->
+            enterDoor(target, delay = 2)
+        }
+    }
+}

--- a/game/src/main/kotlin/content/area/morytania/burgh_de_rott/BurghDeRottLowFence.kt
+++ b/game/src/main/kotlin/content/area/morytania/burgh_de_rott/BurghDeRottLowFence.kt
@@ -1,0 +1,33 @@
+package content.area.morytania.burgh_de_rott
+
+import world.gregs.voidps.engine.Script
+import world.gregs.voidps.engine.entity.character.player.Player
+import world.gregs.voidps.engine.entity.character.player.chat.obstacle
+import world.gregs.voidps.engine.entity.character.player.skill.Skill
+import world.gregs.voidps.engine.entity.character.player.skill.level.Level.has
+import world.gregs.voidps.engine.entity.obj.GameObject
+import world.gregs.voidps.type.Direction
+
+class BurghDeRottLowFence : Script {
+
+    init {
+        objectOperate("Jump-over", "burgh_de_rott_low_fence") { (target) ->
+            if (!has(Skill.Agility, 25)) {
+                obstacle(25)
+                return@objectOperate
+            }
+            jump(target)
+        }
+    }
+
+    private suspend fun Player.jump(target: GameObject) {
+        val direction = if (tile.x < target.tile.x) Direction.EAST else Direction.WEST
+        val landing = if (direction == Direction.EAST) target.tile else target.tile.add(Direction.WEST)
+        // Take a run up so the jump covers two tiles, the animation is too long for a single step
+        walkOverDelay(landing.minus(direction).minus(direction))
+        face(direction)
+        delay()
+        anim("low_fence_jump")
+        exactMoveDelay(landing, 60, direction = direction)
+    }
+}

--- a/game/src/main/kotlin/content/skill/agility/shortcut/Stiles.kt
+++ b/game/src/main/kotlin/content/skill/agility/shortcut/Stiles.kt
@@ -29,6 +29,10 @@ class Stiles : Script {
             climbStile(target, Direction.NORTH)
         }
 
+        objectOperate("Climb-over", "meiyerditch_broken_fence") { (target) ->
+            climbStile(target, Direction.NORTH)
+        }
+
         objectOperate("Climb-over", "ardougne_farm_stile") { (target) ->
             climbStile(target, Direction.EAST)
         }

--- a/game/src/main/kotlin/content/skill/magic/spell/SpellRunes.kt
+++ b/game/src/main/kotlin/content/skill/magic/spell/SpellRunes.kt
@@ -6,6 +6,7 @@ import world.gregs.voidps.cache.definition.data.InterfaceComponentDefinition
 import world.gregs.voidps.engine.client.message
 import world.gregs.voidps.engine.data.definition.InterfaceDefinitions
 import world.gregs.voidps.engine.data.definition.ItemDefinitions
+import world.gregs.voidps.engine.data.definition.Tables
 import world.gregs.voidps.engine.entity.World
 import world.gregs.voidps.engine.entity.character.player.Player
 import world.gregs.voidps.engine.entity.character.player.chat.ChatType
@@ -35,6 +36,11 @@ object SpellRunes {
     fun Transaction.removeItems(player: Player, spell: String, message: Boolean = true) {
         val component = InterfaceDefinitions.getComponent(player.spellBook, spell)
         if (component == null || !player.has(Skill.Magic, component.magicLevel, message = message)) {
+            error = TransactionError.Deficient(0)
+            return
+        }
+        val slayerLevel = Tables.intOrNull("spells.$spell.slayer_level")
+        if (slayerLevel != null && !player.has(Skill.Slayer, slayerLevel, if (message) " to cast this spell" else null)) {
             error = TransactionError.Deficient(0)
             return
         }

--- a/game/src/test/kotlin/content/area/morytania/burgh_de_rott/BurghDeRottGateTest.kt
+++ b/game/src/test/kotlin/content/area/morytania/burgh_de_rott/BurghDeRottGateTest.kt
@@ -1,0 +1,29 @@
+package content.area.morytania.burgh_de_rott
+
+import WorldTest
+import objectOption
+import org.junit.jupiter.api.Test
+import walk
+import world.gregs.voidps.engine.entity.obj.GameObjects
+import world.gregs.voidps.type.Tile
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+
+class BurghDeRottGateTest : WorldTest() {
+
+    @Test
+    fun `Open the gate into Burgh de Rott and walk through`() {
+        val player = createPlayer(Tile(3484, 3245))
+        val gate = GameObjects.find(Tile(3484, 3244), "burgh_de_rott_gate_west_closed")
+
+        player.objectOption(gate, "Open")
+        tick(3)
+
+        assertNotNull(GameObjects.findOrNull(Tile(3485, 3242), "burgh_de_rott_gate_west_opened"))
+        assertNotNull(GameObjects.findOrNull(Tile(3485, 3243), "burgh_de_rott_gate_east_opened"))
+
+        player.walk(Tile(3484, 3243))
+        tick(5)
+        assertEquals(Tile(3484, 3243), player.tile)
+    }
+}

--- a/game/src/test/kotlin/content/area/morytania/burgh_de_rott/BurghDeRottGateTest.kt
+++ b/game/src/test/kotlin/content/area/morytania/burgh_de_rott/BurghDeRottGateTest.kt
@@ -12,18 +12,37 @@ import kotlin.test.assertNotNull
 class BurghDeRottGateTest : WorldTest() {
 
     @Test
-    fun `Open the gate into Burgh de Rott and walk through`() {
+    fun `Gate closes behind the player once they walk through`() {
         val player = createPlayer(Tile(3484, 3245))
         val gate = GameObjects.find(Tile(3484, 3244), "burgh_de_rott_gate_west_closed")
 
         player.objectOption(gate, "Open")
-        tick(3)
+        tick(2)
 
         assertNotNull(GameObjects.findOrNull(Tile(3485, 3242), "burgh_de_rott_gate_west_opened"))
         assertNotNull(GameObjects.findOrNull(Tile(3485, 3243), "burgh_de_rott_gate_east_opened"))
 
-        player.walk(Tile(3484, 3243))
-        tick(5)
+        tick(6)
+
         assertEquals(Tile(3484, 3243), player.tile)
+        assertNotNull(GameObjects.findOrNull(Tile(3484, 3244), "burgh_de_rott_gate_west_closed"))
+        assertNotNull(GameObjects.findOrNull(Tile(3485, 3244), "burgh_de_rott_gate_east_closed"))
+    }
+
+    @Test
+    fun `Other players can't follow through the open gate`() {
+        val player = createPlayer(Tile(3484, 3245))
+        val other = createPlayer(Tile(3485, 3244))
+        val gate = GameObjects.find(Tile(3484, 3244), "burgh_de_rott_gate_west_closed")
+
+        player.objectOption(gate, "Open")
+        tick(2)
+
+        // The gate is open but never gave up its collision, so the doorway is still blocked
+        assertNotNull(GameObjects.findOrNull(Tile(3485, 3243), "burgh_de_rott_gate_east_opened"))
+        other.walk(Tile(3485, 3243))
+        tick(1)
+
+        assertEquals(Tile(3485, 3244), other.tile)
     }
 }

--- a/game/src/test/kotlin/content/skill/agility/shortcut/StilesTest.kt
+++ b/game/src/test/kotlin/content/skill/agility/shortcut/StilesTest.kt
@@ -58,4 +58,26 @@ internal class StilesTest : WorldTest() {
             assertEquals(target, player.tile)
         }
     }
+
+    @TestFactory
+    fun `Climb the Meiyerditch broken fence`() = listOf(
+        Delta(0, 0) to Tile(3584, 3264),
+        Delta(0, -1) to Tile(3584, 3264),
+        Delta(-1, 0) to Tile(3584, 3264),
+        Delta(0, 1) to Tile(3584, 3263),
+        Delta(0, 2) to Tile(3584, 3263),
+        Delta(-1, 1) to Tile(3584, 3263),
+    ).map { (delta, target) ->
+        dynamicTest("Climb broken fence from $delta to $target") {
+            val objTile = Tile(3584, 3263)
+            val obj = GameObjects.find(objTile, "meiyerditch_broken_fence")
+            val player = createPlayer(objTile.add(delta))
+
+            player.objectOption(obj, "Climb-over")
+
+            tick(4)
+
+            assertEquals(target, player.tile)
+        }
+    }
 }

--- a/game/src/test/kotlin/content/skill/magic/spell/MagicDartRequirementTest.kt
+++ b/game/src/test/kotlin/content/skill/magic/spell/MagicDartRequirementTest.kt
@@ -1,0 +1,30 @@
+package content.skill.magic.spell
+
+import WorldTest
+import org.junit.jupiter.api.Test
+import world.gregs.voidps.engine.entity.character.player.skill.Skill
+import world.gregs.voidps.engine.inv.add
+import world.gregs.voidps.engine.inv.equipment
+import world.gregs.voidps.engine.inv.inventory
+import world.gregs.voidps.network.login.protocol.visual.update.player.EquipSlot
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+internal class MagicDartRequirementTest : WorldTest() {
+
+    @Test
+    fun `Magic dart requires 55 slayer`() {
+        val player = createPlayer()
+        player.levels.set(Skill.Magic, 99)
+        player.levels.set(Skill.Slayer, 54)
+        player.equipment.set(EquipSlot.Weapon.index, "slayers_staff")
+        player.inventory.add("death_rune", 5)
+        player.inventory.add("mind_rune", 20)
+
+        assertFalse(player.hasSpellItems("magic_dart", message = false))
+
+        player.levels.set(Skill.Slayer, 55)
+
+        assertTrue(player.hasSpellItems("magic_dart", message = false))
+    }
+}

--- a/game/src/test/kotlin/content/skill/magic/spell/MagicDartTest.kt
+++ b/game/src/test/kotlin/content/skill/magic/spell/MagicDartTest.kt
@@ -1,0 +1,21 @@
+package content.skill.magic.spell
+
+import content.entity.combat.hit.hit
+import content.skill.melee.CombatFormulaTest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import world.gregs.voidps.engine.entity.character.player.skill.Skill
+
+internal class MagicDartTest : CombatFormulaTest() {
+
+    @Test
+    fun `Magic dart damages the target`() {
+        val player = createPlayer(Skill.Magic to 99)
+        val target = createPlayer(Skill.Constitution to 990)
+
+        player.hit(target, offensiveType = "magic", spell = "magic_dart", damage = 100)
+        tick(3)
+
+        assertEquals(890, target.levels.get(Skill.Constitution))
+    }
+}


### PR DESCRIPTION
Three unrelated fixes, each with a test.

**Magic dart dealt no damage.** `max_hit = -1` marks a spell that never deals damage, and `CombatHitsplats` returns early on it. Magic dart carried `-1` for the opposite reason: its max hit scales with magic level and `Damage.maximum` special cases it before reading the table. Dropped the key from the row rather than changing the value, and documented what `-1` means on the column.

**Burgh de Rott gate would not open.** Objects 12817 and 12816 at 3484,3244 offer "Open" in the cache but had no object config, so the generic handler had no `_closed`/`_opened` ids to swap. Defined both halves and their opened variants, 12819 and 12818. `ObjectDoorsGates` never generated them because it runs `ObjectDecoderFull(members = false)`, which strips names and options from members objects, so other members gates may be missing for the same reason.

The gate now goes through `enterDoor` like the Al Kharid tollgate: it shuts behind the player instead of standing open for five minutes. `enterDoor` opens with `collision = false`, so the closed gate keeps its collision and nobody can follow through. Intended to be quest gated later; for now any player can open it.

**Meiyerditch broken fence could not be climbed.** Object 18411 at 3584,3263 offers "Climb-over" but had no object config. It is wall-straight at rotation 1, blocking the north edge, so `climbStile` with `Direction.NORTH` covers both approaches. No Agility requirement, since the cache option is a plain "Climb-over" like the other stiles.
