### PR TITLE
Fixed Mage of Zamoraks Store

### DIFF
--- a/game/src/main/kotlin/content/area/wilderness/abyss/MageOfZamorak.kt
+++ b/game/src/main/kotlin/content/area/wilderness/abyss/MageOfZamorak.kt
@@ -5,7 +5,6 @@ import content.entity.player.bank.ownsItem
 import content.entity.player.dialogue.*
 import content.entity.player.dialogue.type.*
 import content.quest.questCompleted
-import content.quest.questStage
 import world.gregs.voidps.engine.Script
 import world.gregs.voidps.engine.client.message
 import world.gregs.voidps.engine.client.ui.closeInterfaces

--- a/game/src/main/kotlin/content/area/wilderness/abyss/MageOfZamorak.kt
+++ b/game/src/main/kotlin/content/area/wilderness/abyss/MageOfZamorak.kt
@@ -47,6 +47,8 @@ class MageOfZamorak : Script {
                     else -> npc<Neutral>("This isn't the place to talk. Visit me in Varrock's Chaos Temple if you have something to discuss.")
                 }
                 return@npcOperate
+            } else {
+                npc<Neutral>("Ah, you again. The Wilderness is hardly the appropriate place for a conversation now, is it? What was it you wanted?")
             }
 
             choice {
@@ -133,7 +135,7 @@ class MageOfZamorak : Script {
         npcOperate("Trade", "mage_of_zamorak_wilderness") {
             if(questCompleted("enter_the_abyss")){
                 openShop("battle_runes_enter_the_abyss")
-            } else { 
+            } else {
                 openShop("battle_runes")
             }
         }

--- a/game/src/main/kotlin/content/area/wilderness/abyss/MageOfZamorak.kt
+++ b/game/src/main/kotlin/content/area/wilderness/abyss/MageOfZamorak.kt
@@ -48,7 +48,7 @@ class MageOfZamorak : Script {
                 }
                 return@npcOperate
             } else {
-                npc<Neutral>("Ah, you again. The Wilderness is hardly the appropriate place for a conversation now, is it? What was it you wanted?")
+                npc<Neutral>("Ah, you again. What is it you want?")
             }
 
             choice {

--- a/game/src/main/kotlin/content/area/wilderness/abyss/MageOfZamorak.kt
+++ b/game/src/main/kotlin/content/area/wilderness/abyss/MageOfZamorak.kt
@@ -9,7 +9,6 @@ import world.gregs.voidps.engine.Script
 import world.gregs.voidps.engine.client.message
 import world.gregs.voidps.engine.client.ui.closeInterfaces
 import world.gregs.voidps.engine.data.definition.Areas
-import world.gregs.voidps.engine.entity.character.mode.interact.PlayerOnNPCInteract
 import world.gregs.voidps.engine.entity.character.move.tele
 import world.gregs.voidps.engine.entity.character.npc.NPC
 import world.gregs.voidps.engine.entity.character.player.Player

--- a/game/src/main/kotlin/content/area/wilderness/abyss/MageOfZamorak.kt
+++ b/game/src/main/kotlin/content/area/wilderness/abyss/MageOfZamorak.kt
@@ -5,10 +5,12 @@ import content.entity.player.bank.ownsItem
 import content.entity.player.dialogue.*
 import content.entity.player.dialogue.type.*
 import content.quest.questCompleted
+import content.quest.questStage
 import world.gregs.voidps.engine.Script
 import world.gregs.voidps.engine.client.message
 import world.gregs.voidps.engine.client.ui.closeInterfaces
 import world.gregs.voidps.engine.data.definition.Areas
+import world.gregs.voidps.engine.entity.character.mode.interact.PlayerOnNPCInteract
 import world.gregs.voidps.engine.entity.character.move.tele
 import world.gregs.voidps.engine.entity.character.npc.NPC
 import world.gregs.voidps.engine.entity.character.player.Player
@@ -37,22 +39,25 @@ class MageOfZamorak : Script {
                 return@npcOperate
             }
 
-            if (questCompleted("rune_mysteries")) {
+            if (!questCompleted("rune_mysteries")) {
                 when (get("enter_the_abyss", "unstarted")) {
                     "unstarted" -> {
-                        npc<Neutral>("If you want to talk, this isn't the place for it. Meet me in Varrock's Chaos Temple, by the rune shop. Unless you're here to buy something?")
+                        npc<Neutral>("Meet me in Varrock's Chaos Temple. Here is not the place to talk.")
                         set("enter_the_abyss", "started")
                     }
-                    "started" -> npc<Neutral>("I already told you to meet me in Varrock's Chaos Temple, by the rune shop. Unless you're here to buy something?")
-                    else -> npc<Neutral>("This isn't the place to talk. Visit me in Varrock's Chaos Temple if you have something to discuss. Unless you're here to buy something?")
+                    "started" -> npc<Neutral>("I already told you! Meet me in Varrock's Chaos Temple!")
+                    else -> npc<Neutral>("This isn't the place to talk. Visit me in Varrock's Chaos Temple if you have something to discuss.")
                 }
-            } else {
-                npc<Angry>("This isn't the place to talk. Unless you're here to buy something, you should leave.")
+                return@npcOperate
             }
 
             choice {
                 option("Let's see what you're selling.") {
-                    openShop("mage_of_zamorak")
+                    if(questCompleted("enter_the_abyss")){
+                    openShop("battle_runes_enter_the_abyss")
+                    } else {
+                        openShop("battle_runes")
+                    }
                 }
                 if (questCompleted("enter_the_abyss")) {
                     option<Quiz>("Could you teleport me to the Abyss?") {
@@ -124,6 +129,14 @@ class MageOfZamorak : Script {
                     whereRunes()
                     option<Neutral>("Just looking around.")
                 }
+            }
+        }
+
+        npcOperate("Trade", "mage_of_zamorak_wilderness") {
+            if(questCompleted("enter_the_abyss")){
+                openShop("battle_runes_enter_the_abyss")
+            } else { 
+                openShop("battle_runes")
             }
         }
     }


### PR DESCRIPTION
- Fixed Mage of Zamoraks Store; Before and after enter the abyss mini quest versions of the store.
- Authentic dialog restored. (a small portion has been fixed will see if I can correct more)

** Sources **
- [https://www.youtube.com/watch?v=KIkMa2xDXZA](https://www.youtube.com/watch?v=KIkMa2xDXZAl)
- [https://www.youtube.com/watch?v=ArNbjLv6E3o](https://www.youtube.com/watch?v=ArNbjLv6E3o)
- [https://www.youtube.com/watch?v=A2IeZAuqyjU](https://www.youtube.com/watch?v=A2IeZAuqyjU)
- [https://www.youtube.com/watch?v=kS9h3K40Yrk](https://www.youtube.com/watch?v=kS9h3K40Yrk)
- [https://www.youtube.com/watch?v=-STxiPP1v5c](https://www.youtube.com/watch?v=-STxiPP1v5c)

Fixes #1165 