### PR TITLE
Spirit shield sigil attaching

### DIFF
--- a/game/src/main/kotlin/content/area/misthalin/edgeville/monastery/BrotherBordiss.kt
+++ b/game/src/main/kotlin/content/area/misthalin/edgeville/monastery/BrotherBordiss.kt
@@ -59,10 +59,6 @@ class BrotherBordiss : Script {
             npc<Neutral>("You'll need a blessed spirit shield for me to mount it on. Come back and see me once you have one.")
             return
         }
-        if (!inventory.contains("coins", cost)) {
-            player<Sad>("I don't seem to have enough coins, I will return once I do.")
-            return
-        }
         val shield = SpiritShieldSigils.shield(sigil)
         val success = inventory.transaction {
             remove(sigil)
@@ -71,6 +67,7 @@ class BrotherBordiss : Script {
             add(shield)
         }
         if (!success) {
+            player<Sad>("I don't seem to have enough coins, I will return once I do.")
             return
         }
         item(shield, "Bordiss heats the shield through and works the sigil into it, and hands the finished shield back to you.")

--- a/game/src/main/kotlin/content/area/misthalin/edgeville/monastery/BrotherBordiss.kt
+++ b/game/src/main/kotlin/content/area/misthalin/edgeville/monastery/BrotherBordiss.kt
@@ -1,0 +1,79 @@
+package content.area.misthalin.edgeville.monastery
+
+import content.entity.player.dialogue.Amazed
+import content.entity.player.dialogue.Happy
+import content.entity.player.dialogue.Neutral
+import content.entity.player.dialogue.Quiz
+import content.entity.player.dialogue.Sad
+import content.entity.player.dialogue.type.choice
+import content.entity.player.dialogue.type.item
+import content.entity.player.dialogue.type.npc
+import content.entity.player.dialogue.type.player
+import content.skill.smithing.SpiritShieldSigils
+import world.gregs.voidps.engine.Script
+import world.gregs.voidps.engine.entity.character.player.Player
+import world.gregs.voidps.engine.inv.inventory
+import world.gregs.voidps.engine.inv.transact.operation.AddItem.add
+import world.gregs.voidps.engine.inv.transact.operation.RemoveItem.remove
+
+class BrotherBordiss : Script {
+
+    private val cost = 1_500_000
+
+    init {
+        npcOperate("Talk-to", "brother_bordiss,brother_bordiss_falador") {
+            npc<Happy>("Hello there. What can I do for you?")
+            choice {
+                val sigil = SpiritShieldSigils.SIGILS.firstOrNull { inventory.contains(it) }
+                if (sigil != null) {
+                    option<Quiz>("Can you do anything with this sigil?") {
+                        offerAttachment(sigil)
+                    }
+                }
+                option<Quiz>("What is a dwarf doing in a monastery?") {
+                    npc<Neutral>("Most of my kin follow Guthix, it's true, but I found Saradomin's teachings spoke to me. Balance is all very well; I would rather leave the world better than I found it.")
+                    npc<Neutral>("That is what my power station is for, and I have a forge here to keep my hands busy in the meantime.")
+                }
+                option<Neutral>("Nothing, thanks.")
+            }
+        }
+    }
+
+    private suspend fun Player.offerAttachment(sigil: String) {
+        npc<Amazed>("Now that is a sigil of the corporeal beast! I never thought I'd hold one of those.")
+        npc<Happy>("If you have a blessed spirit shield, I could mount that sigil onto it for you. It is fiddly work, mind, and my furnace does not stoke itself.")
+        npc<Neutral>("I would need 1,500,000 coins for the trouble. What do you say?")
+        choice {
+            option<Happy>("Yes, please!") {
+                attach(sigil)
+            }
+            option<Sad>("That's a bit expensive!") {
+                npc<Neutral>("It is a fair price for work this delicate. Come and find me again if you change your mind.")
+            }
+            option<Neutral>("No, thanks.")
+        }
+    }
+
+    private suspend fun Player.attach(sigil: String) {
+        if (!inventory.contains(SpiritShieldSigils.SHIELD)) {
+            npc<Neutral>("You'll need a blessed spirit shield for me to mount it on. Come back and see me once you have one.")
+            return
+        }
+        if (!inventory.contains("coins", cost)) {
+            player<Sad>("I don't seem to have enough coins, I will return once I do.")
+            return
+        }
+        val shield = SpiritShieldSigils.shield(sigil)
+        val success = inventory.transaction {
+            remove(sigil)
+            remove(SpiritShieldSigils.SHIELD)
+            remove("coins", cost)
+            add(shield)
+        }
+        if (!success) {
+            return
+        }
+        item(shield, "Bordiss heats the shield through and works the sigil into it, and hands the finished shield back to you.")
+        npc<Happy>("There you go. Bear it well, and mind what you point it at.")
+    }
+}

--- a/game/src/main/kotlin/content/skill/smithing/SpiritShieldSigils.kt
+++ b/game/src/main/kotlin/content/skill/smithing/SpiritShieldSigils.kt
@@ -1,0 +1,76 @@
+package content.skill.smithing
+
+import content.entity.player.dialogue.type.item
+import content.entity.player.dialogue.type.statement
+import world.gregs.voidps.engine.Script
+import world.gregs.voidps.engine.entity.character.player.Player
+import world.gregs.voidps.engine.entity.character.player.skill.Skill
+import world.gregs.voidps.engine.entity.character.player.skill.exp.exp
+import world.gregs.voidps.engine.entity.character.player.skill.level.Level.has
+import world.gregs.voidps.engine.entity.character.player.skill.level.Level.hasMax
+import world.gregs.voidps.engine.entity.item.Item
+import world.gregs.voidps.engine.inv.inventory
+import world.gregs.voidps.engine.inv.transact.operation.AddItem.add
+import world.gregs.voidps.engine.inv.transact.operation.RemoveItem.remove
+
+/**
+ * Smithing one of the corporeal beast's sigils onto a blessed spirit shield at an anvil turns the
+ * shield into the spirit shield of that sigil's kind.
+ */
+class SpiritShieldSigils : Script {
+
+    private val prayerLevel = 90
+    private val smithingLevel = 85
+
+    init {
+        itemOnObjectOperate(SIGILS.plus(SHIELD).joinToString(","), "anvil*") { (_, item) ->
+            attach(item)
+        }
+    }
+
+    private suspend fun Player.attach(used: Item) {
+        val sigil = if (used.id == SHIELD) SIGILS.firstOrNull { inventory.contains(it) } else used.id
+        if (sigil == null) {
+            statement("You need a sigil to attach to the shield.")
+            return
+        }
+        if (!inventory.contains(SHIELD)) {
+            statement("You need a blessed spirit shield to attach the sigil to.")
+            return
+        }
+        // Prayer's current level is the player's remaining prayer points, so take the base level.
+        if (!hasMax(Skill.Prayer, prayerLevel)) {
+            statement("You need a Prayer level of $prayerLevel to attach a sigil to a blessed spirit shield.")
+            return
+        }
+        if (!has(Skill.Smithing, smithingLevel)) {
+            statement("You need a Smithing level of $smithingLevel to attach a sigil to a blessed spirit shield.")
+            return
+        }
+        if (!inventory.contains("hammer")) {
+            statement("You need a hammer to work the metal with.")
+            return
+        }
+        anim("smith_item")
+        delay(4)
+        val shield = shield(sigil)
+        val success = inventory.transaction {
+            remove(sigil)
+            remove(SHIELD)
+            add(shield)
+        }
+        if (!success) {
+            return
+        }
+        exp(Skill.Smithing, 1800.0)
+        item(shield, "You successfully attach the ${sigil.removeSuffix("_sigil")} sigil to the blessed spirit shield.")
+    }
+
+    companion object {
+        const val SHIELD = "blessed_spirit_shield"
+
+        val SIGILS = listOf("arcane_sigil", "divine_sigil", "elysian_sigil", "spectral_sigil")
+
+        fun shield(sigil: String) = "${sigil.removeSuffix("_sigil")}_spirit_shield"
+    }
+}

--- a/game/src/test/kotlin/content/area/misthalin/edgeville/monastery/BrotherBordissTest.kt
+++ b/game/src/test/kotlin/content/area/misthalin/edgeville/monastery/BrotherBordissTest.kt
@@ -1,0 +1,85 @@
+package content.area.misthalin.edgeville.monastery
+
+import WorldTest
+import dialogueContinue
+import dialogueOption
+import npcOption
+import org.junit.jupiter.api.Test
+import skipDialogues
+import world.gregs.voidps.engine.entity.character.npc.NPC
+import world.gregs.voidps.engine.entity.character.player.Player
+import world.gregs.voidps.engine.inv.add
+import world.gregs.voidps.engine.inv.inventory
+import world.gregs.voidps.type.Tile
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class BrotherBordissTest : WorldTest() {
+
+    private val cost = 1_500_000
+
+    @Test
+    fun `Bordiss attaches a sigil for a fee`() {
+        val (player, bordiss) = setup("bordiss_attach")
+        player.inventory.add("blessed_spirit_shield")
+        player.inventory.add("elysian_sigil")
+        player.inventory.add("coins", cost)
+
+        player.attach(bordiss)
+
+        assertTrue(player.inventory.contains("elysian_spirit_shield"))
+        assertFalse(player.inventory.contains("blessed_spirit_shield"))
+        assertFalse(player.inventory.contains("elysian_sigil"))
+        assertEquals(0, player.inventory.count("coins"))
+    }
+
+    @Test
+    fun `Bordiss won't attach a sigil without the coins`() {
+        val (player, bordiss) = setup("bordiss_poor")
+        player.inventory.add("blessed_spirit_shield")
+        player.inventory.add("elysian_sigil")
+        player.inventory.add("coins", cost - 1)
+
+        player.attach(bordiss)
+
+        assertFalse(player.inventory.contains("elysian_spirit_shield"))
+        assertTrue(player.inventory.contains("elysian_sigil"))
+        assertEquals(cost - 1, player.inventory.count("coins"))
+    }
+
+    @Test
+    fun `Bordiss won't attach a sigil without a blessed spirit shield`() {
+        val (player, bordiss) = setup("bordiss_shieldless")
+        player.inventory.add("elysian_sigil")
+        player.inventory.add("coins", cost)
+
+        player.attach(bordiss)
+
+        assertFalse(player.inventory.contains("elysian_spirit_shield"))
+        assertTrue(player.inventory.contains("elysian_sigil"))
+        assertEquals(cost, player.inventory.count("coins"))
+    }
+
+    private fun setup(name: String): Pair<Player, NPC> {
+        val player = createPlayer(emptyTile, name)
+        val bordiss = createNPC("brother_bordiss", emptyTile.addX(1))
+        tick()
+        return player to bordiss
+    }
+
+    private fun Player.attach(bordiss: NPC) {
+        npcOption(bordiss, "Talk-to")
+        tick(2)
+        dialogueContinue() // "Hello there. What can I do for you?"
+        dialogueOption(1) // "Can you do anything with this sigil?"
+        dialogueContinue(4) // repeated player line + Bordiss's offer
+        dialogueOption(1) // "Yes, please!"
+        skipDialogues()
+        tick()
+    }
+
+    private companion object {
+        private val emptyTile = Tile(3200, 3200)
+    }
+}

--- a/game/src/test/kotlin/content/skill/smithing/SpiritShieldSigilsTest.kt
+++ b/game/src/test/kotlin/content/skill/smithing/SpiritShieldSigilsTest.kt
@@ -1,0 +1,133 @@
+package content.skill.smithing
+
+import WorldTest
+import dialogueContinue
+import itemOnObject
+import org.junit.jupiter.api.DynamicTest
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestFactory
+import world.gregs.voidps.engine.entity.character.player.Player
+import world.gregs.voidps.engine.entity.character.player.skill.Skill
+import world.gregs.voidps.engine.entity.character.player.skill.level.Level
+import world.gregs.voidps.engine.entity.obj.GameObject
+import world.gregs.voidps.engine.inv.add
+import world.gregs.voidps.engine.inv.inventory
+import world.gregs.voidps.type.Tile
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class SpiritShieldSigilsTest : WorldTest() {
+
+    @TestFactory
+    fun `Attach each sigil to a blessed spirit shield`() = SpiritShieldSigils.SIGILS.map { sigil ->
+        DynamicTest.dynamicTest(sigil) {
+            val player = createPlayer(emptyTile)
+            val anvil = createObject("anvil", emptyTile.addY(1))
+            player.qualified()
+            player.inventory.add("blessed_spirit_shield", sigil, "hammer")
+
+            player.attach(anvil, sigil)
+
+            assertTrue(player.inventory.contains(SpiritShieldSigils.shield(sigil)))
+            assertFalse(player.inventory.contains("blessed_spirit_shield"))
+            assertFalse(player.inventory.contains(sigil))
+            assertEquals(Level.experience(85) + 1800.0, player.experience.get(Skill.Smithing))
+        }
+    }
+
+    @Test
+    fun `Attach a sigil by using the shield on the anvil`() {
+        val player = createPlayer(emptyTile)
+        val anvil = createObject("anvil", emptyTile.addY(1))
+        player.qualified()
+        player.inventory.add("blessed_spirit_shield", "divine_sigil", "hammer")
+
+        player.attach(anvil, "blessed_spirit_shield")
+
+        assertTrue(player.inventory.contains("divine_spirit_shield"))
+    }
+
+    @Test
+    fun `Attaching a sigil needs a blessed spirit shield`() {
+        val player = createPlayer(emptyTile)
+        val anvil = createObject("anvil", emptyTile.addY(1))
+        player.qualified()
+        player.inventory.add("divine_sigil", "hammer")
+
+        player.attach(anvil, "divine_sigil")
+
+        assertFalse(player.inventory.contains("divine_spirit_shield"))
+        assertTrue(player.inventory.contains("divine_sigil"))
+    }
+
+    @Test
+    fun `Attaching a sigil needs a hammer`() {
+        val player = createPlayer(emptyTile)
+        val anvil = createObject("anvil", emptyTile.addY(1))
+        player.qualified()
+        player.inventory.add("blessed_spirit_shield", "divine_sigil")
+
+        player.attach(anvil, "divine_sigil")
+
+        assertFalse(player.inventory.contains("divine_spirit_shield"))
+        assertTrue(player.inventory.contains("blessed_spirit_shield"))
+        assertTrue(player.inventory.contains("divine_sigil"))
+    }
+
+    @Test
+    fun `Attaching a sigil needs ninety prayer`() {
+        val player = createPlayer(emptyTile)
+        val anvil = createObject("anvil", emptyTile.addY(1))
+        player.qualified(prayer = 89)
+        player.inventory.add("blessed_spirit_shield", "divine_sigil", "hammer")
+
+        player.attach(anvil, "divine_sigil")
+
+        assertFalse(player.inventory.contains("divine_spirit_shield"))
+        assertTrue(player.inventory.contains("blessed_spirit_shield"))
+        assertTrue(player.inventory.contains("divine_sigil"))
+    }
+
+    @Test
+    fun `Attaching a sigil needs eighty five smithing`() {
+        val player = createPlayer(emptyTile)
+        val anvil = createObject("anvil", emptyTile.addY(1))
+        player.qualified(smithing = 84)
+        player.inventory.add("blessed_spirit_shield", "divine_sigil", "hammer")
+
+        player.attach(anvil, "divine_sigil")
+
+        assertFalse(player.inventory.contains("divine_spirit_shield"))
+        assertTrue(player.inventory.contains("blessed_spirit_shield"))
+        assertTrue(player.inventory.contains("divine_sigil"))
+    }
+
+    @Test
+    fun `Spent prayer points don't block attaching a sigil`() {
+        val player = createPlayer(emptyTile)
+        val anvil = createObject("anvil", emptyTile.addY(1))
+        player.qualified()
+        player.levels.set(Skill.Prayer, 0)
+        player.inventory.add("blessed_spirit_shield", "divine_sigil", "hammer")
+
+        player.attach(anvil, "divine_sigil")
+
+        assertTrue(player.inventory.contains("divine_spirit_shield"))
+    }
+
+    private fun Player.qualified(prayer: Int = 90, smithing: Int = 85) {
+        experience.set(Skill.Prayer, Level.experience(prayer))
+        experience.set(Skill.Smithing, Level.experience(smithing))
+    }
+
+    private fun Player.attach(anvil: GameObject, used: String) {
+        itemOnObject(anvil, inventory.indexOf(used))
+        tick(6)
+        dialogueContinue()
+    }
+
+    private companion object {
+        private val emptyTile = Tile(3200, 3200)
+    }
+}


### PR DESCRIPTION
Smithing one of the corporeal beast's four sigils onto a blessed spirit shield at an anvil now makes the spirit shield of that sigil's kind, taking 85 Smithing, base level 90 Prayer and a hammer for 1800 Smithing experience. Either the sigil or the shield can be the item used on the anvil; using the shield picks up whichever sigil is carried.

Prayer is checked against the base level because the current level in this engine is the player's remaining prayer points, so praying at all would otherwise lock a player out of their own shield.

Brother Bordiss will do the same for 1,500,000 coins. He had no dialogue at all before this, so he also answers for himself on what a dwarf is doing in a Saradominist monastery.

Perils of Ice Mountain has no script yet, so Bordiss's quest requirement is left off rather than making the service unreachable, matching how the blessing and the sigil drops are already ungated.