### PR TITLE
Pestle and mortar recipes and Herblore recipe fixes

### DIFF
--- a/data/skill/herblore/barbarian_mix.recipes.toml
+++ b/data/skill/herblore/barbarian_mix.recipes.toml
@@ -20,8 +20,8 @@ message = "You mix the caviar into your antifire potion."
 
 [antipoison_mix_r]
 skill = "herblore"
-level = 15
-xp = 1.2
+level = 6
+xp = 12.0
 ticks = 2
 remove = ["antipoison_2", "roe"]
 add = ["antipoison_mix_2"]
@@ -30,8 +30,8 @@ message = "You mix the roe into your antipoison potion."
 
 [antipoison_mix_c]
 skill = "herblore"
-level = 15
-xp = 1.2
+level = 6
+xp = 12.0
 ticks = 2
 remove = ["antipoison_2", "caviar"]
 add = ["antipoison_mix_2"]
@@ -44,7 +44,7 @@ level = 74
 xp = 52.0
 ticks = 2
 remove = ["antipoison+_2", "caviar"]
-add = ["super_antipoison_mix_2"]
+add = ["antidote+_mix_2"]
 animation = "mixing_potion"
 message = "You mix the caviar into your antipoison+ potion."
 
@@ -80,7 +80,7 @@ message = "You mix the caviar into your combat potion."
 
 [defence_mix]
 skill = "herblore"
-level = 11
+level = 33
 xp = 25.0
 ticks = 2
 remove = ["defence_potion_2", "caviar"]
@@ -118,26 +118,6 @@ add = ["hunting_mix_2"]
 animation = "mixing_potion"
 message = "You mix the caviar into your hunting potion."
 
-[magic_mix_r]
-skill = "herblore"
-level = 7
-xp = 8.0
-ticks = 2
-remove = ["super_magic_potion_2", "roe"]
-add = ["super_magic_mix_2"]
-animation = "mixing_potion"
-message = "You mix the roe into your magic potion."
-
-[magic_mix_c]
-skill = "herblore"
-level = 7
-xp = 8.0
-ticks = 2
-remove = ["super_magic_potion_2", "caviar"]
-add = ["super_magic_mix_2"]
-animation = "mixing_potion"
-message = "You mix the caviar into your magic potion."
-
 [magic_essence_mix]
 skill = "herblore"
 level = 61
@@ -147,26 +127,6 @@ remove = ["magic_essence_2", "caviar"]
 add = ["magic_essence_mix_2"]
 animation = "mixing_potion"
 message = "You mix the caviar into your magic essence potion."
-
-[ranging_mix_c]
-skill = "herblore"
-level = 5
-xp = 8.0
-ticks = 2
-remove = ["super_ranging_potion_2", "caviar"]
-add = ["super_ranging_mix_2"]
-animation = "mixing_potion"
-message = "You mix the caviar into your ranging potion."
-
-[ranging_mix_r]
-skill = "herblore"
-level = 5
-xp = 8.0
-ticks = 2
-remove = ["super_ranging_potion_2", "roe"]
-add = ["super_ranging_mix_2"]
-animation = "mixing_potion"
-message = "You mix the roe into your ranging potion."
 
 [relicyms_mix_r]
 skill = "herblore"
@@ -210,7 +170,7 @@ message = "You mix the caviar into your restore potion."
 
 [strength_mix_r]
 skill = "herblore"
-level = 9
+level = 14
 xp = 17.0
 ticks = 2
 remove = ["strength_potion_2", "roe"]
@@ -220,7 +180,7 @@ message = "You mix the roe into your strength potion."
 
 [strength_mix_c]
 skill = "herblore"
-level = 9
+level = 14
 xp = 17.0
 ticks = 2
 remove = ["strength_potion_2", "caviar"]

--- a/data/skill/herblore/barbarian_mix_decant.recipes.toml
+++ b/data/skill/herblore/barbarian_mix_decant.recipes.toml
@@ -215,14 +215,14 @@ ticks = 1
 message = "You split the potion between the two vials."
 
 ["antipoison+_mix_combine"]
-remove = ["super_antipoison_mix_1", "super_antipoison_mix_1"]
-add = ["super_antipoison_mix_2", "vial"]
+remove = ["antidote+_mix_1", "antidote+_mix_1"]
+add = ["antidote+_mix_2", "vial"]
 ticks = 1
 message = "You pour from one container into the other."
 
 ["antipoison+_mix_split"]
-remove = ["super_antipoison_mix_2", "vial"]
-add = ["super_antipoison_mix_1", "super_antipoison_mix_1"]
+remove = ["antidote+_mix_2", "vial"]
+add = ["antidote+_mix_1", "antidote+_mix_1"]
 ticks = 1
 message = "You split the potion between the two vials."
 

--- a/data/skill/herblore/crushing.recipes.toml
+++ b/data/skill/herblore/crushing.recipes.toml
@@ -78,3 +78,163 @@ remove = ["mud_rune"]
 add = ["ground_mud_runes"]
 animation = "pestle_and_mortar"
 message = "You grind the mud runes into a powder."
+
+[gorak_claw_powder]
+ticks = 1
+requires = ["pestle_and_mortar"]
+remove = ["gorak_claws"]
+add = ["gorak_claw_powder"]
+animation = "pestle_and_mortar"
+message = "You crush the gorak claws."
+
+[goat_horn_dust]
+ticks = 1
+requires = ["pestle_and_mortar"]
+remove = ["desert_goat_horn"]
+add = ["goat_horn_dust"]
+animation = "pestle_and_mortar"
+message = "You crush the goat horn."
+
+[ground_ashes]
+ticks = 1
+requires = ["pestle_and_mortar"]
+remove = ["ashes"]
+add = ["ground_ashes"]
+animation = "pestle_and_mortar"
+message = "You grind the ashes into a fine powder."
+
+[ground_fishing_bait]
+ticks = 1
+requires = ["pestle_and_mortar"]
+remove = ["fishing_bait"]
+add = ["ground_fishing_bait"]
+animation = "pestle_and_mortar"
+message = "You grind the fishing bait."
+
+[ground_seaweed]
+ticks = 1
+requires = ["pestle_and_mortar"]
+remove = ["seaweed"]
+add = ["ground_seaweed"]
+animation = "pestle_and_mortar"
+message = "You grind the seaweed."
+
+[karambwan_paste_raw]
+ticks = 1
+requires = ["pestle_and_mortar"]
+remove = ["raw_karambwan"]
+add = ["karambwan_paste_raw"]
+animation = "pestle_and_mortar"
+message = "You grind the karambwan into a paste."
+
+[karambwan_paste_cooked]
+ticks = 1
+requires = ["pestle_and_mortar"]
+remove = ["cooked_karambwan"]
+add = ["karambwan_paste_cooked"]
+animation = "pestle_and_mortar"
+message = "You grind the karambwan into a paste."
+
+[karambwan_paste_poison]
+ticks = 1
+requires = ["pestle_and_mortar"]
+remove = ["poison_karambwan"]
+add = ["karambwan_paste_poison"]
+animation = "pestle_and_mortar"
+message = "You grind the karambwan into a paste."
+
+[ground_bat_bones]
+ticks = 1
+requires = ["pestle_and_mortar"]
+remove = ["bat_bones"]
+add = ["ground_bat_bones"]
+animation = "pestle_and_mortar"
+message = "You grind the bat bones to dust."
+
+[ground_charcoal]
+ticks = 1
+requires = ["pestle_and_mortar"]
+remove = ["charcoal"]
+add = ["ground_charcoal"]
+animation = "pestle_and_mortar"
+message = "You grind the charcoal."
+
+[ground_cod]
+ticks = 1
+requires = ["pestle_and_mortar"]
+remove = ["cod"]
+add = ["ground_cod"]
+animation = "pestle_and_mortar"
+message = "You grind the cod."
+
+[ground_kelp]
+ticks = 1
+requires = ["pestle_and_mortar"]
+remove = ["kelp_mogre_camp"]
+add = ["ground_kelp"]
+animation = "pestle_and_mortar"
+message = "You grind the kelp."
+
+[ground_crab_meat]
+ticks = 1
+requires = ["pestle_and_mortar"]
+remove = ["crab_meat"]
+add = ["ground_crab_meat"]
+animation = "pestle_and_mortar"
+message = "You grind the crab meat."
+
+[rune_dust]
+ticks = 1
+requires = ["pestle_and_mortar"]
+remove = ["rune_shards"]
+add = ["rune_dust"]
+animation = "pestle_and_mortar"
+message = "You grind the rune shards to dust."
+
+[ground_astral_rune]
+ticks = 1
+requires = ["pestle_and_mortar"]
+remove = ["astral_rune_shards"]
+add = ["ground_astral_rune"]
+animation = "pestle_and_mortar"
+message = "You grind the astral rune shards to dust."
+
+[ground_tooth]
+ticks = 1
+requires = ["pestle_and_mortar"]
+remove = ["suqah_tooth"]
+add = ["ground_tooth"]
+animation = "pestle_and_mortar"
+message = "You grind the suqah tooth."
+
+[diamond_root_dust]
+ticks = 1
+requires = ["pestle_and_mortar"]
+remove = ["diamond_root"]
+add = ["diamond_root_dust"]
+animation = "pestle_and_mortar"
+message = "You grind the diamond root."
+
+[ground_thistle]
+ticks = 1
+requires = ["pestle_and_mortar"]
+remove = ["dried_thistle"]
+add = ["ground_thistle"]
+animation = "pestle_and_mortar"
+message = "You grind the thistle."
+
+[garlic_powder]
+ticks = 1
+requires = ["pestle_and_mortar"]
+remove = ["garlic"]
+add = ["garlic_powder"]
+animation = "pestle_and_mortar"
+message = "You grind the garlic into a powder."
+
+[black_mushroom_ink]
+ticks = 1
+requires = ["pestle_and_mortar"]
+remove = ["black_mushroom"]
+add = ["black_mushroom_ink"]
+animation = "pestle_and_mortar"
+message = "You grind the mushroom into ink."

--- a/data/skill/herblore/crushing.recipes.toml
+++ b/data/skill/herblore/crushing.recipes.toml
@@ -1,7 +1,7 @@
 [unicorn_dust]
 skill = "herblore"
 level = 1
-xp = 1.0
+xp = 0.0
 ticks = 1
 requires = ["pestle_and_mortar"]
 remove = ["unicorn_horn"]
@@ -12,7 +12,7 @@ message = "You crush the unicorn horn."
 [silver_dust]
 skill = "herblore"
 level = 1
-xp = 1.0
+xp = 0.0
 ticks = 1
 requires = ["pestle_and_mortar"]
 remove = ["silver_bar"]
@@ -23,7 +23,7 @@ message = "You crush the silver bar."
 [kebbit_teeth_dust]
 skill = "herblore"
 level = 1
-xp = 1.0
+xp = 0.0
 ticks = 1
 requires = ["pestle_and_mortar"]
 remove = ["kebbit_teeth"]
@@ -34,7 +34,7 @@ message = "You crush the kebbit teeth."
 [dragon_scale_dust]
 skill = "herblore"
 level = 1
-xp = 1.0
+xp = 0.0
 ticks = 1
 requires = ["pestle_and_mortar"]
 remove = ["blue_dragon_scale"]
@@ -45,7 +45,7 @@ message = "You crush the blue dragon scales."
 [crushed_nest]
 skill = "herblore"
 level = 1
-xp = 1.0
+xp = 0.0
 ticks = 1
 requires = ["pestle_and_mortar"]
 remove = ["birds_nest_empty"]
@@ -56,7 +56,7 @@ message = "You crush the birds nest."
 [crushed_gem]
 skill = "herblore"
 level = 1
-xp = 1.0
+xp = 0.0
 ticks = 1
 requires = ["pestle_and_mortar"]
 remove = ["uncut_opal"]

--- a/data/skill/herblore/juju_potion_unfinished.recipes.toml
+++ b/data/skill/herblore/juju_potion_unfinished.recipes.toml
@@ -1,7 +1,7 @@
 [erzilla_potion_unf]
 skill = "herblore"
 level = 54
-xp = 1.0
+xp = 0.0
 ticks = 2
 remove = ["juju_vial_of_water", "clean_erzille"]
 add = ["erzille_potion_unf"]
@@ -11,7 +11,7 @@ message = "You mix the erzille into your vial of water."
 [argway_potion_unf]
 skill = "herblore"
 level = 56
-xp = 1.0
+xp = 0.0
 ticks = 2
 remove = ["juju_vial_of_water", "clean_argway"]
 add = ["argway_potion_unf"]
@@ -21,7 +21,7 @@ message = "You mix the argway into your vial of water."
 [ugune_potion_unf]
 skill = "herblore"
 level = 55
-xp = 1.0
+xp = 0.0
 ticks = 2
 remove = ["juju_vial_of_water", "clean_ugune"]
 add = ["ugune_potion_unf"]
@@ -31,7 +31,7 @@ message = "You mix the ugune into your vial of water."
 [shengo_potion_unf]
 skill = "herblore"
 level = 57
-xp = 1.0
+xp = 0.0
 ticks = 2
 remove = ["juju_vial_of_water", "clean_shengo"]
 add = ["shengo_potion_unf"]
@@ -41,7 +41,7 @@ message = "You mix the shengo into your vial of water."
 [samaden_potion_unf]
 skill = "herblore"
 level = 58
-xp = 1.0
+xp = 0.0
 ticks = 2
 remove = ["juju_vial_of_water", "clean_samaden"]
 add = ["samaden_potion_unf"]

--- a/data/skill/herblore/juju_potion_unfinished.recipes.toml
+++ b/data/skill/herblore/juju_potion_unfinished.recipes.toml
@@ -74,7 +74,7 @@ level = 75
 xp = 179.0
 ticks = 2
 remove = ["samaden_potion_unf", "zamorak_vine"]
-add = ["guthixs_gift_3"]
+add = ["zamoraks_favour_3"]
 animation = "mixing_potion"
 message = "You mix the zamorak vine into your potion."
 

--- a/data/skill/herblore/potion.recipes.toml
+++ b/data/skill/herblore/potion.recipes.toml
@@ -30,13 +30,13 @@ message = "You mix the limpwurt root into your potion."
 
 [stat_restore_potion_finished]
 skill = "herblore"
-level = 12
-xp = 50.0
+level = 22
+xp = 62.5
 ticks = 2
 remove = ["harralander_potion_unf", "red_spiders_eggs"]
 add = ["restore_potion_3"]
 animation = "mixing_potion"
-message = "You mix the limpwurt root into your potion."
+message = "You mix the red spiders' eggs into your potion."
 
 [guthix_balance_potion_finished]
 skill = "herblore"
@@ -103,10 +103,10 @@ skill = "herblore"
 level = 36
 xp = 84.0
 ticks = 2
-remove = ["harralander_potion_unf", "desert_goat_horn"]
+remove = ["harralander_potion_unf", "goat_horn_dust"]
 add = ["combat_potion_3"]
 animation = "mixing_potion"
-message = "You mix the desert goat horn into your potion."
+message = "You mix the goat horn dust into your potion."
 
 [prayer_potion_finished]
 skill = "herblore"
@@ -134,7 +134,7 @@ level = 42
 xp = 95.0
 ticks = 2
 remove = ["wergali_potion_unf", "frog_spawn"]
-add = ["summoning_potion_3"]
+add = ["crafting_potion_3"]
 animation = "mixing_potion"
 message = "You mix the frog spawn into your potion."
 
@@ -341,12 +341,12 @@ message = "You mix the wine of zamorak into your potion"
 ["weapon_poison+_finished"]
 skill = "herblore"
 level = 73
-xp = 137.5
+xp = 165.0
 ticks = 2
 remove = ["weapon_poison+_unf", "red_spiders_eggs"]
 add = ["weapon_poison+"]
 animation = "mixing_potion"
-message = "You mix the wine of red spiders eggs into your potion"
+message = "You mix the red spiders' eggs into your potion"
 
 [magic_potion_finished]
 skill = "herblore"
@@ -384,7 +384,7 @@ level = 82
 xp = 190.0
 ticks = 2
 remove = ["weapon_poison++_unf", "poison_ivy_berries"]
-add = ["saradomin_brew_3"]
+add = ["weapon_poison++"]
 animation = "mixing_potion"
 message = "You mix the poison ivy berries into your potion"
 
@@ -401,7 +401,7 @@ message = "You mix the papaya fruit into your potion"
 [super_anti_fire_finished]
 skill = "herblore"
 level = 85
-xp = 200.0
+xp = 210.0
 ticks = 2
 remove = ["antifire_3", "phoenix_feather"]
 add = ["super_antifire_3"]
@@ -451,9 +451,9 @@ message = "You mix the ground mud runes into your potion"
 [extreme_ranging_potion_finished]
 skill = "herblore"
 level = 92
-xp = 250.0
+xp = 260.0
 ticks = 2
-remove = ["super_ranging_potion_3", "grenwall_spikes"]
+remove = ["super_ranging_potion_3", { id = "grenwall_spikes", amount = 5 }]
 add = ["extreme_ranging_3"]
 animation = "mixing_potion"
 message = "You mix the grenwall spikes into your potion"

--- a/data/skill/herblore/potion_unfinished.recipes.toml
+++ b/data/skill/herblore/potion_unfinished.recipes.toml
@@ -41,7 +41,7 @@ message = "You put the Tarromin leaf into the vial of water."
 [rogues_purse_unf_potion]
 skill = "herblore"
 level = 5
-xp = 1.0
+xp = 0.0
 ticks = 1
 remove = ["clean_rogues_purse", "vial_of_water"]
 add = ["rogues_purse_potion_unf"]
@@ -111,7 +111,7 @@ message = "You put the Irit leaf into the vial of water."
 [wergali_unf_potion]
 skill = "herblore"
 level = 5
-xp = 1.0
+xp = 0.0
 ticks = 1
 remove = ["clean_wergali", "vial_of_water"]
 add = ["wergali_potion_unf"]
@@ -141,7 +141,7 @@ message = "You put the Kwuarm leaf into the vial of water."
 [magic_essence_unf_potion]
 skill = "herblore"
 level = 57
-xp = 1.0
+xp = 0.0
 ticks = 1
 remove = ["star_flower", "vial_of_water"]
 add = ["magic_essence_unf"]
@@ -211,7 +211,7 @@ message = "You mix the garlic into your potion."
 ["antipoison+_potion_unf"]
 skill = "herblore"
 level = 68
-xp = 1.0
+xp = 0.0
 ticks = 2
 remove = ["coconut_milk", "clean_toadflax"]
 add = ["antipoison+_unf"]
@@ -221,7 +221,7 @@ message = "You mix the toadflax leaf into your potion."
 ["antipoison++_potion_unf"]
 skill = "herblore"
 level = 79
-xp = 1.0
+xp = 0.0
 ticks = 2
 remove = ["coconut_milk", "clean_irit"]
 add = ["antipoison++_unf"]
@@ -231,7 +231,7 @@ message = "You mix the irit leaf into your potion."
 ["weaponpoison+_potion_unf"]
 skill = "herblore"
 level = 73
-xp = 1.0
+xp = 0.0
 ticks = 2
 remove = ["coconut_milk", "cactus_spine"]
 add = ["weapon_poison+_unf"]
@@ -241,7 +241,7 @@ message = "You mix the cactus spine into your potion."
 ["weaponpoison++_potion_unf"]
 skill = "herblore"
 level = 82
-xp = 1.0
+xp = 0.0
 ticks = 2
 remove = ["coconut_milk", "cave_nightshade"]
 add = ["weapon_poison++_unf"]

--- a/data/skill/herblore/potion_unfinished.recipes.toml
+++ b/data/skill/herblore/potion_unfinished.recipes.toml
@@ -150,7 +150,7 @@ message = "You put the Star flower into the vial of water."
 
 [snapdragon_unf_potion]
 skill = "herblore"
-level = 30
+level = 63
 xp = 0.0
 ticks = 1
 remove = ["clean_snapdragon", "vial_of_water"]
@@ -240,7 +240,7 @@ message = "You mix the cactus spine into your potion."
 
 ["weaponpoison++_potion_unf"]
 skill = "herblore"
-level = 73
+level = 82
 xp = 1.0
 ticks = 2
 remove = ["coconut_milk", "cave_nightshade"]

--- a/game/src/test/kotlin/content/skill/herblore/CrushingTest.kt
+++ b/game/src/test/kotlin/content/skill/herblore/CrushingTest.kt
@@ -5,6 +5,7 @@ import itemOnItem
 import net.pearx.kasechange.toSentenceCase
 import org.junit.jupiter.api.DynamicTest.dynamicTest
 import org.junit.jupiter.api.TestFactory
+import world.gregs.voidps.engine.entity.character.player.skill.Skill
 import world.gregs.voidps.engine.inv.add
 import world.gregs.voidps.engine.inv.inventory
 import kotlin.test.assertEquals
@@ -23,6 +24,7 @@ class CrushingTest : WorldTest() {
 
             assertEquals(1, player.inventory.count(product))
             assertEquals(0, player.inventory.count(ingredient))
+            assertEquals(0.0, player.experience.get(Skill.Herblore))
         }
     }
 

--- a/game/src/test/kotlin/content/skill/herblore/CrushingTest.kt
+++ b/game/src/test/kotlin/content/skill/herblore/CrushingTest.kt
@@ -1,0 +1,60 @@
+package content.skill.herblore
+
+import WorldTest
+import itemOnItem
+import net.pearx.kasechange.toSentenceCase
+import org.junit.jupiter.api.DynamicTest.dynamicTest
+import org.junit.jupiter.api.TestFactory
+import world.gregs.voidps.engine.inv.add
+import world.gregs.voidps.engine.inv.inventory
+import kotlin.test.assertEquals
+
+class CrushingTest : WorldTest() {
+
+    @TestFactory
+    fun `Crush an item with a pestle and mortar`() = crushable.map { (ingredient, product) ->
+        dynamicTest("Crush ${ingredient.toSentenceCase()}") {
+            val player = createPlayer()
+            player.inventory.add("pestle_and_mortar")
+            player.inventory.add(ingredient)
+
+            player.itemOnItem("pestle_and_mortar", ingredient)
+            tick(3)
+
+            assertEquals(1, player.inventory.count(product))
+            assertEquals(0, player.inventory.count(ingredient))
+        }
+    }
+
+    private companion object {
+        private val crushable = listOf(
+            "unicorn_horn" to "unicorn_horn_dust",
+            "kebbit_teeth" to "kebbit_teeth_dust",
+            "blue_dragon_scale" to "dragon_scale_dust",
+            "birds_nest_empty" to "crushed_nest",
+            "uncut_opal" to "crushed_gem",
+            "chocolate_bar" to "chocolate_dust",
+            "mud_rune" to "ground_mud_runes",
+            "gorak_claws" to "gorak_claw_powder",
+            "desert_goat_horn" to "goat_horn_dust",
+            "ashes" to "ground_ashes",
+            "fishing_bait" to "ground_fishing_bait",
+            "seaweed" to "ground_seaweed",
+            "raw_karambwan" to "karambwan_paste_raw",
+            "cooked_karambwan" to "karambwan_paste_cooked",
+            "poison_karambwan" to "karambwan_paste_poison",
+            "bat_bones" to "ground_bat_bones",
+            "charcoal" to "ground_charcoal",
+            "cod" to "ground_cod",
+            "kelp_mogre_camp" to "ground_kelp",
+            "crab_meat" to "ground_crab_meat",
+            "rune_shards" to "rune_dust",
+            "astral_rune_shards" to "ground_astral_rune",
+            "suqah_tooth" to "ground_tooth",
+            "diamond_root" to "diamond_root_dust",
+            "dried_thistle" to "ground_thistle",
+            "garlic" to "garlic_powder",
+            "black_mushroom" to "black_mushroom_ink",
+        )
+    }
+}

--- a/game/src/test/kotlin/content/skill/herblore/PotionMakingTest.kt
+++ b/game/src/test/kotlin/content/skill/herblore/PotionMakingTest.kt
@@ -5,6 +5,7 @@ import itemOnItem
 import net.pearx.kasechange.toSentenceCase
 import org.junit.jupiter.api.Assertions.assertNotEquals
 import org.junit.jupiter.api.DynamicTest.dynamicTest
+import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestFactory
 import world.gregs.voidps.engine.entity.character.player.skill.Skill
 import world.gregs.voidps.engine.inv.add
@@ -38,7 +39,7 @@ class PotionMakingTest : WorldTest() {
         listOf("tarromin_potion_unf", "limpwurt_root", "strength_potion_3"),
         listOf("harralander_potion_unf", "red_spiders_eggs", "restore_potion_3"),
         listOf("harralander_potion_unf", "chocolate_dust", "energy_potion_3"),
-        listOf("harralander_potion_unf", "desert_goat_horn", "combat_potion_3"),
+        listOf("harralander_potion_unf", "goat_horn_dust", "combat_potion_3"),
         listOf("ranarr_potion_unf", "white_berries", "defence_potion_3"),
         listOf("ranarr_potion_unf", "snape_grass", "prayer_potion_3"),
         listOf("irit_potion_unf", "eye_of_newt", "super_attack_3"),
@@ -50,9 +51,24 @@ class PotionMakingTest : WorldTest() {
         listOf("dwarf_weed_potion_unf", "wine_of_zamorak", "super_ranging_potion_3"),
         listOf("torstol_potion_unf", "jangerberries", "zamorak_brew_3"),
         listOf("toadflax_potion_unf", "crushed_nest", "saradomin_brew_3"),
+        listOf("wergali_potion_unf", "frog_spawn", "crafting_potion_3"),
+        listOf("weapon_poison+_unf", "red_spiders_eggs", "weapon_poison+"),
+        listOf("weapon_poison++_unf", "poison_ivy_berries", "weapon_poison++"),
+        listOf("antifire_3", "phoenix_feather", "super_antifire_3"),
+        listOf("samaden_potion_unf", "zamorak_vine", "zamoraks_favour_3"),
+        listOf("antipoison+_2", "caviar", "antidote+_mix_2"),
         listOf("prayer_potion_3", "wyvern_bonemeal", "super_prayer_3"),
         listOf("super_energy_3", "papaya_fruit", "recover_special_3"),
         listOf("extreme_attack_3", "extreme_strength_3", "extreme_defence_3", "extreme_magic_3", "extreme_ranging_3", "clean_torstol", "overload_3"),
+    )
+
+    private val experience = listOf(
+        listOf("harralander_potion_unf", "red_spiders_eggs", "restore_potion_3") to 62.5,
+        listOf("harralander_potion_unf", "goat_horn_dust", "combat_potion_3") to 84.0,
+        listOf("weapon_poison+_unf", "red_spiders_eggs", "weapon_poison+") to 165.0,
+        listOf("antifire_3", "phoenix_feather", "super_antifire_3") to 210.0,
+        listOf("antipoison_2", "roe", "antipoison_mix_2") to 12.0,
+        listOf("antipoison+_2", "caviar", "antidote+_mix_2") to 52.0,
     )
 
     @TestFactory
@@ -73,6 +89,70 @@ class PotionMakingTest : WorldTest() {
             }
             assertNotEquals(0.0, player.experience.get(Skill.Herblore))
         }
+    }
+
+    @TestFactory
+    fun `Potions give their listed experience`() = experience.map { (items, xp) ->
+        dynamicTest("Create ${items.last().toSentenceCase()}") {
+            val player = createPlayer()
+            player.levels.set(Skill.Herblore, 99)
+            for (item in items.dropLast(1)) {
+                player.inventory.add(item)
+            }
+
+            player.itemOnItem(0, 1)
+            tick(2)
+
+            assertEquals(1, player.inventory.count(items.last()))
+            assertEquals(xp, player.experience.get(Skill.Herblore))
+        }
+    }
+
+    @Test
+    fun `Extreme ranging takes five grenwall spikes`() {
+        val player = createPlayer()
+        player.levels.set(Skill.Herblore, 99)
+        player.inventory.add("super_ranging_potion_3")
+        player.inventory.add("grenwall_spikes", 7)
+
+        player.itemOnItem(0, 1)
+        tick(2)
+
+        assertEquals(1, player.inventory.count("extreme_ranging_3"))
+        assertEquals(2, player.inventory.count("grenwall_spikes"))
+        assertEquals(260.0, player.experience.get(Skill.Herblore))
+    }
+
+    @TestFactory
+    fun `Barbarian mixes need their listed level`() = listOf(
+        Triple("super_magic_potion_2", "super_magic_mix_2", 83),
+        Triple("super_ranging_potion_2", "super_ranging_mix_2", 80),
+        Triple("defence_potion_2", "defence_mix_2", 33),
+    ).map { (potion, mix, level) ->
+        dynamicTest("Mix ${mix.toSentenceCase()}") {
+            val player = createPlayer()
+            player.levels.set(Skill.Herblore, level - 1)
+            player.inventory.add(potion)
+            player.inventory.add("caviar")
+
+            player.itemOnItem(0, 1)
+            tick(2)
+
+            assertEquals(0, player.inventory.count(mix))
+            assertEquals(1, player.inventory.count(potion))
+        }
+    }
+
+    @Test
+    fun `Antipoison+ mix decants into two doses`() {
+        val player = createPlayer()
+        player.inventory.add("antidote+_mix_1", 2)
+
+        player.itemOnItem(0, 1)
+        tick(2)
+
+        assertEquals(1, player.inventory.count("antidote+_mix_2"))
+        assertEquals(1, player.inventory.count("vial"))
     }
 
     @TestFactory

--- a/game/src/test/kotlin/content/skill/herblore/PotionMakingTest.kt
+++ b/game/src/test/kotlin/content/skill/herblore/PotionMakingTest.kt
@@ -143,6 +143,27 @@ class PotionMakingTest : WorldTest() {
         }
     }
 
+    @TestFactory
+    fun `Unfinished potions give no experience`() = listOf(
+        Triple("coconut_milk", "clean_toadflax", "antipoison+_unf"),
+        Triple("coconut_milk", "cactus_spine", "weapon_poison+_unf"),
+        Triple("juju_vial_of_water", "clean_erzille", "erzille_potion_unf"),
+        Triple("star_flower", "vial_of_water", "magic_essence_unf"),
+    ).map { (first, second, unfinished) ->
+        dynamicTest("Create ${unfinished.toSentenceCase()}") {
+            val player = createPlayer()
+            player.levels.set(Skill.Herblore, 99)
+            player.inventory.add(first)
+            player.inventory.add(second)
+
+            player.itemOnItem(0, 1)
+            tick(2)
+
+            assertEquals(1, player.inventory.count(unfinished))
+            assertEquals(0.0, player.experience.get(Skill.Herblore))
+        }
+    }
+
     @Test
     fun `Antipoison+ mix decants into two doses`() {
         val player = createPlayer()
@@ -169,6 +190,7 @@ class PotionMakingTest : WorldTest() {
             assertEquals(1, player.inventory.count("${herb.removePrefix("clean_")}_potion_unf"))
             assertEquals(0, player.inventory.count(herb))
             assertEquals(0, player.inventory.count("vial_of_water"))
+            assertEquals(0.0, player.experience.get(Skill.Herblore))
         }
     }
 }


### PR DESCRIPTION
## Pestle and mortar

Twenty ingredients the wiki lists for the pestle and mortar had no recipe

## Herblore recipes naming the wrong item

Checked every Herblore recipe against the 2011 potion and barbarian mix tables.

- The combat potion asked for a desert goat horn rather than goat horn dust, so the dust had no use and the horn skipped the grinding step.
- The crafting potion produced a summoning potion, and weapon poison++ produced a Saradomin brew.
- Zamorak's favour produced Guthix's gift.
- The antipoison+ mix produced and decanted a super antipoison mix, which left the antidote+ mix unobtainable and gave super antipoison mix a second, cheaper recipe.
- Extreme ranging took one grenwall spike instead of five.

Magic mix and ranging mix each had a second recipe making the same item from the same ingredients at level 7 and 5 for 8 experience. Overlapping definitions resolve in file order, so those were the ones actually running.

Wrong level or experience on the restore potion (22, 62.5), super antifire (210), extreme ranging (260), weapon poison+ (165), and the anti-poison (6, 12), strength (14) and defence (33) mixes. The snapdragon and weapon poison++ unfinished potions were well below the level of the potion they lead to, unlike every other unfinished potion. Two messages named the wrong secondary, one of them a merge of two lines.

## Experience on the first step

Adding a herb to a vial grants no Herblore experience, but seven unfinished potions and all five juju ones paid out 1. Grinding gives none either, and six of the crushing recipes paid out 1 while the rest paid nothing. Guthix balance keeps its 25, which is the real partial award for each of its two secondaries.

## Testing

- `CrushingTest` covers all 27 grinds, product and no experience
- `PotionMakingTest` gains the corrected potions, an experience factory, the five-spike case, a mix level-gate factory, antidote+ decanting, and asserts no experience for unfinished potions including the coconut milk, juju and star flower ones

## Left alone

- `wergali_potion_unf` and `rogues_purse_potion_unf` do not follow the level-of-the-potion convention the other unfinished potions use, and I could not pin the 2011 value. Neither is exploitable, the finished potions still gate correctly.
- Relicym's balm, Serum 207, Guthix rest, the goblin potion and Shrink-me-quick have items and decant recipes but no creation recipe. Prayer renewal has no items at all.
- The existing silver dust recipe grinds a silver bar with the pestle, which the wiki says does not work, but removing it would make silver dust unobtainable since the Ectofuntus grinder does not handle silver.
- Ground guam, the fish food ingredient, has no recipe. Adding one would put a second option on guam and a pestle alongside guam tar, and there is no fish food recipe for it to feed.