### PR TITLE
Fix graves spawning at stale instance exit tiles

### DIFF
--- a/game/src/main/kotlin/content/entity/death/PlayerDeath.kt
+++ b/game/src/main/kotlin/content/entity/death/PlayerDeath.kt
@@ -13,6 +13,7 @@ import content.entity.player.effect.energy.runEnergy
 import content.entity.player.inv.item.tradeable
 import content.entity.player.kept.ItemsKeptOnDeath
 import content.entity.proj.shoot
+import content.quest.instance
 import content.quest.instanceLogout
 import content.skill.prayer.getActivePrayerVarKey
 import content.skill.prayer.praying
@@ -79,7 +80,9 @@ class PlayerDeath : Script {
                 clear(getActivePrayerVarKey())
                 dismissFamiliar()
                 if (onDeath.dropItems) {
-                    val tile = instanceLogout() ?: tile
+                    // Instance exit tile only applies while actually inside one; a leftover
+                    // value would send the grave and every dropped item to that old tile.
+                    val tile = if (instance() != null) instanceLogout() ?: tile else tile
                     dropItems(this, killer, tile)
                 }
                 levels.clear()

--- a/game/src/main/kotlin/content/quest/Cutscene.kt
+++ b/game/src/main/kotlin/content/quest/Cutscene.kt
@@ -158,6 +158,9 @@ fun Player.instance(): Region? {
 fun Player.clearInstance(): Boolean {
     val id: Int = remove("instance") ?: return false
     clear("instance_offset")
+    // Only meaningful while inside the instance; leaving it set sends the next instance exit
+    // (and any death drop) back to an exit tile that has nothing to do with where the player is.
+    clear("instance_logout_tile")
     val region = Region(id)
     Instances.free(region)
     get<DynamicZones>().clear(region)

--- a/game/src/main/kotlin/content/quest/InstanceLogout.kt
+++ b/game/src/main/kotlin/content/quest/InstanceLogout.kt
@@ -4,6 +4,14 @@ import world.gregs.voidps.engine.Script
 
 class InstanceLogout : Script {
     init {
+        playerSpawn {
+            // Saves written before instance exits cleared it can still carry a logout tile from
+            // an instance left long ago; drop it so deaths and exits use the real location.
+            if (instance() == null) {
+                clear("instance_logout_tile")
+            }
+        }
+
         playerDespawn {
             if (get("instance_logout", false)) {
                 exitInstance()

--- a/game/src/test/kotlin/content/area/misthalin/lumbridge/church/GravestonesTest.kt
+++ b/game/src/test/kotlin/content/area/misthalin/lumbridge/church/GravestonesTest.kt
@@ -67,6 +67,24 @@ class GravestonesTest : WorldTest() {
     }
 
     @Test
+    fun `A stale instance logout tile doesn't move the grave`() {
+        val tile = Tile(2872, 5361, 2) // God Wars Dungeon, Bandos chamber
+        val logout = Tile(3246, 3198) // Lumbridge catacombs exit, left over from Blood Pact
+        val player = createPlayer(tile)
+        player["instance_logout_tile"] = logout.id
+        player.inventory.add("coins", 10)
+        tick()
+
+        player.damage(101)
+        tick(9)
+
+        assertNotNull(NPCs.firstOrNull(tile) { it.id.startsWith("gravestone") })
+        assertNotNull(FloorItems.firstOrNull(tile, "coins"))
+        assertNull(NPCs.firstOrNull(logout) { it.id.startsWith("gravestone") })
+        assertNull(FloorItems.firstOrNull(logout, "coins"))
+    }
+
+    @Test
     fun `A gravestone breaks after 3 minutes`() {
         val tile = Tile(3235, 3220)
         val player = createPlayer(tile)


### PR DESCRIPTION
### Problem

`instanceLogout()` reads the player var `instance_logout_tile`, which is set when *entering* an instance (`LumbridgeCatacombs`, `HuntForSurok`, `Edmond`, `PollnivneachDungeon`, and every random event via `random_event_origin`) and was never cleared — `clearInstance()` removed `instance` and `instance_offset` but not this one. The var is persisted in the save's `[variables]`, so a single Blood Pact run or random event permanently redirected every later death, anywhere in the game, to that old exit tile.

`instanceOrigin()` has the same latent flaw: entering a later instance that doesn't set its own logout tile would teleport the player to the stale one on exit.

### Fix

- `PlayerDeath` only uses the instance exit tile while the player is actually inside an instance.
- `clearInstance()` clears `instance_logout_tile` alongside `instance_offset`.
- `InstanceLogout` clears it on spawn when not in an instance, so saves that already carry a stale value recover on next login.

### Testing

New `GravestonesTest` case: with a stale logout tile set, die in the Bandos chamber and assert the grave and dropped items are at the death tile and nothing lands on the logout tile. Full `:game:test` suite passes.