### PR TITLE
Fix uninteractable duel arena bank chests

### DIFF
--- a/data/area/kharidian_desert/al_kharid/duel_arena/duel_arena.objs.toml
+++ b/data/area/kharidian_desert/al_kharid/duel_arena/duel_arena.objs.toml
@@ -1,0 +1,3 @@
+[bank_chest_duel_arena]
+id = 27663
+examine = "I can store my items safely here."

--- a/game/src/main/kotlin/content/entity/npc/Banker.kt
+++ b/game/src/main/kotlin/content/entity/npc/Banker.kt
@@ -35,6 +35,10 @@ class Banker : Script {
             openBank()
         }
 
+        objectOperate("Bank", "bank_chest_*") {
+            openBank()
+        }
+
         objectOperate("Use", "bank_booth_*", arrive = false) { (target) ->
             val banker = NPCs.first { it.def.name == "Banker" }
             talkWith(banker)

--- a/game/src/test/kotlin/content/area/kharidian_desert/al_kharid/duel_arena/DuelArenaBankTest.kt
+++ b/game/src/test/kotlin/content/area/kharidian_desert/al_kharid/duel_arena/DuelArenaBankTest.kt
@@ -1,0 +1,22 @@
+package content.area.kharidian_desert.al_kharid.duel_arena
+
+import WorldTest
+import objectOption
+import org.junit.jupiter.api.Test
+import world.gregs.voidps.engine.client.ui.hasOpen
+import world.gregs.voidps.engine.entity.obj.GameObjects
+import world.gregs.voidps.type.Tile
+import kotlin.test.assertTrue
+
+class DuelArenaBankTest : WorldTest() {
+
+    @Test
+    fun `Bank at duel arena bank chest`() {
+        val player = createPlayer(Tile(3381, 3268))
+        val chest = GameObjects.find(Tile(3381, 3269), "bank_chest_duel_arena")
+        player.objectOption(chest, "Bank")
+        tick(2)
+
+        assertTrue(player.hasOpen("bank"))
+    }
+}


### PR DESCRIPTION
Closes #1181

## Problem

The Duel Arena bank chests are object id `27663` (`Bank chest`, options `[Bank, Examine]`). Void had no definition for that id, and `Banker.kt` only registered the `Use` option on `bank_chest_*`, so interacting fell through to "Nothing interesting happens".

## Changes

- Added `bank_chest_duel_arena` (id 27663) to a new `data/area/kharidian_desert/al_kharid/duel_arena/duel_arena.objs.toml`. The same id is used by the two arena chests (3381,3269 / 3382,3270) and the three tournament area chests (3216,5093 / 3233,5108 / 3249,5085), so one definition covers all five.
- Registered `objectOperate("Bank", "bank_chest_*")` in `Banker.kt`. A separate registration is needed because the option string is a handler key and isn't comma-split.
- Added `DuelArenaBankTest` covering the arena chest opening the bank interface.

## Testing

`./gradlew :game:test --tests "content.area.kharidian_desert.al_kharid.duel_arena.DuelArenaBankTest"` passes.