### PR TITLE
Add Evil Chicken's Lair

### DIFF
--- a/data/area/misthalin/zanaris/evil_chicken_lair/evil_chicken_lair.anims.toml
+++ b/data/area/misthalin/zanaris/evil_chicken_lair/evil_chicken_lair.anims.toml
@@ -6,3 +6,11 @@ id = 2301
 
 [evil_chicken_attack]
 id = 2302
+
+[teleport_evil_chicken_lair]
+id = 2755
+ticks = 1
+
+[teleport_land_evil_chicken_lair]
+id = 2757
+ticks = 1

--- a/data/area/misthalin/zanaris/evil_chicken_lair/evil_chicken_lair.npc-spawns.toml
+++ b/data/area/misthalin/zanaris/evil_chicken_lair/evil_chicken_lair.npc-spawns.toml
@@ -1,4 +1,6 @@
 spawns = [
+# 6212
+  { id = "kklik", x = 1560, y = 4401, direction = "NORTH" },
   { id = "baby_black_dragon", x = 1542, y = 4393 },
   { id = "black_dragon_evil_chicken_lair", x = 1563, y = 4359 },
   { id = "black_dragon_evil_chicken_lair_2", x = 1558, y = 4370 },

--- a/data/area/misthalin/zanaris/evil_chicken_lair/evil_chicken_lair.npcs.toml
+++ b/data/area/misthalin/zanaris/evil_chicken_lair/evil_chicken_lair.npcs.toml
@@ -52,3 +52,6 @@ mage = 100
 max_hit_slash = 210
 hunt_mode = "cowardly"
 
+[kklik]
+id = 3377
+examine = "A small dragon fairy."

--- a/data/area/misthalin/zanaris/evil_chicken_lair/evil_chicken_lair.objs.toml
+++ b/data/area/misthalin/zanaris/evil_chicken_lair/evil_chicken_lair.objs.toml
@@ -1,0 +1,23 @@
+[chicken_shrine]
+id = 12093
+examine = "A shrine to the Evil Chicken."
+
+[evil_chicken_lair_portal]
+id = 12260
+examine = "A portal leading out of the lair."
+
+[evil_chicken_lair_tunnel_entrance]
+id = 12253
+examine = "There is a sheer drop below the tunnel."
+
+[evil_chicken_lair_tunnel_entrance_rope]
+id = 12254
+examine = "A rope leading down into the tunnel."
+
+[evil_chicken_lair_rope]
+id = 12255
+examine = "A rope leading up out of the tunnel."
+
+[evil_chicken_nest]
+id = 12259
+examine = "The Evil Chicken's nest."

--- a/data/area/misthalin/zanaris/evil_chicken_lair/evil_chicken_lair.teles.toml
+++ b/data/area/misthalin/zanaris/evil_chicken_lair/evil_chicken_lair.teles.toml
@@ -1,0 +1,15 @@
+# 6212 evil chicken's lair
+[evil_chicken_lair_portal]
+option = "Enter"
+tile = { x = 1563, y = 4354 }
+to = { x = 2452, y = 4476 }
+
+[evil_chicken_lair_tunnel_entrance_rope]
+option = "Climb-down"
+tile = { x = 1559, y = 4380 }
+to = { x = 1545, y = 4382 }
+
+[evil_chicken_lair_rope]
+option = "Climb-up"
+tile = { x = 1545, y = 4381 }
+to = { x = 1561, y = 4380 }

--- a/data/entity/player/modal/tab/music_player/music_tracks.toml
+++ b/data/entity/player/modal/tab/music_player/music_tracks.toml
@@ -2027,7 +2027,7 @@ areas = [ { region = 11924 } ]
 
 [chickened_out]
 index = 395
-areas = [ { region = 9796 } ]
+areas = [ { region = 6212 }, { region = 9796 } ]
 
 [too_many_cooks]
 index = 398

--- a/game/src/main/kotlin/content/area/misthalin/zanaris/evil_chicken_lair/EvilChickenLair.kt
+++ b/game/src/main/kotlin/content/area/misthalin/zanaris/evil_chicken_lair/EvilChickenLair.kt
@@ -21,7 +21,7 @@ class EvilChickenLair : Script {
                 return@itemOnObjectOperate
             }
             message("You place the raw chicken on the shrine.")
-            delay(anim("teleport_evil_chicken_lair"))
+            animDelay("teleport_evil_chicken_lair")
             tele(ENTRANCE)
             anim("teleport_land_evil_chicken_lair")
         }

--- a/game/src/main/kotlin/content/area/misthalin/zanaris/evil_chicken_lair/EvilChickenLair.kt
+++ b/game/src/main/kotlin/content/area/misthalin/zanaris/evil_chicken_lair/EvilChickenLair.kt
@@ -1,0 +1,65 @@
+package content.area.misthalin.zanaris.evil_chicken_lair
+
+import world.gregs.voidps.engine.Script
+import world.gregs.voidps.engine.client.message
+import world.gregs.voidps.engine.client.variable.remaining
+import world.gregs.voidps.engine.client.variable.start
+import world.gregs.voidps.engine.entity.character.move.tele
+import world.gregs.voidps.engine.entity.character.player.Teleport
+import world.gregs.voidps.engine.entity.obj.replace
+import world.gregs.voidps.engine.inv.inventory
+import world.gregs.voidps.engine.inv.remove
+import world.gregs.voidps.engine.timer.toTicks
+import world.gregs.voidps.type.Tile
+import java.util.concurrent.TimeUnit
+
+class EvilChickenLair : Script {
+    init {
+        itemOnObjectOperate("raw_chicken", "chicken_shrine") {
+            walkToDelay(SHRINE_TILE)
+            if (!inventory.remove("raw_chicken")) {
+                return@itemOnObjectOperate
+            }
+            message("You place the raw chicken on the shrine.")
+            delay(anim("teleport_evil_chicken_lair"))
+            tele(ENTRANCE)
+            anim("teleport_land_evil_chicken_lair")
+        }
+
+        objTeleportTakeOff("Enter", "evil_chicken_lair_portal") { _, _ ->
+            anim("teleport_evil_chicken_lair")
+        }
+
+        objTeleportLand("Enter", "evil_chicken_lair_portal") { _, _ ->
+            anim("teleport_land_evil_chicken_lair")
+        }
+
+        itemOnObjectOperate("rope", "evil_chicken_lair_tunnel_entrance") { (target) ->
+            arriveDelay()
+            if (!inventory.remove("rope")) {
+                return@itemOnObjectOperate
+            }
+            message("You tie the rope to the top of the tunnel and throw it down.")
+            target.replace("evil_chicken_lair_tunnel_entrance_rope", ticks = ROPE_TICKS)
+        }
+
+        // The tunnel entrance isn't named like a rope so Stairs' generic climb animation doesn't apply.
+        objTeleportTakeOff("Climb-down", "evil_chicken_lair_tunnel_entrance_rope") { _, _ ->
+            val remaining = remaining("teleport_delay")
+            if (remaining > 0) {
+                return@objTeleportTakeOff remaining
+            } else if (remaining < 0) {
+                anim("climb_down")
+                start("teleport_delay", 2)
+                return@objTeleportTakeOff 2
+            }
+            return@objTeleportTakeOff Teleport.CONTINUE
+        }
+    }
+
+    companion object {
+        private val SHRINE_TILE = Tile(2452, 4476)
+        private val ENTRANCE = Tile(1563, 4357)
+        private val ROPE_TICKS = TimeUnit.MINUTES.toTicks(3)
+    }
+}

--- a/game/src/test/kotlin/content/area/misthalin/zanaris/evil_chicken_lair/EvilChickenLairTest.kt
+++ b/game/src/test/kotlin/content/area/misthalin/zanaris/evil_chicken_lair/EvilChickenLairTest.kt
@@ -1,0 +1,92 @@
+package content.area.misthalin.zanaris.evil_chicken_lair
+
+import WorldTest
+import itemOnObject
+import org.junit.jupiter.api.Test
+import world.gregs.voidps.engine.client.instruction.handle.interactObject
+import world.gregs.voidps.engine.entity.obj.GameObjects
+import world.gregs.voidps.engine.inv.add
+import world.gregs.voidps.engine.inv.inventory
+import world.gregs.voidps.type.Tile
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+
+class EvilChickenLairTest : WorldTest() {
+
+    @Test
+    fun `Raw chicken on the shrine teleports into the lair`() {
+        val player = createPlayer(Tile(2452, 4476))
+        player.inventory.add("raw_chicken")
+
+        val shrine = GameObjects.find(Tile(2452, 4477), "chicken_shrine")
+        player.itemOnObject(shrine, player.inventory.indexOf("raw_chicken"))
+        tick(10)
+
+        assertEquals(0, player.inventory.count("raw_chicken"))
+        assertEquals(Tile(1563, 4357), player.tile)
+    }
+
+    @Test
+    fun `Shrine teleport waits until the player stands in front of the shrine`() {
+        val player = createPlayer(Tile(2451, 4477))
+        player.inventory.add("raw_chicken")
+
+        val shrine = GameObjects.find(Tile(2452, 4477), "chicken_shrine")
+        player.itemOnObject(shrine, player.inventory.indexOf("raw_chicken"))
+        tick()
+
+        assertEquals(1, player.inventory.count("raw_chicken"), "Teleport started before reaching the shrine")
+
+        tick(10)
+        assertEquals(Tile(1563, 4357), player.tile)
+    }
+
+    @Test
+    fun `Cooked chicken does nothing to the shrine`() {
+        val player = createPlayer(Tile(2452, 4476))
+        player.inventory.add("cooked_chicken")
+
+        val shrine = GameObjects.find(Tile(2452, 4477), "chicken_shrine")
+        player.itemOnObject(shrine, player.inventory.indexOf("cooked_chicken"))
+        tick(4)
+
+        assertEquals(1, player.inventory.count("cooked_chicken"))
+        assertEquals(Tile(2452, 4476), player.tile)
+    }
+
+    @Test
+    fun `Portal teleports out of the lair`() {
+        val player = createPlayer(Tile(1563, 4357))
+
+        val portal = GameObjects.find(Tile(1563, 4354), "evil_chicken_lair_portal")
+        player.interactObject(portal, "Enter")
+        tick(10)
+
+        assertEquals(Tile(2452, 4476), player.tile)
+    }
+
+    @Test
+    fun `Rope on the tunnel entrance allows climbing down and back up`() {
+        val player = createPlayer(Tile(1561, 4380))
+        player.inventory.add("rope")
+
+        val tunnel = GameObjects.find(Tile(1559, 4380), "evil_chicken_lair_tunnel_entrance")
+        player.itemOnObject(tunnel, player.inventory.indexOf("rope"))
+        tick(2)
+
+        assertEquals(0, player.inventory.count("rope"))
+        assertNull(GameObjects.findOrNull(Tile(1559, 4380), "evil_chicken_lair_tunnel_entrance"))
+        val roped = GameObjects.find(Tile(1559, 4380), "evil_chicken_lair_tunnel_entrance_rope")
+        assertNotNull(roped)
+
+        player.interactObject(roped, "Climb-down")
+        tick(10)
+        assertEquals(Tile(1545, 4382), player.tile)
+
+        val rope = GameObjects.find(Tile(1545, 4381), "evil_chicken_lair_rope")
+        player.interactObject(rope, "Climb-up")
+        tick(10)
+        assertEquals(Tile(1561, 4380), player.tile)
+    }
+}


### PR DESCRIPTION
Using a raw chicken on the chicken shrine north-east of Zanaris now teleports into the Evil Chicken's Lair, and the portal inside teleports back out to the shrine.

A rope used on the tunnel entrance on the west wall opens it for three minutes, leading down to the baby black dragon. The permanent rope at the bottom climbs back up. The tunnel entrance isn't named like a rope, so the generic climb animation for ladders doesn't cover it and a climb-down animation is registered for the roped variant.

Both teleports use the disappear and reappear pair, declared as a single tick each: the animations run 40 client ticks, so rounding up to two ticks let the player stand back up before the teleport fired.

K'klik is spawned by the nest, and Chickened Out plays in the lair.

[Screencast_20260820_134931.webm](https://github.com/user-attachments/assets/fa3d428a-6f33-4d94-9cd9-4987183136a3)
