### PR TITLE
Bonus Prayer experience for offering bones at an altar

### DIFF
--- a/data/skill/prayer/prayer.gfx.toml
+++ b/data/skill/prayer/prayer.gfx.toml
@@ -15,3 +15,6 @@ id = 2213
 
 [bless_grave]
 id = 1274
+
+[bone_offering]
+id = 624

--- a/game/src/main/kotlin/content/skill/prayer/bone/BoneOffering.kt
+++ b/game/src/main/kotlin/content/skill/prayer/bone/BoneOffering.kt
@@ -35,7 +35,7 @@ class BoneOffering : Script {
         val xp = Tables.intOrNull("bones.${item.id}.xp") ?: return
         repeat(amount) {
             if (inventory.remove(item.id)) {
-                exp(Skill.Prayer, xp / 10.0)
+                exp(Skill.Prayer, (xp / 10.0) * BONUS)
                 anim("offer_bones")
                 areaGfx("bone_offering", tile)
                 message(
@@ -53,5 +53,12 @@ class BoneOffering : Script {
                 mode = EmptyMode
             }
         }
+    }
+
+    companion object {
+        /**
+         * Offering bones at an altar grants half again the experience gained from burying them.
+         */
+        private const val BONUS = 1.5
     }
 }

--- a/game/src/test/kotlin/content/skill/prayer/PrayerTest.kt
+++ b/game/src/test/kotlin/content/skill/prayer/PrayerTest.kt
@@ -85,4 +85,16 @@ internal class PrayerTest : WorldTest() {
             assertFalse(player.inventory.contains(bone))
         }
     }
+
+    @Test
+    fun `Offering bones grants half again the burying experience`() {
+        val player = createPlayer(Tile(3244, 3207))
+        player.inventory.add("bones")
+        val altar = GameObjects.find(Tile(3243, 3206), "prayer_altar_lumbridge")
+
+        player.itemOnObject(altar, 0)
+        tick(2)
+
+        assertEquals(6.7, player.experience.get(Skill.Prayer))
+    }
 }


### PR DESCRIPTION
Offering bones at an altar now grants 1.5x the experience gained from burying them, rather than the same amount.

Also adds the missing `bone_offering` graphic (624). `BoneOffering` already spawned it on the altar, but no definition existed so nothing rendered.

### Testing

`PrayerTest` covers bones granting 6.7 experience when offered at an altar, against 4.5 for burying.