### PR TITLE
Dragonfire shield charging, discharge and creation

### DIFF
--- a/data/area/kandarin/ancient_cavern/ancient_cavern.items.toml
+++ b/data/area/kandarin/ancient_cavern/ancient_cavern.items.toml
@@ -1,38 +1,3 @@
-[dragonfire_shield_charged]
-id = 11283
-limit = 10
-tradeable = false
-bank_stacks = false
-aka = ["dragonfire_shield", "dfs", "dragon_fire_shield"]
-charges = 0
-degrade = "dragonfire_shield_uncharged"
-slot = "Shield"
-material = "metal"
-examine = "A heavy shield with a snarling, draconic visage."
-weight = 7.257
-
-[dragonfire_shield_uncharged]
-id = 11284
-price = 10200000
-limit = 10
-slot = "Shield"
-material = "metal"
-examine = "A heavy shield with a snarling, draconic visage."
-weight = 7.257
-
-[dragonfire_shield_uncharged_noted]
-id = 11285
-
-[draconic_visage]
-id = 11286
-price = 10900000
-limit = 10
-weight = 1.814
-examine = "It looks like this could be attached to a shield somehow."
-
-[draconic_visage_noted]
-id = 11287
-
 [dragon_full_helm]
 id = 11335
 price = 48171291

--- a/data/entity/player/combat/special_attack.gfx.toml
+++ b/data/entity/player/combat/special_attack.gfx.toml
@@ -131,11 +131,6 @@ id = 2319
 [power_of_light_impact]
 id = 2320
 
-[dragonfire_shield_discharge]
-id = 1166
-delay = 80
-curve = 0
-
 [guthans_effect]
 id = 398
 height = 50

--- a/data/entity/player/equipment/dragonfire_shield.anims.toml
+++ b/data/entity/player/equipment/dragonfire_shield.anims.toml
@@ -1,0 +1,5 @@
+[dragonfire_shield_discharge]
+id = 6696
+
+[dragonfire_shield_empty]
+id = 6700

--- a/data/entity/player/equipment/dragonfire_shield.gfx.toml
+++ b/data/entity/player/equipment/dragonfire_shield.gfx.toml
@@ -2,7 +2,7 @@
 # twelve below the standard forty so it leaves and lands at the shield's own height.
 [dragonfire_shield_discharge]
 id = 1166
-delay = 50
+delay = 110
 time_offset = 7
 multiplier = 7
 curve = 10

--- a/data/entity/player/equipment/dragonfire_shield.gfx.toml
+++ b/data/entity/player/equipment/dragonfire_shield.gfx.toml
@@ -2,7 +2,7 @@
 # twelve below the standard forty so it leaves and lands at the shield's own height.
 [dragonfire_shield_discharge]
 id = 1166
-delay = 110
+delay = 90
 time_offset = 7
 multiplier = 7
 curve = 10

--- a/data/entity/player/equipment/dragonfire_shield.gfx.toml
+++ b/data/entity/player/equipment/dragonfire_shield.gfx.toml
@@ -1,0 +1,20 @@
+# The fire waits out the shield's wind up, then travels seven client ticks per tile. Heights sit
+# twelve below the standard forty so it leaves and lands at the shield's own height.
+[dragonfire_shield_discharge]
+id = 1166
+delay = 50
+time_offset = 7
+multiplier = 7
+curve = 10
+height = -12
+end_height = -12
+
+[dragonfire_shield_discharge_cast]
+id = 1165
+
+[dragonfire_shield_discharge_impact]
+id = 1167
+height = 56
+
+[dragonfire_shield_empty]
+id = 1160

--- a/data/entity/player/equipment/dragonfire_shield.items.toml
+++ b/data/entity/player/equipment/dragonfire_shield.items.toml
@@ -1,0 +1,35 @@
+[dragonfire_shield_charged]
+id = 11283
+limit = 10
+tradeable = false
+bank_stacks = false
+aka = ["dragonfire_shield", "dfs", "dragon_fire_shield"]
+charges = 0
+charges_max = 50
+degrade = "dragonfire_shield_uncharged"
+slot = "Shield"
+material = "metal"
+examine = "A heavy shield with a snarling, draconic visage."
+weight = 7.257
+
+[dragonfire_shield_uncharged]
+id = 11284
+price = 10200000
+limit = 10
+slot = "Shield"
+material = "metal"
+examine = "A heavy shield with a snarling, draconic visage."
+weight = 7.257
+
+[dragonfire_shield_uncharged_noted]
+id = 11285
+
+[draconic_visage]
+id = 11286
+price = 10900000
+limit = 10
+weight = 1.814
+examine = "It looks like this could be attached to a shield somehow."
+
+[draconic_visage_noted]
+id = 11287

--- a/data/entity/player/equipment/dragonfire_shield.sounds.toml
+++ b/data/entity/player/equipment/dragonfire_shield.sounds.toml
@@ -1,0 +1,5 @@
+[dragonfire_shield_discharge]
+id = 3761
+
+[dragonfire_shield_empty]
+id = 3760

--- a/engine/src/main/kotlin/world/gregs/voidps/engine/entity/item/Item.kt
+++ b/engine/src/main/kotlin/world/gregs/voidps/engine/entity/item/Item.kt
@@ -14,8 +14,14 @@ class Item(
         get() = ItemDefinitions.getOrNull(id)
     private val itemCharge: Boolean
         get() {
-            val charges = defOrNull?.getOrNull<Int>("charges")
-            return charges != null && charges > 1 && defOrNull?.contains("charge") != true
+            val definition = defOrNull ?: return false
+            if (definition.contains("charge")) {
+                return false
+            }
+            // Charges held in the item's value, the capacity rather than the starting amount says
+            // whether it's chargeable - an item that starts empty still only ever counts as one.
+            val charges = definition.getOrNull<Int>("charges_max") ?: definition.getOrNull<Int>("charges") ?: return false
+            return charges > 1
         }
     val amount: Int
         get() = if (itemCharge) 1 else value

--- a/game/src/main/kotlin/content/area/asgarnia/asgarnian_ice_dungeon/SkeletalWyvern.kt
+++ b/game/src/main/kotlin/content/area/asgarnia/asgarnian_ice_dungeon/SkeletalWyvern.kt
@@ -1,6 +1,7 @@
 package content.area.asgarnia.asgarnian_ice_dungeon
 
 import content.entity.combat.hit.Hit
+import content.entity.player.equip.Equipment
 import world.gregs.voidps.engine.Script
 import world.gregs.voidps.engine.entity.character.Character
 import world.gregs.voidps.engine.entity.character.player.Player
@@ -21,11 +22,9 @@ class SkeletalWyvern : Script {
     // TODO: fix blue ice orb for range as not as it is on runescape the blue ice orb is above his head not his chest
 
     fun hasWyvernShield(target: Character): Boolean {
-        if (target !is Player) return false
-        val shieldId = target.equipped(EquipSlot.Shield).id
-        return shieldId == "elemental_shield" ||
-            shieldId == "mind_shield" ||
-            shieldId == "body_shield" ||
-            shieldId.startsWith("dragonfire_shield")
+        if (target !is Player) {
+            return false
+        }
+        return Equipment.fireResistantShield(target.equipped(EquipSlot.Shield).id)
     }
 }

--- a/game/src/main/kotlin/content/area/misthalin/edgeville/Oziach.kt
+++ b/game/src/main/kotlin/content/area/misthalin/edgeville/Oziach.kt
@@ -1,0 +1,80 @@
+package content.area.misthalin.edgeville
+
+import content.entity.npc.shop.openShop
+import content.entity.player.dialogue.Amazed
+import content.entity.player.dialogue.Happy
+import content.entity.player.dialogue.Neutral
+import content.entity.player.dialogue.Quiz
+import content.entity.player.dialogue.Sad
+import content.entity.player.dialogue.type.choice
+import content.entity.player.dialogue.type.item
+import content.entity.player.dialogue.type.npc
+import content.entity.player.dialogue.type.player
+import world.gregs.voidps.engine.Script
+import world.gregs.voidps.engine.entity.character.player.Player
+import world.gregs.voidps.engine.inv.inventory
+import world.gregs.voidps.engine.inv.transact.operation.AddItem.add
+import world.gregs.voidps.engine.inv.transact.operation.RemoveItem.remove
+
+class Oziach : Script {
+
+    private val cost = 1_250_000
+
+    init {
+        npcOperate("Talk-to", "oziach") { (target) ->
+            npc<Happy>("What can I do for ye, mighty dragon slayer?")
+            choice {
+                if (inventory.contains("draconic_visage")) {
+                    option<Quiz>("Can you do anything with this draconic visage?") {
+                        offerShield()
+                    }
+                }
+                option<Quiz>("Can I see your wares?") {
+                    npc<Happy>("Of course.")
+                    openShop(target.def["shop"])
+                }
+                option<Neutral>("Nothing, thanks.")
+            }
+        }
+    }
+
+    private suspend fun Player.offerShield() {
+        npc<Amazed>("Ye've found a draconic visage! Amazin'! Ye can almost feel it pulsin' with draconic power!")
+        npc<Happy>("Now, if ye want me to, I could attach this to yer anti-dragonbreath shield and make something pretty special.")
+        npc<Neutral>("The shield won't be easy to wield though; ye'll need level 75 Defence.")
+        npc<Neutral>("I'll charge 1,250,000 coins to construct it. What d'ye say?")
+        choice {
+            option<Happy>("Yes, please!") {
+                forgeShield()
+            }
+            option<Neutral>("No, thanks.") {
+                npc<Happy>("Talk to me again if ye change yer mind, mighty dragon slayer.")
+            }
+            option<Sad>("That's a bit expensive!") {
+                npc<Neutral>("It's the price ye pay to make such a magnificent shield.")
+            }
+        }
+    }
+
+    private suspend fun Player.forgeShield() {
+        if (!inventory.contains("anti_dragon_shield")) {
+            npc<Neutral>("Ye need an anti-dragonbreath shield for me to attach this onto, talk to me again once ye do.")
+            return
+        }
+        if (!inventory.contains("coins", cost)) {
+            player<Sad>("I don't seem to have enough coins, I will return once I do.")
+            return
+        }
+        val success = inventory.transaction {
+            remove("draconic_visage")
+            remove("anti_dragon_shield")
+            remove("coins", cost)
+            add("dragonfire_shield_uncharged")
+        }
+        if (!success) {
+            return
+        }
+        item("dragonfire_shield_uncharged", "Oziach skilfully forges the shield and visage into a new shield.")
+        npc<Happy>("There ye go. Now, the more dragonfire yer shield absorbs, the more powerful it'll become.")
+    }
+}

--- a/game/src/main/kotlin/content/entity/death/PlayerDeath.kt
+++ b/game/src/main/kotlin/content/entity/death/PlayerDeath.kt
@@ -10,6 +10,7 @@ import content.entity.combat.hit.directHit
 import content.entity.gfx.areaGfx
 import content.entity.player.effect.energy.MAX_RUN_ENERGY
 import content.entity.player.effect.energy.runEnergy
+import content.entity.player.equip.DragonfireShield
 import content.entity.player.inv.item.tradeable
 import content.entity.player.kept.ItemsKeptOnDeath
 import content.entity.proj.shoot
@@ -111,6 +112,9 @@ class PlayerDeath : Script {
                 continue
             }
         }
+
+        // Only the shields being dropped lose their charges, a protected one stays charged
+        DragonfireShield.releaseCharges(player)
 
         // inFullPvp covers wilderness + the Clan Wars FFA dangerous arena: no grave, drops go to the killer.
         val pvpDrop = player.inFullPvp

--- a/game/src/main/kotlin/content/entity/player/combat/CombatExperience.kt
+++ b/game/src/main/kotlin/content/entity/player/combat/CombatExperience.kt
@@ -40,6 +40,10 @@ class CombatExperience : Script {
                     }
                     "defensive" -> grant(this, target, Skill.Defence, damage / 2.5)
                 }
+            } else if (type == "dragonfire") {
+                // Dragonfire from a player is the dragonfire shield's discharge.
+                grant(this, target, Skill.Magic, damage / 7.5)
+                grant(this, target, Skill.Defence, damage / 10.0)
             } else if (type == "range") {
                 if (attackType == "long_range") {
                     grant(this, target, Skill.Ranged, damage / 5.0)

--- a/game/src/main/kotlin/content/entity/player/effect/Dragonfire.kt
+++ b/game/src/main/kotlin/content/entity/player/effect/Dragonfire.kt
@@ -44,10 +44,7 @@ object Dragonfire {
         } else if (source is Player) {
             return SHIELD_MAX_HIT
         } else if (target is Player) {
-            if (Equipment.antiDragonShield(target)) {
-                target.message("Your shield absorbs most of the dragon's fiery breath!", ChatType.Filter)
-            }
-            target.message(if (success) "You're horribly burnt by the dragon fire!" else "You manage to resist some of the dragon fire!", ChatType.Filter)
+            target.message(message(target, success), ChatType.Filter)
         }
         return maxHit(
             type = type,
@@ -60,6 +57,15 @@ object Dragonfire {
                 else -> 0
             },
         )
+    }
+
+    /**
+     * Only whichever protection did the most to soften the breath is reported, they don't stack up.
+     */
+    private fun message(target: Player, success: Boolean): String = when {
+        Equipment.antiDragonShield(target) -> "Your shield absorbs most of the dragon's fiery breath!"
+        !success -> "You manage to resist some of the dragon fire!"
+        else -> "You're horribly burnt by the dragon fire!"
     }
 
     internal fun maxHit(type: String, success: Boolean, shield: Boolean, protection: Boolean = false, potion: Int = 0): Int {

--- a/game/src/main/kotlin/content/entity/player/effect/Dragonfire.kt
+++ b/game/src/main/kotlin/content/entity/player/effect/Dragonfire.kt
@@ -44,7 +44,7 @@ object Dragonfire {
         } else if (source is Player) {
             return SHIELD_MAX_HIT
         } else if (target is Player) {
-            target.message(message(target, success), ChatType.Filter)
+            target.message(message(target), ChatType.Filter)
         }
         return maxHit(
             type = type,
@@ -60,12 +60,18 @@ object Dragonfire {
     }
 
     /**
-     * Only whichever protection did the most to soften the breath is reported, they don't stack up.
+     * Only the strongest protection is reported, they don't stack up into several messages.
      */
-    private fun message(target: Player, success: Boolean): String = when {
-        Equipment.antiDragonShield(target) -> "Your shield absorbs most of the dragon's fiery breath!"
-        !success -> "You manage to resist some of the dragon fire!"
-        else -> "You're horribly burnt by the dragon fire!"
+    private fun message(target: Player): String {
+        val shield = Equipment.antiDragonShield(target)
+        return when {
+            target.superAntifire -> "Your potion heavily protects you from the dragon's fire."
+            shield && target.antifire -> "Your shield and potion fully protect you from the heat of the dragon's breath."
+            shield -> "Your shield manages to block some of the dragon's breath."
+            target.antifire -> "Your potion slightly protects you from the heat of the dragon's breath."
+            target.protectMagic() -> "Your prayers help resist some of the dragonfire!"
+            else -> "You are hit by the dragon's fiery breath."
+        }
     }
 
     internal fun maxHit(type: String, success: Boolean, shield: Boolean, protection: Boolean = false, potion: Int = 0): Int {

--- a/game/src/main/kotlin/content/entity/player/effect/Dragonfire.kt
+++ b/game/src/main/kotlin/content/entity/player/effect/Dragonfire.kt
@@ -7,20 +7,27 @@ import world.gregs.voidps.engine.client.message
 import world.gregs.voidps.engine.entity.character.Character
 import world.gregs.voidps.engine.entity.character.npc.NPC
 import world.gregs.voidps.engine.entity.character.player.Player
+import world.gregs.voidps.engine.entity.character.player.chat.ChatType
 import world.gregs.voidps.engine.timer.toTicks
 import java.util.concurrent.TimeUnit
 
 object Dragonfire {
 
     /**
+     * Maximum hit of the dragonfire shield's discharge.
+     */
+    const val SHIELD_MAX_HIT = 290
+
+    /**
      * Calculate the dragonfire max hit
      * @param success for hitting extra damage if accuracy roll was low or is kbd special dragon breath
      */
     fun maxHit(source: Character, target: Character, success: Boolean): Int {
+        // Player dragonfire always comes from the dragonfire shield, which dragons are immune to.
         if (source is Player && target is NPC && Target.isDragon(target) && !Target.isMetalDragon(target)) {
-            return -1
+            return 0
         }
-        var type = type(source)
+        val type = type(source)
         if (source is Player && target is Player) {
             if (Equipment.antiDragonShield(target)) {
                 return when {
@@ -32,12 +39,15 @@ object Dragonfire {
             return when {
                 target.antifire -> 200
                 target.superAntifire -> 0
-                else -> 250
+                else -> SHIELD_MAX_HIT
             }
         } else if (source is Player) {
-            type = "chromatic"
+            return SHIELD_MAX_HIT
         } else if (target is Player) {
-            target.message(if (success) "You're horribly burnt by the dragon fire!" else "You manage to resist some of the dragon fire!")
+            if (Equipment.antiDragonShield(target)) {
+                target.message("Your shield absorbs most of the dragon's fiery breath!", ChatType.Filter)
+            }
+            target.message(if (success) "You're horribly burnt by the dragon fire!" else "You manage to resist some of the dragon fire!", ChatType.Filter)
         }
         return maxHit(
             type = type,

--- a/game/src/main/kotlin/content/entity/player/equip/DragonfireShield.kt
+++ b/game/src/main/kotlin/content/entity/player/equip/DragonfireShield.kt
@@ -1,0 +1,198 @@
+package content.entity.player.equip
+
+import content.entity.combat.Target
+import content.entity.combat.dead
+import content.entity.combat.hit.hit
+import content.entity.combat.target
+import content.entity.player.dialogue.type.statement
+import content.entity.proj.shoot
+import world.gregs.voidps.engine.Script
+import world.gregs.voidps.engine.client.message
+import world.gregs.voidps.engine.client.ui.ItemOption
+import world.gregs.voidps.engine.client.ui.chat.plural
+import world.gregs.voidps.engine.client.variable.hasClock
+import world.gregs.voidps.engine.client.variable.remaining
+import world.gregs.voidps.engine.client.variable.start
+import world.gregs.voidps.engine.entity.character.areaSound
+import world.gregs.voidps.engine.entity.character.mode.combat.CombatDamage
+import world.gregs.voidps.engine.entity.character.npc.NPC
+import world.gregs.voidps.engine.entity.character.player.Player
+import world.gregs.voidps.engine.entity.character.player.skill.Skill
+import world.gregs.voidps.engine.entity.character.player.skill.exp.exp
+import world.gregs.voidps.engine.entity.character.player.skill.level.Level.has
+import world.gregs.voidps.engine.entity.character.soundGlobal
+import world.gregs.voidps.engine.entity.distanceTo
+import world.gregs.voidps.engine.inv.Inventory
+import world.gregs.voidps.engine.inv.charge
+import world.gregs.voidps.engine.inv.charges
+import world.gregs.voidps.engine.inv.discharge
+import world.gregs.voidps.engine.inv.equipment
+import world.gregs.voidps.engine.inv.inventory
+import world.gregs.voidps.engine.inv.replace
+import world.gregs.voidps.engine.inv.transact.operation.AddItem.add
+import world.gregs.voidps.engine.inv.transact.operation.RemoveItem.remove
+import world.gregs.voidps.engine.timer.toTicks
+import world.gregs.voidps.network.login.protocol.visual.update.player.EquipSlot
+import java.util.concurrent.TimeUnit
+
+/**
+ * The dragonfire shield absorbs the breath attacks it blocks, one charge each, and can spend a
+ * charge to fire that dragonfire back at the current target.
+ */
+class DragonfireShield : Script {
+
+    private val maximumRange = 12
+    private val cooldown = TimeUnit.MINUTES.toTicks(2)
+    private val attackDelay = 3
+    private val smithingLevel = 90
+
+    init {
+        itemOption("Activate", "$CHARGED,$UNCHARGED", "worn_equipment", handler = ::activate)
+        itemOption("Inspect", "$CHARGED,$UNCHARGED", handler = ::inspect)
+        itemOption("Empty", CHARGED, handler = ::empty)
+        combatDamage("dragonfire", handler = ::absorb)
+        combatDamage("icy_breath", handler = ::absorb)
+        itemOnObjectOperate("draconic_visage", "anvil*") { attachVisage() }
+    }
+
+    /**
+     * Absorbs a breath attack into the shield, converting an uncharged shield into a charged one.
+     */
+    private fun absorb(player: Player, damage: CombatDamage) {
+        if (damage.source !is NPC) {
+            return
+        }
+        val index = EquipSlot.Shield.index
+        when (player.equipment[index].id) {
+            UNCHARGED -> player.equipment.replace(index, UNCHARGED, CHARGED)
+            CHARGED -> player.equipment.charge(player, index, 1)
+        }
+    }
+
+    private fun activate(player: Player, option: ItemOption) {
+        if (option.item.id != CHARGED) {
+            player.message("Your shield has no charges left.")
+            return
+        }
+        if (player.hasClock("dragonfire_shield_cooldown")) {
+            player.message("Your dragonfire shield is still recharging.")
+            return
+        }
+        val target = player.target
+        if (target == null || target.dead || !Target.attackable(player, target)) {
+            player.message("You can only unleash the shield's dragonfire during combat.")
+            return
+        }
+        if (player.tile.distanceTo(target) > maximumRange) {
+            player.message("You are too far away from your target.")
+            return
+        }
+        if (!player.equipment.discharge(player, EquipSlot.Shield.index, 1)) {
+            return
+        }
+        player.start("dragonfire_shield_cooldown", cooldown)
+        player.start("action_delay", maxOf(player.remaining("action_delay"), attackDelay))
+        // The animation and the shield's graphic play together, the fire itself is held back by the
+        // projectile's own delay while the shield winds up.
+        player.anim("dragonfire_shield_discharge")
+        player.gfx("dragonfire_shield_discharge_cast")
+        player.soundGlobal("dragonfire_shield_discharge")
+        val flight = player.shoot("dragonfire_shield_discharge", target)
+        val damage = player.hit(target, weapon = option.item, offensiveType = "dragonfire", delay = flight, special = false)
+        if (damage > 0) {
+            target.gfx("dragonfire_shield_discharge_impact", delay = flight)
+            areaSound("fire_strike_impact", target.tile, delay = flight, volume = 20)
+        }
+    }
+
+    private fun inspect(player: Player, option: ItemOption) {
+        val charges = player.inventories.inventory(option.inventory).charges(player, option.slot)
+        if (charges <= 0) {
+            player.message("The shield has no charges.")
+            return
+        }
+        player.message("The shield has $charges ${"charge".plural(charges)}.")
+    }
+
+    private fun empty(player: Player, option: ItemOption) {
+        val inventory = player.inventories.inventory(option.inventory)
+        val charges = inventory.charges(player, option.slot)
+        if (charges <= 0) {
+            player.message("The shield has no charges.")
+            return
+        }
+        if (!inventory.discharge(player, option.slot, charges)) {
+            return
+        }
+        player.anim("dragonfire_shield_empty")
+        player.gfx("dragonfire_shield_empty")
+        player.soundGlobal("dragonfire_shield_empty")
+        player.message("You release the charges.")
+    }
+
+    /**
+     * Smiths a draconic visage onto an anti-dragon shield at an anvil.
+     */
+    private suspend fun Player.attachVisage() {
+        if (!inventory.contains("anti_dragon_shield")) {
+            statement("You need an anti-dragon shield to attach the visage to.")
+            return
+        }
+        if (!has(Skill.Smithing, smithingLevel, message = false)) {
+            statement("You need a Smithing level of $smithingLevel to do this.")
+            return
+        }
+        if (!inventory.contains("hammer")) {
+            statement("You need a hammer to work the metal with.")
+            return
+        }
+        statement(
+            """
+            You set to work, trying to attach the ancient draconic
+            visage to your anti-dragonbreath shield. It's not easy to
+            work with the ancient artifact and it takes all of your
+            skills as a master smith.
+        """,
+        )
+        anim("smith_item")
+        delay(4)
+        val success = inventory.transaction {
+            remove("draconic_visage")
+            remove("anti_dragon_shield")
+            add(UNCHARGED)
+        }
+        if (!success) {
+            return
+        }
+        exp(Skill.Smithing, 2000.0)
+        statement(
+            """
+            Even for an experienced armourer it is not an easy task, but
+            eventually it is ready. You have crafted the draconic visage
+            and anti-dragonbreath shield into a dragonfire shield.
+        """,
+        )
+    }
+
+    companion object {
+        const val CHARGED = "dragonfire_shield_charged"
+        const val UNCHARGED = "dragonfire_shield_uncharged"
+
+        /**
+         * Empties every dragonfire shield about to be lost on death, its charges don't survive the drop.
+         */
+        fun releaseCharges(player: Player) {
+            releaseCharges(player, player.inventory)
+            releaseCharges(player, player.equipment)
+        }
+
+        private fun releaseCharges(player: Player, inventory: Inventory) {
+            for (index in inventory.items.indices) {
+                if (inventory[index].id != CHARGED) {
+                    continue
+                }
+                inventory.discharge(player, index, inventory.charges(player, index))
+            }
+        }
+    }
+}

--- a/game/src/main/kotlin/content/entity/player/equip/Equipment.kt
+++ b/game/src/main/kotlin/content/entity/player/equip/Equipment.kt
@@ -9,12 +9,10 @@ import content.skill.melee.weapon.Weapon
 import content.skill.melee.weapon.combatStyle
 import content.skill.prayer.protectMagic
 import content.skill.summoning.isFamiliar
-import world.gregs.voidps.engine.client.message
 import world.gregs.voidps.engine.data.definition.Areas
 import world.gregs.voidps.engine.entity.character.Character
 import world.gregs.voidps.engine.entity.character.npc.NPC
 import world.gregs.voidps.engine.entity.character.player.Player
-import world.gregs.voidps.engine.entity.character.player.chat.ChatType
 import world.gregs.voidps.engine.entity.character.player.equip.equipped
 import world.gregs.voidps.engine.entity.character.player.skill.Skill
 import world.gregs.voidps.network.login.protocol.visual.update.player.EquipSlot
@@ -39,34 +37,13 @@ object Equipment {
             return baseDamage
         }
         var damage = baseDamage
-        when (source) {
-            is NPC if type == "dragonfire" && source.isFamiliar -> damage = (damage * 0.7).toInt()
-            is Player if type == "icy_breath" && fireResistantShield(source.equipped(EquipSlot.Shield).id) -> damage = 100
-            is Player if type == "dragonfire" -> {
-                val metal = target is NPC && (target.id.contains("bronze") || target.id.contains("iron") || target.id.contains("steel"))
-                var multiplier = 1.0
-
-                val shield = source.equipped(EquipSlot.Shield).id
-                if (shield == "anti_dragon_shield" || shield.startsWith("dragonfire_shield")) {
-                    multiplier -= if (metal) 0.6 else 0.8
-                    source.message("Your shield absorbs most of the dragon's fiery breath!", ChatType.Filter)
-                }
-
-                if (source.antifire || source.superAntifire) {
-                    multiplier -= if (source.superAntifire) 1.0 else 0.5
-                }
-
-                if (multiplier > 0.0) {
-                    val black = target is NPC && target.id.contains("black")
-                    if (!metal && !black && random.nextDouble() <= 0.1) {
-                        multiplier -= 0.1
-                        source.message("You manage to resist some of the dragon fire!", ChatType.Filter)
-                    } else {
-                        source.message("You're horribly burnt by the dragon fire!", ChatType.Filter)
-                    }
-                }
-                damage = (damage * multiplier.coerceAtLeast(0.0)).toInt()
-            }
+        if (source is NPC && type == "dragonfire" && source.isFamiliar) {
+            damage = (damage * 0.7).toInt()
+        }
+        // A fire resistant shield doesn't stop a wyvern's icy breath outright, the rare hit that
+        // gets past it is capped instead.
+        if (type == "icy_breath" && target is Player && fireResistantShield(target.equipped(EquipSlot.Shield).id)) {
+            damage = damage.coerceAtMost(100)
         }
         if (source is Player && target is NPC && target.id.startsWith("tormented_demon") && !target.contains("shield_cooldown")) {
             damage = (damage * 0.25).toInt()
@@ -133,7 +110,7 @@ object Equipment {
 
     fun hasGodArmour(player: Player) = false
 
-    fun fireResistantShield(shield: String) = shield == "elemental_shield" || shield == "mind_shield" || shield == "body_shield" || shield == "dragonfire_shield"
+    fun fireResistantShield(shield: String) = shield == "elemental_shield" || shield == "mind_shield" || shield == "body_shield" || shield.startsWith("dragonfire_shield")
 
     fun wearingMatchingArenaGear(player: Player, spell: String): Boolean = isMatchingArenaSpell(spell, player.equipped(EquipSlot.Cape).id)
     fun isMatchingArenaSpell(spell: String, cape: String): Boolean = isSaradomin(spell, cape) || isGuthix(spell, cape) || isZamorak(spell, cape)

--- a/game/src/main/kotlin/content/entity/player/equip/EquipmentBonuses.kt
+++ b/game/src/main/kotlin/content/entity/player/equip/EquipmentBonuses.kt
@@ -11,6 +11,7 @@ import world.gregs.voidps.engine.data.definition.ItemDefinitions
 import world.gregs.voidps.engine.entity.character.player.Player
 import world.gregs.voidps.engine.entity.character.player.appearance
 import world.gregs.voidps.engine.entity.item.Item
+import world.gregs.voidps.engine.inv.charges
 import world.gregs.voidps.engine.inv.equipment
 import world.gregs.voidps.network.login.protocol.visual.VisualMask.APPEARANCE_MASK
 import java.math.RoundingMode
@@ -21,6 +22,8 @@ class EquipmentBonuses : Script {
     val df = DecimalFormat("0.0").apply {
         roundingMode = RoundingMode.FLOOR
     }
+
+    val chargeDefences = setOf("stab_defence", "slash_defence", "crush_defence", "range_defence", "summoning_defence")
 
     init {
         playerSpawn {
@@ -102,7 +105,7 @@ class EquipmentBonuses : Script {
 
     fun updateStats(player: Player, item: Item, add: Boolean) {
         names.forEach { (name, key) ->
-            val value = item.def[key, 0]
+            val value = item.def[key, 0] + chargeBonus(item, key)
             if (value == 0) {
                 return@forEach
             }
@@ -115,6 +118,16 @@ class EquipmentBonuses : Script {
             player[key] = modified
             sendBonus(player, name, key, modified)
         }
+    }
+
+    /**
+     * Each charge held by a dragonfire shield adds one to its melee, ranged and summoning defences.
+     */
+    fun chargeBonus(item: Item, key: String): Int {
+        if (item.id != "dragonfire_shield_charged" || key !in chargeDefences) {
+            return 0
+        }
+        return item.charges()
     }
 
     fun sendBonus(player: Player, name: String, key: String, value: Int) {

--- a/game/src/test/kotlin/content/area/misthalin/edgeville/OziachTest.kt
+++ b/game/src/test/kotlin/content/area/misthalin/edgeville/OziachTest.kt
@@ -1,0 +1,80 @@
+package content.area.misthalin.edgeville
+
+import WorldTest
+import dialogueContinue
+import dialogueOption
+import npcOption
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import world.gregs.voidps.engine.entity.character.npc.NPC
+import world.gregs.voidps.engine.entity.character.player.Player
+import world.gregs.voidps.engine.inv.add
+import world.gregs.voidps.engine.inv.inventory
+import world.gregs.voidps.type.Tile
+
+class OziachTest : WorldTest() {
+
+    private val cost = 1_250_000
+
+    @Test
+    fun `Oziach forges a visage and shield into a dragonfire shield`() {
+        val (player, oziach) = setup("oziach_forge")
+        player.inventory.add("draconic_visage", "anti_dragon_shield")
+        player.inventory.add("coins", cost)
+
+        player.forge(oziach)
+
+        assertTrue(player.inventory.contains("dragonfire_shield_uncharged"))
+        assertEquals(0, player.inventory.count("draconic_visage"))
+        assertEquals(0, player.inventory.count("anti_dragon_shield"))
+        assertEquals(0, player.inventory.count("coins"))
+    }
+
+    @Test
+    fun `Oziach won't forge a shield without the coins`() {
+        val (player, oziach) = setup("oziach_poor")
+        player.inventory.add("draconic_visage", "anti_dragon_shield")
+        player.inventory.add("coins", cost - 1)
+
+        player.forge(oziach)
+
+        assertEquals(0, player.inventory.count("dragonfire_shield_uncharged"))
+        assertEquals(1, player.inventory.count("draconic_visage"))
+        assertEquals(cost - 1, player.inventory.count("coins"))
+    }
+
+    @Test
+    fun `Oziach won't forge a shield without an anti-dragon shield`() {
+        val (player, oziach) = setup("oziach_shieldless")
+        player.inventory.add("draconic_visage")
+        player.inventory.add("coins", cost)
+
+        player.forge(oziach)
+
+        assertEquals(0, player.inventory.count("dragonfire_shield_uncharged"))
+        assertEquals(cost, player.inventory.count("coins"))
+    }
+
+    private fun setup(name: String): Pair<Player, NPC> {
+        val player = createPlayer(emptyTile, name)
+        val oziach = createNPC("oziach", emptyTile.addX(1))
+        tick()
+        return player to oziach
+    }
+
+    private fun Player.forge(oziach: NPC) {
+        npcOption(oziach, "Talk-to")
+        tick(2)
+        dialogueContinue() // "What can I do for ye, mighty dragon slayer?"
+        dialogueOption(1) // "Can you do anything with this draconic visage?"
+        dialogueContinue(5) // repeated player line + Oziach's offer
+        dialogueOption(1) // "Yes, please!"
+        dialogueContinue(2)
+        tick()
+    }
+
+    private companion object {
+        private val emptyTile = Tile(3200, 3200)
+    }
+}

--- a/game/src/test/kotlin/content/entity/player/equip/DragonfireShieldTest.kt
+++ b/game/src/test/kotlin/content/entity/player/equip/DragonfireShieldTest.kt
@@ -204,7 +204,7 @@ class DragonfireShieldTest : WorldTest() {
 
         assertEquals(health, rat.levels.get(Skill.Constitution), "the shield is still winding up")
 
-        tick(3)
+        tick(2)
 
         assertEquals(health, rat.levels.get(Skill.Constitution), "the shield is still winding up")
 

--- a/game/src/test/kotlin/content/entity/player/equip/DragonfireShieldTest.kt
+++ b/game/src/test/kotlin/content/entity/player/equip/DragonfireShieldTest.kt
@@ -1,0 +1,243 @@
+package content.entity.player.equip
+
+import FakeRandom
+import WorldTest
+import containsMessage
+import content.entity.combat.hit.directHit
+import content.entity.combat.target
+import content.entity.player.effect.Dragonfire
+import content.entity.player.effect.skullCounter
+import dialogueContinue
+import interfaceOption
+import itemOnObject
+import itemOption
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import world.gregs.voidps.engine.client.variable.hasClock
+import world.gregs.voidps.engine.entity.character.npc.NPC
+import world.gregs.voidps.engine.entity.character.player.Player
+import world.gregs.voidps.engine.entity.character.player.skill.Skill
+import world.gregs.voidps.engine.entity.item.floor.FloorItems
+import world.gregs.voidps.engine.inv.add
+import world.gregs.voidps.engine.inv.charges
+import world.gregs.voidps.engine.inv.equipment
+import world.gregs.voidps.engine.inv.inventory
+import world.gregs.voidps.network.login.protocol.visual.update.player.EquipSlot
+import world.gregs.voidps.type.Tile
+import world.gregs.voidps.type.setRandom
+
+class DragonfireShieldTest : WorldTest() {
+
+    private val charged = "dragonfire_shield_charged"
+    private val uncharged = "dragonfire_shield_uncharged"
+    private val shield = EquipSlot.Shield.index
+
+    @Test
+    fun `Absorbing dragonfire charges an uncharged shield`() {
+        val player = createPlayer(emptyTile)
+        val dragon = spawn("green_dragon", emptyTile.addY(2))
+        player.equipment.set(shield, uncharged)
+
+        player.directHit(dragon, 100, "dragonfire")
+
+        assertEquals(charged, player.equipment[shield].id)
+        assertEquals(1, player.equipment.charges(player, shield))
+    }
+
+    @Test
+    fun `Absorbing more dragonfire adds charges up to the maximum`() {
+        val player = createPlayer(emptyTile)
+        val dragon = spawn("green_dragon", emptyTile.addY(2))
+        player.equipment.set(shield, charged, 49)
+
+        player.directHit(dragon, 100, "dragonfire")
+        assertEquals(50, player.equipment.charges(player, shield))
+
+        player.directHit(dragon, 100, "dragonfire")
+        assertEquals(50, player.equipment.charges(player, shield))
+    }
+
+    @Test
+    fun `Charges add to the shields defensive bonuses`() {
+        val player = createPlayer(emptyTile)
+        val dragon = spawn("green_dragon", emptyTile.addY(2))
+        player.equipment.set(shield, uncharged)
+        val defence = player["stab_defence", 0]
+
+        player.directHit(dragon, 100, "dragonfire")
+
+        assertEquals(defence + 1, player["stab_defence", 0])
+        assertEquals(1, player.equipment.charges(player, shield))
+    }
+
+    @Test
+    fun `Emptying a shield releases every charge`() {
+        val player = createPlayer()
+        player.inventory.set(0, charged, 20)
+
+        player.itemOption("Empty", charged, slot = 0)
+
+        assertEquals(uncharged, player.inventory[0].id)
+    }
+
+    @Test
+    fun `Discharging spends a charge and rolls the shields maximum hit`() {
+        val player = createPlayer(emptyTile)
+        val rat = spawn("giant_rat", emptyTile.addY(1))
+        player.equipment.set(shield, charged, 20)
+        player.target = rat
+
+        player.activate()
+
+        assertEquals(19, player.equipment.charges(player, shield))
+        assertEquals(290, player["max_hit", 0])
+        assertTrue(player.hasClock("dragonfire_shield_cooldown"))
+    }
+
+    @Test
+    fun `Dragons are immune to the shields dragonfire`() {
+        val player = createPlayer(emptyTile)
+        val dragon = spawn("green_dragon", emptyTile.addY(2))
+        player.equipment.set(shield, charged, 20)
+        player.target = dragon
+        player["max_hit"] = 99
+
+        player.activate()
+
+        assertEquals(19, player.equipment.charges(player, shield))
+        assertEquals(0, player["max_hit", 0])
+    }
+
+    @Test
+    fun `Discharging twice is blocked by the cooldown`() {
+        val player = createPlayer(emptyTile)
+        val rat = spawn("giant_rat", emptyTile.addY(1))
+        player.equipment.set(shield, charged, 20)
+        player.target = rat
+
+        player.activate()
+        player.activate()
+
+        assertEquals(19, player.equipment.charges(player, shield))
+    }
+
+    @Test
+    fun `An uncharged shield can't be discharged`() {
+        val player = createPlayer(emptyTile)
+        val rat = spawn("giant_rat", emptyTile.addY(1))
+        player.equipment.set(shield, uncharged)
+        player.target = rat
+
+        player.activate()
+
+        assertFalse(player.hasClock("dragonfire_shield_cooldown"))
+    }
+
+    @Test
+    fun `Attaching a draconic visage to an anti-dragon shield creates an uncharged shield`() {
+        val player = createPlayer(emptyTile)
+        val anvil = createObject("anvil", emptyTile.addY(1))
+        player.levels.set(Skill.Smithing, 90)
+        player.inventory.add("draconic_visage", "anti_dragon_shield", "hammer")
+        val experience = player.experience.get(Skill.Smithing)
+
+        player.itemOnObject(anvil, player.inventory.indexOf("draconic_visage"))
+        tick(2)
+        player.dialogueContinue()
+        tick(6)
+        player.dialogueContinue()
+
+        assertTrue(player.inventory.contains(uncharged))
+        assertFalse(player.inventory.contains("draconic_visage"))
+        assertFalse(player.inventory.contains("anti_dragon_shield"))
+        assertEquals(experience + 2000.0, player.experience.get(Skill.Smithing))
+    }
+
+    @Test
+    fun `Attaching a visage requires ninety smithing`() {
+        val player = createPlayer(emptyTile)
+        val anvil = createObject("anvil", emptyTile.addY(1))
+        player.levels.set(Skill.Smithing, 89)
+        player.inventory.add("draconic_visage", "anti_dragon_shield", "hammer")
+
+        player.itemOnObject(anvil, player.inventory.indexOf("draconic_visage"))
+        tick(2)
+
+        assertFalse(player.inventory.contains(uncharged))
+        assertTrue(player.inventory.contains("draconic_visage"))
+        assertTrue(player.inventory.contains("anti_dragon_shield"))
+    }
+
+    @Test
+    fun `A dropped shield loses its charges on death`() {
+        val player = createPlayer(emptyTile)
+        player.equipment.set(shield, charged, 20)
+        player.skullCounter = 20
+
+        player.levels.set(Skill.Constitution, 0)
+        tick(10)
+
+        assertTrue(FloorItems.at(emptyTile).any { it.id == uncharged })
+        assertTrue(FloorItems.at(emptyTile).none { it.id == charged })
+    }
+
+    @Test
+    fun `The discharge fires after the shield winds up`() {
+        setRandom(object : FakeRandom() {
+            override fun nextInt(from: Int, until: Int) = until - 1
+        })
+        val player = createPlayer(emptyTile)
+        val rat = spawn("giant_rat", emptyTile.addY(4))
+        player.equipment.set(shield, charged, 20)
+        player.target = rat
+        val health = rat.levels.get(Skill.Constitution)
+
+        player.interfaceOption("worn_equipment", "shield_slot", "*", optionIndex = 1, item = player.equipment[shield])
+        tick(1)
+
+        assertEquals(health, rat.levels.get(Skill.Constitution), "the shield is still winding up")
+
+        tick(2)
+
+        assertTrue(rat.levels.get(Skill.Constitution) < health, "the fire lands once the wind up finishes")
+    }
+
+    @Test
+    fun `A shield absorbing dragonfire tells the player`() {
+        val player = createPlayer(emptyTile)
+        val dragon = spawn("green_dragon", emptyTile.addY(2))
+        player.equipment.set(shield, charged, 20)
+
+        Dragonfire.maxHit(dragon, player, success = true)
+
+        assertTrue(player.containsMessage("Your shield absorbs most of the dragon's fiery breath!"))
+    }
+
+    @Test
+    fun `An unshielded player isn't told about absorbing dragonfire`() {
+        val player = createPlayer(emptyTile)
+        val dragon = spawn("green_dragon", emptyTile.addY(2))
+
+        Dragonfire.maxHit(dragon, player, success = true)
+
+        assertFalse(player.containsMessage("Your shield absorbs"))
+        assertTrue(player.containsMessage("You're horribly burnt by the dragon fire!"))
+    }
+
+    private fun spawn(id: String, tile: Tile): NPC {
+        val npc = createNPC(id, tile)
+        tick()
+        return npc
+    }
+
+    private fun Player.activate() {
+        interfaceOption("worn_equipment", "shield_slot", "*", optionIndex = 1, item = equipment[shield])
+        tick(2)
+    }
+
+    private companion object {
+        private val emptyTile = Tile(3200, 3200)
+    }
+}

--- a/game/src/test/kotlin/content/entity/player/equip/DragonfireShieldTest.kt
+++ b/game/src/test/kotlin/content/entity/player/equip/DragonfireShieldTest.kt
@@ -204,7 +204,11 @@ class DragonfireShieldTest : WorldTest() {
 
         assertEquals(health, rat.levels.get(Skill.Constitution), "the shield is still winding up")
 
-        tick(2)
+        tick(3)
+
+        assertEquals(health, rat.levels.get(Skill.Constitution), "the shield is still winding up")
+
+        tick(1)
 
         assertTrue(rat.levels.get(Skill.Constitution) < health, "the fire lands once the wind up finishes")
     }

--- a/game/src/test/kotlin/content/entity/player/equip/DragonfireShieldTest.kt
+++ b/game/src/test/kotlin/content/entity/player/equip/DragonfireShieldTest.kt
@@ -213,6 +213,7 @@ class DragonfireShieldTest : WorldTest() {
         Dragonfire.maxHit(dragon, player, success = true)
 
         assertTrue(player.containsMessage("Your shield absorbs most of the dragon's fiery breath!"))
+        assertFalse(player.containsMessage("horribly burnt"), "only the shield message is sent")
     }
 
     @Test

--- a/game/src/test/kotlin/content/entity/player/equip/DragonfireShieldTest.kt
+++ b/game/src/test/kotlin/content/entity/player/equip/DragonfireShieldTest.kt
@@ -2,19 +2,24 @@ package content.entity.player.equip
 
 import FakeRandom
 import WorldTest
-import containsMessage
 import content.entity.combat.hit.directHit
 import content.entity.combat.target
 import content.entity.player.effect.Dragonfire
+import content.entity.player.effect.antifire
 import content.entity.player.effect.skullCounter
+import content.entity.player.effect.superAntifire
+import content.skill.prayer.getActivePrayerVarKey
 import dialogueContinue
 import interfaceOption
 import itemOnObject
 import itemOption
+import messages
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.DynamicTest
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestFactory
 import world.gregs.voidps.engine.client.variable.hasClock
 import world.gregs.voidps.engine.entity.character.npc.NPC
 import world.gregs.voidps.engine.entity.character.player.Player
@@ -204,27 +209,36 @@ class DragonfireShieldTest : WorldTest() {
         assertTrue(rat.levels.get(Skill.Constitution) < health, "the fire lands once the wind up finishes")
     }
 
-    @Test
-    fun `A shield absorbing dragonfire tells the player`() {
-        val player = createPlayer(emptyTile)
-        val dragon = spawn("green_dragon", emptyTile.addY(2))
-        player.equipment.set(shield, charged, 20)
+    @TestFactory
+    fun `Only the strongest dragonfire protection is reported`() = listOf(
+        "Your potion heavily protects you from the dragon's fire." to { player: Player ->
+            player.superAntifire(1)
+            player.equipment.set(shield, charged, 20)
+        },
+        "Your shield and potion fully protect you from the heat of the dragon's breath." to { player: Player ->
+            player.antifire(1)
+            player.equipment.set(shield, charged, 20)
+        },
+        "Your shield manages to block some of the dragon's breath." to { player: Player ->
+            player.equipment.set(shield, charged, 20)
+        },
+        "Your potion slightly protects you from the heat of the dragon's breath." to { player: Player ->
+            player.antifire(1)
+        },
+        "Your prayers help resist some of the dragonfire!" to { player: Player ->
+            player.addVarbit(player.getActivePrayerVarKey(), "protect_from_magic")
+        },
+        "You are hit by the dragon's fiery breath." to { _: Player -> },
+    ).map { (expected, setup) ->
+        DynamicTest.dynamicTest(expected) {
+            val player = createPlayer(emptyTile)
+            val dragon = spawn("green_dragon", emptyTile.addY(2))
+            setup(player)
 
-        Dragonfire.maxHit(dragon, player, success = true)
+            Dragonfire.maxHit(dragon, player, success = true)
 
-        assertTrue(player.containsMessage("Your shield absorbs most of the dragon's fiery breath!"))
-        assertFalse(player.containsMessage("horribly burnt"), "only the shield message is sent")
-    }
-
-    @Test
-    fun `An unshielded player isn't told about absorbing dragonfire`() {
-        val player = createPlayer(emptyTile)
-        val dragon = spawn("green_dragon", emptyTile.addY(2))
-
-        Dragonfire.maxHit(dragon, player, success = true)
-
-        assertFalse(player.containsMessage("Your shield absorbs"))
-        assertTrue(player.containsMessage("You're horribly burnt by the dragon fire!"))
+            assertEquals(listOf(expected), player.messages.filter { it in messages }, "exactly one message is sent")
+        }
     }
 
     private fun spawn(id: String, tile: Tile): NPC {
@@ -240,5 +254,14 @@ class DragonfireShieldTest : WorldTest() {
 
     private companion object {
         private val emptyTile = Tile(3200, 3200)
+
+        private val messages = setOf(
+            "Your potion heavily protects you from the dragon's fire.",
+            "Your shield and potion fully protect you from the heat of the dragon's breath.",
+            "Your shield manages to block some of the dragon's breath.",
+            "Your potion slightly protects you from the heat of the dragon's breath.",
+            "Your prayers help resist some of the dragonfire!",
+            "You are hit by the dragon's fiery breath.",
+        )
     }
 }

--- a/game/src/test/kotlin/content/entity/player/equip/IcyBreathTest.kt
+++ b/game/src/test/kotlin/content/entity/player/equip/IcyBreathTest.kt
@@ -1,0 +1,61 @@
+package content.entity.player.equip
+
+import WorldTest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import world.gregs.voidps.engine.inv.equipment
+import world.gregs.voidps.network.login.protocol.visual.update.player.EquipSlot
+import world.gregs.voidps.type.Tile
+
+class IcyBreathTest : WorldTest() {
+
+    private val shield = EquipSlot.Shield.index
+
+    @Test
+    fun `A fire resistant shield caps a wyvern's icy breath`() {
+        val player = createPlayer(emptyTile)
+        val wyvern = createNPC("skeletal_wyvern", emptyTile.addY(4))
+        player.equipment.set(shield, "elemental_shield")
+
+        val damage = Equipment.shieldDamageReductionModifiers(wyvern, player, "icy_breath", 500)
+
+        assertEquals(100, damage)
+    }
+
+    @Test
+    fun `A charged dragonfire shield caps a wyvern's icy breath`() {
+        val player = createPlayer(emptyTile)
+        val wyvern = createNPC("skeletal_wyvern", emptyTile.addY(4))
+        player.equipment.set(shield, "dragonfire_shield_charged", 20)
+
+        val damage = Equipment.shieldDamageReductionModifiers(wyvern, player, "icy_breath", 500)
+
+        assertEquals(100, damage)
+    }
+
+    @Test
+    fun `A capped hit is never raised to the cap`() {
+        val player = createPlayer(emptyTile)
+        val wyvern = createNPC("skeletal_wyvern", emptyTile.addY(4))
+        player.equipment.set(shield, "mind_shield")
+
+        val damage = Equipment.shieldDamageReductionModifiers(wyvern, player, "icy_breath", 40)
+
+        assertEquals(40, damage)
+    }
+
+    @Test
+    fun `Icy breath is unreduced without a fire resistant shield`() {
+        val player = createPlayer(emptyTile)
+        val wyvern = createNPC("skeletal_wyvern", emptyTile.addY(4))
+        player.equipment.set(shield, "rune_kiteshield")
+
+        val damage = Equipment.shieldDamageReductionModifiers(wyvern, player, "icy_breath", 500)
+
+        assertEquals(500, damage)
+    }
+
+    private companion object {
+        private val emptyTile = Tile(3200, 3200)
+    }
+}

--- a/game/src/test/kotlin/content/skill/summoning/EnchantedHeadgearTest.kt
+++ b/game/src/test/kotlin/content/skill/summoning/EnchantedHeadgearTest.kt
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.Test
 import world.gregs.voidps.engine.data.definition.NPCDefinitions
 import world.gregs.voidps.engine.entity.character.player.Player
 import world.gregs.voidps.engine.entity.character.player.skill.Skill
+import world.gregs.voidps.engine.inv.charges
 import world.gregs.voidps.engine.inv.equipment
 import world.gregs.voidps.engine.inv.inventory
 import world.gregs.voidps.engine.inv.remove
@@ -107,7 +108,7 @@ class EnchantedHeadgearTest : WorldTest() {
         tick(1)
 
         val slot = player.inventory.indexOf("antlers_charged")
-        assertEquals(12, player.inventory[slot].amount, "the helm's charge shows the scroll count")
+        assertEquals(12, player.inventory.charges(player, slot), "the helm's charge shows the scroll count")
     }
 
     @Test


### PR DESCRIPTION
Implements the dragonfire shield, which had item definitions but no behaviour.

Referenced against the [2011 wiki revision](https://runescape.wiki/w/Dragonfire_shield?oldid=4845107)

## Shield

- **Charging** - every dragonfire and skeletal wyvern icy breath the shield absorbs adds a charge, up to 50. An uncharged shield becomes charged on the first one. Each charge adds one to its melee, ranged and summoning defences.
- **Activate** - the worn option spends a charge to breathe dragonfire back at the current target for up to 290, on a two minute cooldown, at up to twelve squares and over obstacles, granting Magic, Defence and Constitution experience. Dragons are immune.
- **Inspect** reports the charge count, **Empty** releases the lot and reverts to the tradeable uncharged shield.
- Charges are lost with the shield on death, worked out after items kept on death so a protected shield stays charged.

## Creation

- Smith a draconic visage onto an anti-dragon shield at an anvil, needing 90 Smithing and a hammer, for 2000 Smithing experience.
- Or pay Oziach 1,250,000 coins to forge it. He had no dialogue at all before this, only the shop his definition points at.

Both produce the uncharged shield.

## Supporting fixes

Each of these was reached, or made reachable, by the shield.

- **`Item.amount` counted charges as a quantity.** The guard only recognised item-value charges when the definition's *starting* charge count was above one, which it never is for something that starts empty. A twenty charge shield therefore looked like twenty items: items kept on death protected three of them and the rest dropped as a stack. Capacity now decides, which also covers satchels, tea flasks and enchanted headgear.
- **Dragonfire reduction in `Equipment` read the wrong entity.** It sat in a `when (source)` and used the attacker's shield and antifire, messaging the attacker. Unreachable while only npcs breathed dragonfire, but firing the shield woke it up and cut the wielder's own damage by 80% while telling them their shield had absorbed it. `Dragonfire.maxHit` already applies the victim's shield, potion and prayer, so the duplicate is gone and its shield message moved there, where it reaches the victim.
- **Fire resistant shields did nothing against icy breath**, from the same wrong-entity bug, and `fireResistantShield` compared against `dragonfire_shield`, an alias rather than an equipped id. The cap also *replaced* the damage rather than limiting it, so a small hit was raised to it. `SkeletalWyvern` now shares the one shield check instead of keeping its own copy.
- **Player dragonfire granted Constitution experience alone**, now Magic and Defence too.
- **`Dragonfire.maxHit` returned `-1` for an immune dragon**, which would have thrown out of `random.nextInt(0, 0)` in `Damage.roll` as soon as a player could deal dragonfire.

## Data

Shield definitions moved out of `ancient_cavern.*` into `data/entity/player/equipment/dragonfire_shield.*`, since it is not ancient cavern content.

## Testing

20 tests across `DragonfireShieldTest`, `OziachTest` and `IcyBreathTest` covering charging and the cap, the defence bonus, activate with its cooldown, range and dragon immunity, inspect and empty, death conversion, both creation routes and their requirements, and the icy breath cap. Full suite green.

One test changed: `EnchantedHeadgearTest` asserted a helm's stored scroll count through `Item.amount`, now read through `charges()`.
