### PR TITLE
Add Ectofuntus

### DIFF
--- a/data/area/morytania/port_phasmatys/ectofuntus.anims.toml
+++ b/data/area/morytania/port_phasmatys/ectofuntus.anims.toml
@@ -1,0 +1,14 @@
+[wind_bone_grinder]
+id = 1648
+
+[fill_bone_hopper]
+id = 1649
+
+[empty_bone_bin]
+id = 1650
+
+[worship_ectofuntus]
+id = 1651
+
+[fill_bucket_slime]
+id = 4471

--- a/data/area/morytania/port_phasmatys/ectofuntus.objs.toml
+++ b/data/area/morytania/port_phasmatys/ectofuntus.objs.toml
@@ -1,0 +1,27 @@
+[ectofuntus_hopper]
+id = 11162
+examine = "A big grinding thing."
+
+[ectofuntus_bone_grinder]
+id = 11163
+examine = "A big grinding thing."
+
+[ectofuntus_bin]
+id = 11164
+examine = "A big grinding thing."
+
+[pool_of_slime]
+id = 17116
+examine = "A subterranean pool of ectoplasm."
+
+[pool_of_slime_2]
+clone = "pool_of_slime"
+id = 17117
+
+[pool_of_slime_3]
+clone = "pool_of_slime"
+id = 17118
+
+[pool_of_slime_4]
+clone = "pool_of_slime"
+id = 17119

--- a/data/area/morytania/port_phasmatys/ectofuntus.sounds.toml
+++ b/data/area/morytania/port_phasmatys/ectofuntus.sounds.toml
@@ -1,0 +1,14 @@
+[grinder_grinding]
+id = 1131
+
+[fill_ectoplasm]
+id = 1132
+
+[fill_grinder]
+id = 1133
+
+[grinder_empty]
+id = 1136
+
+[worship_ectofuntus]
+id = 2671

--- a/data/area/morytania/port_phasmatys/ectofuntus.vars.toml
+++ b/data/area/morytania/port_phasmatys/ectofuntus.vars.toml
@@ -1,0 +1,19 @@
+# Ectofuntus worships since ecto-tokens were last collected; capped at 53 (265 tokens).
+[ectofuntus_charges]
+format = "int"
+persist = true
+
+# Bone string id currently loaded in the grinder, "" when the grinder is empty.
+[bone_grinder_bones]
+format = "string"
+persist = true
+
+# Grinder stage: 0 = empty, 1 = bones in the hopper, 2 = bonemeal in the bin.
+[bone_grinder_stage]
+format = "int"
+persist = true
+
+# false = manual (fill, wind, empty), true = automatic (one fill grinds the inventory).
+[bone_grinder_auto]
+format = "boolean"
+persist = true

--- a/data/area/morytania/port_phasmatys/port_phasmatys.objs.toml
+++ b/data/area/morytania/port_phasmatys/port_phasmatys.objs.toml
@@ -60,9 +60,6 @@ examine = "An appliance for cooking with."
 [ahoy_ladder_from_cellar]
 id = 5264
 
-[ahoy_new_green_floor]
-id = 17119
-
 [ahoy_tower_stairs_lv1_withwall]
 id = 37454
 

--- a/data/skill/prayer/bones.tables.toml
+++ b/data/skill/prayer/bones.tables.toml
@@ -1,35 +1,46 @@
 [bones]
 xp = "int"
+bonemeal = "item"
 
 [.skeletal_monkey_bones]
 xp = 30
+bonemeal = "skeletal_monkey_bonemeal"
 
 [.bones]
 xp = 45
+bonemeal = "bonemeal_bones"
 
 [.burnt_bones]
 xp = 45
+bonemeal = "burnt_bonemeal"
 
 [.bat_bones]
 xp = 50
+bonemeal = "bat_bonemeal"
 
 [.wolf_bones]
 xp = 45
+bonemeal = "wolf_bonemeal"
 
 [.monkey_bones]
 xp = 50
+bonemeal = "monkey_bonemeal"
 
 [.small_zombie_monkey_bones]
 xp = 50
+bonemeal = "small_zombie_monkey_bonemeal"
 
 [.large_zombie_monkey_bones]
 xp = 50
+bonemeal = "large_zombie_monkey_bonemeal"
 
 [.big_bones]
 xp = 150
+bonemeal = "big_bonemeal"
 
 [.jogre_bones]
 xp = 150
+bonemeal = "jogre_bonemeal"
 
 [.curved_bone]
 xp = 151
@@ -39,48 +50,64 @@ xp = 151
 
 [.small_ninja_monkey_bones]
 xp = 160
+bonemeal = "small_ninja_monkey_bonemeal"
 
 [.medium_ninja_monkey_bones]
 xp = 180
+bonemeal = "medium_ninja_monkey_bonemeal"
 
 [.gorilla_bones]
 xp = 180
+bonemeal = "gorilla_bonemeal"
 
 [.bearded_gorilla_bones]
 xp = 200
+bonemeal = "bearded_gorilla_bonemeal"
 
 [.shaikahan_bones]
 xp = 250
+bonemeal = "shaikahan_bonemeal"
 
 [.zogre_bones]
 xp = 225
+bonemeal = "zogre_bonemeal"
 
 [.babydragon_bones]
 xp = 300
+bonemeal = "baby_dragon_bonemeal"
 
 [.wyvern_bones]
 xp = 500
+bonemeal = "wyvern_bonemeal"
 
 [.dragon_bones]
 xp = 720
+bonemeal = "dragon_bonemeal"
 
 [.fayrg_bones]
 xp = 840
+bonemeal = "fayrg_bonemeal"
 
 [.raurg_bones]
 xp = 960
+bonemeal = "raurg_bonemeal"
 
 [.dagannoth_bones]
 xp = 1250
+bonemeal = "dagannoth_bonemeal"
 
 [.ourg_bones]
 xp = 1400
+bonemeal = "ourg_bonemeal"
 
 [.ourg_bones_general_graardor]
 xp = 1400
+bonemeal = "ourg_bonemeal"
 
 [.frost_dragon_bones_dungeoneering]
 xp = 1800
+bonemeal = "frost_dragon_bonemeal"
 
 [.frost_dragon_bones]
 xp = 1800
+bonemeal = "frost_dragon_bonemeal"

--- a/game/src/main/kotlin/content/area/morytania/port_phasmatys/GhostDisciple.kt
+++ b/game/src/main/kotlin/content/area/morytania/port_phasmatys/GhostDisciple.kt
@@ -1,0 +1,87 @@
+package content.area.morytania.port_phasmatys
+
+import content.entity.player.dialogue.Neutral
+import content.entity.player.dialogue.Quiz
+import content.entity.player.dialogue.type.choice
+import content.entity.player.dialogue.type.npc
+import content.entity.player.dialogue.type.player
+import content.entity.player.inv.item.addOrDrop
+import content.quest.member.ghosts_ahoy.checkGhostspeak
+import world.gregs.voidps.engine.Script
+import world.gregs.voidps.engine.entity.character.player.Player
+import world.gregs.voidps.engine.inv.inventory
+
+class GhostDisciple : Script {
+
+    init {
+        npcOperate("Talk-to", "ahoy_disciple") {
+            if (!checkGhostspeak()) {
+                return@npcOperate
+            }
+            if (get("ectofuntus_charges", 0) > 0) {
+                collect()
+                return@npcOperate
+            }
+            talk()
+        }
+
+        npcOperate("Collect", "ahoy_disciple") {
+            collect()
+        }
+    }
+
+    private suspend fun Player.collect() {
+        val amount = get("ectofuntus_charges", 0) * TOKENS_PER_WORSHIP
+        if (amount <= 0) {
+            npc<Neutral>("I'm sorry, but you haven't earned any.")
+            return
+        }
+        if (inventory.isFull() && !inventory.contains("ecto_token")) {
+            npc<Neutral>("I have $amount ectotokens waiting for you mortal, but you do not have room in your inventory for them.")
+            return
+        }
+        set("ectofuntus_charges", 0)
+        addOrDrop("ecto_token", amount)
+        npc<Neutral>("Certainly, mortal. Here's $amount ectotokens.")
+    }
+
+    private suspend fun Player.talk() {
+        if (tile.level > 0) {
+            npc<Neutral>("Put bones of any type into the machine's hopper, and then turn the handle to grind them. You will need a pot to empty the machine of ground up bones.")
+            return
+        }
+        npc<Neutral>("This is the Ectofuntus, the most marvellous creation of Necrovarus, our glorious leader.")
+        options()
+    }
+
+    private suspend fun Player.options() {
+        choice {
+            option<Quiz>("What is the Ectofuntus?") {
+                npc<Neutral>("It provides the power to keep us ghosts from passing over into the next plane of existence.")
+                player<Quiz>("And how does it work?")
+                npc<Neutral>("You have to pour a bucket of ectoplasm into the fountain, a pot of ground bones, and then worship at the Ectofuntus. A unit of unholy power will then be created.")
+                options()
+            }
+            option<Quiz>("Where do I get ectoplasm from?") {
+                npc<Neutral>("Necrovarus sensed the power bubbling beneath our feet, and we delved long and deep beneath Port Phasmatys, until we found a pool of natural ectoplasm. You may find it by using the trapdoor over there.")
+                options()
+            }
+            option<Quiz>("How do I grind bones?") {
+                npc<Neutral>("There is a bone grinding machine upstairs. Put bones of any type into the machine's hopper, and then turn the handle to grind them. You will need a pot to empty the machine of ground up bones.")
+                options()
+            }
+            option<Quiz>("How do I receive Ectotokens?") {
+                npc<Neutral>("We disciples keep track of how many units of power have been produced. Just talk to us once you have generated some and we will reimburse you with the correct amount of Ectotokens.")
+                player<Quiz>("How do I generate units of power?")
+                npc<Neutral>("You have to pour a bucket of ectoplasm into the fountain and then worship at the Ectofuntus with a pot of ground bones. This will create a unit of unholy power.")
+                options()
+            }
+            option("Thanks for your time.")
+        }
+    }
+
+    companion object {
+        /** Ecto-tokens awarded for each worship at the Ectofuntus. */
+        private const val TOKENS_PER_WORSHIP = 5
+    }
+}

--- a/game/src/main/kotlin/content/area/morytania/port_phasmatys/NecrovarusTemple.kt
+++ b/game/src/main/kotlin/content/area/morytania/port_phasmatys/NecrovarusTemple.kt
@@ -21,7 +21,7 @@ import world.gregs.voidps.engine.inv.remove
 import world.gregs.voidps.type.Tile
 import world.gregs.voidps.type.equals
 
-class Ectofuntus : Script {
+class NecrovarusTemple : Script {
     init {
         itemOnObjectOperate("bone_key_ghosts_ahoy", "ahoy_harbour_door_closed") { interaction ->
             if (!interaction.target.tile.equals(3656, 3514, 1)) {

--- a/game/src/main/kotlin/content/area/morytania/port_phasmatys/PortPhasmatysBarrier.kt
+++ b/game/src/main/kotlin/content/area/morytania/port_phasmatys/PortPhasmatysBarrier.kt
@@ -2,26 +2,68 @@ package content.area.morytania.port_phasmatys
 
 import world.gregs.voidps.engine.Script
 import world.gregs.voidps.engine.client.message
+import world.gregs.voidps.engine.data.definition.Areas
+import world.gregs.voidps.engine.entity.character.player.Player
 import world.gregs.voidps.engine.entity.character.player.chat.ChatType
+import world.gregs.voidps.engine.entity.obj.GameObject
+import world.gregs.voidps.engine.inv.inventory
+import world.gregs.voidps.engine.inv.remove
 import world.gregs.voidps.type.Tile
 
+/**
+ * The barrier transforms once Ghosts Ahoy is complete; before then it offers a toll of two
+ * ecto-tokens, afterwards it can only be passed and is always free.
+ */
 class PortPhasmatysBarrier : Script {
 
     init {
-        objectOperate("Pass", "phasmatys_barrier") { (target) ->
+        objectOperate("Pass", "phasmatys_barrier_north") { (target) ->
 //            https://youtu.be/PrkWAZmuEnw?si=T86lk1tMR91q2fjv&t=150
-            message("All visitors to Port Phasmatys must pay a toll charge of 2 Ectotockens. However, you have done the ghosts of our town a service that surpasses all values, so you may pass without charge.", ChatType.Filter)
-            if (target.rotation == 2) {
-                val x = if (tile.x <= target.tile.x) target.tile.x + 1 else target.tile.x
-                val y = tile.y.coerceIn(target.tile.y, target.tile.y + 1)
-                walkOverDelay(tile.copy(y = y))
-                walkOverDelay(Tile(x, y))
-            } else if (target.rotation == 3) {
-                val x = tile.x.coerceIn(target.tile.x, target.tile.x + 1)
-                val y = if (tile.y >= target.tile.y) target.tile.y - 1 else target.tile.y
-                walkOverDelay(tile.copy(x = x))
-                walkOverDelay(Tile(x, y))
-            }
+            message("All visitors to Port Phasmatys must pay a toll charge of 2 Ectotokens. However, you have done the ghosts of our town a service that surpasses all values, so you may pass without charge.", ChatType.Filter)
+            cross(target)
         }
+
+        objectOperate("Pass", "phasmatys_barrier") { (target) ->
+            if (!leaving()) {
+                message("All visitors to Port Phasmatys must pay a toll charge of 2 Ectotokens.", ChatType.Filter)
+                return@objectOperate
+            }
+            cross(target)
+        }
+
+        objectOperate("Pay-toll(2-Ecto)", "phasmatys_barrier") { (target) ->
+            if (leaving()) {
+                cross(target)
+                return@objectOperate
+            }
+            if (!inventory.remove("ecto_token", TOLL)) {
+                message("All visitors to Port Phasmatys must pay a toll charge of 2 Ectotokens.", ChatType.Filter)
+                message("You need to go to the Temple and earn some. Talk to the disciples - they will tell you how.", ChatType.Filter)
+                return@objectOperate
+            }
+            message("You pay the toll charge of 2 Ectotokens.", ChatType.Filter)
+            cross(target)
+        }
+    }
+
+    /** The toll is only charged on the way in; leaving the city is always free. */
+    private fun Player.leaving(): Boolean = tile in Areas["port_phasmatys"]
+
+    private suspend fun Player.cross(target: GameObject) {
+        if (target.rotation == 2) {
+            val x = if (tile.x <= target.tile.x) target.tile.x + 1 else target.tile.x
+            val y = tile.y.coerceIn(target.tile.y, target.tile.y + 1)
+            walkOverDelay(tile.copy(y = y))
+            walkOverDelay(Tile(x, y))
+        } else if (target.rotation == 3) {
+            val x = tile.x.coerceIn(target.tile.x, target.tile.x + 1)
+            val y = if (tile.y >= target.tile.y) target.tile.y - 1 else target.tile.y
+            walkOverDelay(tile.copy(x = x))
+            walkOverDelay(Tile(x, y))
+        }
+    }
+
+    companion object {
+        private const val TOLL = 2
     }
 }

--- a/game/src/main/kotlin/content/quest/member/ghosts_ahoy/Ectopool.kt
+++ b/game/src/main/kotlin/content/quest/member/ghosts_ahoy/Ectopool.kt
@@ -5,8 +5,10 @@ import world.gregs.voidps.engine.Script
 import world.gregs.voidps.engine.client.message
 import world.gregs.voidps.engine.entity.character.move.tele
 import world.gregs.voidps.engine.entity.character.player.Teleport
+import world.gregs.voidps.engine.entity.character.player.chat.ChatType
 import world.gregs.voidps.engine.entity.character.player.skill.Skill
 import world.gregs.voidps.engine.entity.character.player.skill.level.Level.has
+import world.gregs.voidps.engine.entity.character.sound
 import world.gregs.voidps.engine.get
 import world.gregs.voidps.engine.inv.inventory
 import world.gregs.voidps.engine.inv.replace
@@ -45,8 +47,14 @@ class Ectopool : Script {
             return@objTeleportTakeOff Teleport.CANCEL
         }
 
-        itemOnObjectOperate("bucket", "ahoy_new_green_floor") {
-            inventory.replace("bucket", "bucket_of_slime")
+        itemOnObjectOperate("bucket", "pool_of_slime*") {
+            while (inventory.contains("bucket")) {
+                anim("fill_bucket_slime")
+                sound("fill_ectoplasm")
+                inventory.replace("bucket", "bucket_of_slime")
+                delay(3)
+                message("You fill the bucket with ectoplasm.", ChatType.Filter)
+            }
         }
     }
 }

--- a/game/src/main/kotlin/content/skill/prayer/bone/BoneGrinder.kt
+++ b/game/src/main/kotlin/content/skill/prayer/bone/BoneGrinder.kt
@@ -1,0 +1,197 @@
+package content.skill.prayer.bone
+
+import content.entity.player.dialogue.type.choice
+import content.entity.player.dialogue.type.statement
+import net.pearx.kasechange.toLowerSpaceCase
+import world.gregs.voidps.engine.Script
+import world.gregs.voidps.engine.client.message
+import world.gregs.voidps.engine.data.config.RowDefinition
+import world.gregs.voidps.engine.data.definition.Tables
+import world.gregs.voidps.engine.entity.character.player.Player
+import world.gregs.voidps.engine.entity.character.sound
+import world.gregs.voidps.engine.entity.item.Item
+import world.gregs.voidps.engine.inv.inventory
+import world.gregs.voidps.engine.inv.remove
+import world.gregs.voidps.engine.inv.replace
+import world.gregs.voidps.engine.inv.transact.TransactionError
+import world.gregs.voidps.engine.inv.transact.operation.RemoveItem.remove
+import world.gregs.voidps.engine.inv.transact.operation.ReplaceItem.replace
+import world.gregs.voidps.engine.queue.weakQueue
+
+class BoneGrinder : Script {
+
+    init {
+        objectOperate("Fill", "ectofuntus_hopper") {
+            fill(null)
+        }
+
+        itemOnObjectOperate(obj = "ectofuntus_hopper") { (_, item) ->
+            fill(item)
+        }
+
+        objectOperate("Wind", "ectofuntus_bone_grinder") {
+            wind()
+        }
+
+        objectOperate("Empty", "ectofuntus_bin") {
+            empty()
+        }
+
+        objectOperate("Status", "ectofuntus_bone_grinder") {
+            status()
+        }
+
+        objectOperate("Settings", "ectofuntus_bone_grinder") {
+            settings()
+        }
+    }
+
+    private suspend fun Player.fill(item: Item?) {
+        if (get("bone_grinder_stage", 0) != EMPTY) {
+            message("You already have some bones in the hopper.")
+            return
+        }
+        if (item != null && Tables.intOrNull("bones.${item.id}.xp") != null && Tables.itemOrNull("bones.${item.id}.bonemeal") == null) {
+            statement("These bones could break the bone grinder. Perhaps I should find some different bones.")
+            return
+        }
+        val row = boneRow(item)
+        if (row == null) {
+            message("You have no bones to grind.")
+            return
+        }
+        if (get("bone_grinder_auto", false)) {
+            grind(row)
+            return
+        }
+        load(row)
+    }
+
+    private fun Player.load(row: RowDefinition) {
+        anim("fill_bone_hopper")
+        sound("fill_grinder")
+        if (!inventory.remove(row.rowId)) {
+            return
+        }
+        set("bone_grinder_bones", row.rowId)
+        set("bone_grinder_stage", HOPPER)
+        message("You fill the hopper with bones.")
+    }
+
+    private fun Player.wind() {
+        when (get("bone_grinder_stage", 0)) {
+            EMPTY -> {
+                message("You have no bones loaded to grind.")
+                return
+            }
+            BIN -> {
+                message("You already have some bonemeal that needs to be collected.")
+                return
+            }
+        }
+        anim("wind_bone_grinder")
+        sound("grinder_grinding")
+        set("bone_grinder_stage", BIN)
+        message("You wind the grinder handle.")
+        message("Some crushed bones pour into the bin.")
+    }
+
+    private fun Player.empty() {
+        if (get("bone_grinder_stage", 0) != BIN) {
+            message("You have no bonemeal to collect.")
+            return
+        }
+        if (!inventory.contains("empty_pot")) {
+            message("You don't have any pots to take the bonemeal with.")
+            return
+        }
+        val bones = get("bone_grinder_bones", "")
+        val bonemeal = Tables.itemOrNull("bones.$bones.bonemeal") ?: return
+        anim("empty_bone_bin")
+        sound("grinder_empty")
+        if (!inventory.replace("empty_pot", bonemeal)) {
+            return
+        }
+        set("bone_grinder_stage", EMPTY)
+        set("bone_grinder_bones", "")
+        message("You empty the bin into the pot.")
+    }
+
+    private fun Player.status() {
+        val mode = if (get("bone_grinder_auto", false)) "automatic" else "manual"
+        val state = when (get("bone_grinder_stage", 0)) {
+            HOPPER -> "There are ${get("bone_grinder_bones", "").toLowerSpaceCase()} in the hopper."
+            BIN -> "There is bonemeal waiting in the bin."
+            else -> "The grinder is empty."
+        }
+        message("$state The grinder is set to $mode.")
+    }
+
+    private suspend fun Player.settings() {
+        choice("How should the grinder operate?") {
+            option("Automatic.") {
+                set("bone_grinder_auto", true)
+                message("The grinder is now set to automatic.")
+            }
+            option("Manual.") {
+                set("bone_grinder_auto", false)
+                message("The grinder is now set to manual.")
+            }
+        }
+    }
+
+    /**
+     * Automatic mode; runs the fill, wind and empty steps unattended, repeating until the
+     * player runs out of either bones or empty pots.
+     */
+    private fun Player.grind(row: RowDefinition) {
+        if (!inventory.contains("empty_pot")) {
+            message("You don't have any pots to take the bonemeal with.")
+            return
+        }
+        anim("fill_bone_hopper")
+        sound("fill_grinder")
+        weakQueue("bone_grinder", GRIND_TICKS) {
+            anim("wind_bone_grinder")
+            sound("grinder_grinding")
+            weakQueue("bone_grinder", GRIND_TICKS) {
+                collect(row)
+            }
+        }
+    }
+
+    private fun Player.collect(row: RowDefinition) {
+        val bonemeal = row.item("bonemeal")
+        inventory.transaction {
+            remove(row.rowId)
+            replace("empty_pot", bonemeal)
+        }
+        if (inventory.transaction.error != TransactionError.None) {
+            return
+        }
+        anim("empty_bone_bin")
+        sound("grinder_empty")
+        message("You grind the ${row.rowId.toLowerSpaceCase()} into the pot.")
+        val next = boneRow(null) ?: return
+        grind(next)
+    }
+
+    private fun Player.boneRow(item: Item?): RowDefinition? {
+        if (item != null) {
+            val row = Tables.get("bones").rows().firstOrNull { it.rowId == item.id } ?: return null
+            row.itemOrNull("bonemeal") ?: return null
+            return row
+        }
+        return Tables.get("bones").rows().firstOrNull {
+            it.itemOrNull("bonemeal") ?: return@firstOrNull false
+            inventory.contains(it.rowId)
+        }
+    }
+
+    companion object {
+        private const val EMPTY = 0
+        private const val HOPPER = 1
+        private const val BIN = 2
+        private const val GRIND_TICKS = 3
+    }
+}

--- a/game/src/main/kotlin/content/skill/prayer/bone/Ectofuntus.kt
+++ b/game/src/main/kotlin/content/skill/prayer/bone/Ectofuntus.kt
@@ -1,0 +1,71 @@
+package content.skill.prayer.bone
+
+import world.gregs.voidps.engine.Script
+import world.gregs.voidps.engine.client.message
+import world.gregs.voidps.engine.data.config.RowDefinition
+import world.gregs.voidps.engine.data.definition.Tables
+import world.gregs.voidps.engine.entity.character.player.Player
+import world.gregs.voidps.engine.entity.character.player.skill.Skill
+import world.gregs.voidps.engine.entity.character.player.skill.exp.exp
+import world.gregs.voidps.engine.entity.character.sound
+import world.gregs.voidps.engine.entity.obj.GameObject
+import world.gregs.voidps.engine.inv.inventory
+import world.gregs.voidps.engine.inv.transact.TransactionError
+import world.gregs.voidps.engine.inv.transact.operation.ReplaceItem.replace
+
+class Ectofuntus : Script {
+
+    init {
+        objectOperate("Worship", "ectofuntus") { (target) ->
+            worship(target)
+        }
+    }
+
+    private fun Player.worship(target: GameObject) {
+        if (get("ectofuntus_charges", 0) >= MAXIMUM_CHARGES) {
+            message("The Ectofuntus is full.")
+            return
+        }
+        val row = bonemealRow()
+        val slime = inventory.contains("bucket_of_slime")
+        if (row == null && !slime) {
+            message("You don't have any ectoplasm or crushed bones to put into the Ectofuntus.")
+            return
+        }
+        if (row == null) {
+            message("You need a pot of crushed bones to put into the Ectofuntus.")
+            return
+        }
+        if (!slime) {
+            message("You need ectoplasm to put into the Ectofuntus.")
+            return
+        }
+        val bonemeal = row.item("bonemeal")
+        inventory.transaction {
+            replace("bucket_of_slime", "bucket")
+            replace(bonemeal, "empty_pot")
+        }
+        if (inventory.transaction.error != TransactionError.None) {
+            return
+        }
+        face(target)
+        anim("worship_ectofuntus")
+        sound("worship_ectofuntus")
+        exp(Skill.Prayer, row.int("xp") * MULTIPLIER / 10.0)
+        inc("ectofuntus_charges")
+        message("You put some ectoplasm and bonemeal into the Ectofuntus, and worship it.")
+    }
+
+    private fun Player.bonemealRow(): RowDefinition? = Tables.get("bones").rows().firstOrNull {
+        val bonemeal = it.itemOrNull("bonemeal") ?: return@firstOrNull false
+        inventory.contains(bonemeal)
+    }
+
+    companion object {
+        /** Worshipping gives four times the experience of burying the same bones. */
+        private const val MULTIPLIER = 4
+
+        /** Worships allowed before the tokens must be collected from a ghost disciple. */
+        const val MAXIMUM_CHARGES = 53
+    }
+}

--- a/game/src/test/kotlin/content/area/morytania/port_phasmatys/PortPhasmatysBarrierTest.kt
+++ b/game/src/test/kotlin/content/area/morytania/port_phasmatys/PortPhasmatysBarrierTest.kt
@@ -1,0 +1,75 @@
+package content.area.morytania.port_phasmatys
+
+import WorldTest
+import containsMessage
+import objectOption
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import world.gregs.voidps.engine.entity.obj.GameObjects
+import world.gregs.voidps.engine.inv.add
+import world.gregs.voidps.engine.inv.inventory
+import world.gregs.voidps.type.Tile
+import kotlin.test.assertTrue
+
+class PortPhasmatysBarrierTest : WorldTest() {
+
+    private val outside = Tile(3659, 3509)
+
+    private fun barrier() = GameObjects.find(Tile(3659, 3508), "phasmatys_barrier_base")
+
+    @Test
+    fun `Paying the toll costs two ecto-tokens`() {
+        val player = createPlayer(outside)
+        player.inventory.add("ecto_token", 5)
+
+        player.objectOption(barrier(), "Pay-toll(2-Ecto)")
+        tick(6)
+
+        assertEquals(3, player.inventory.count("ecto_token"))
+        assertTrue(player.containsMessage("You pay the toll charge of 2 Ectotokens."))
+    }
+
+    @Test
+    fun `Paying the toll without tokens is refused`() {
+        val player = createPlayer(outside)
+
+        player.objectOption(barrier(), "Pay-toll(2-Ecto)")
+        tick(6)
+
+        assertTrue(player.containsMessage("You need to go to the Temple and earn some."))
+        assertEquals(outside, player.tile)
+    }
+
+    @Test
+    fun `Passing without the quest asks for the toll`() {
+        val player = createPlayer(outside)
+
+        player.objectOption(barrier(), "Pass")
+        tick(6)
+
+        assertTrue(player.containsMessage("must pay a toll charge of 2 Ectotokens"))
+        assertEquals(outside, player.tile)
+    }
+
+    @Test
+    fun `Completing Ghosts Ahoy makes passage free`() {
+        val player = createPlayer(outside)
+        player.set("ghosts_ahoy", "completed")
+
+        player.objectOption(barrier(), "Pass")
+        tick(6)
+
+        assertTrue(player.containsMessage("you may pass without charge"))
+    }
+
+    @Test
+    fun `Leaving the city is free`() {
+        val player = createPlayer(Tile(3659, 3506))
+
+        player.objectOption(barrier(), "Pass")
+        tick(6)
+
+        assertEquals(Tile(3659, 3508), player.tile)
+        assertEquals(0, player.inventory.count("ecto_token"))
+    }
+}

--- a/game/src/test/kotlin/content/skill/prayer/EctofuntusTest.kt
+++ b/game/src/test/kotlin/content/skill/prayer/EctofuntusTest.kt
@@ -1,0 +1,206 @@
+package content.skill.prayer
+
+import WorldTest
+import containsMessage
+import dialogueOption
+import itemOnObject
+import npcOption
+import objectOption
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import world.gregs.voidps.engine.entity.character.player.Player
+import world.gregs.voidps.engine.entity.character.player.skill.Skill
+import world.gregs.voidps.engine.entity.obj.GameObject
+import world.gregs.voidps.engine.entity.obj.GameObjects
+import world.gregs.voidps.engine.inv.add
+import world.gregs.voidps.engine.inv.inventory
+import world.gregs.voidps.type.Tile
+import kotlin.test.assertTrue
+
+class EctofuntusTest : WorldTest() {
+
+    private fun ectofuntus(): GameObject = GameObjects.find(Tile(3658, 3518), "ectofuntus")
+
+    private fun hopper(): GameObject = GameObjects.find(Tile(3660, 3525, 1), "ectofuntus_hopper")
+
+    private fun mill(): GameObject = GameObjects.find(Tile(3659, 3525, 1), "ectofuntus_bone_grinder")
+
+    private fun bin(): GameObject = GameObjects.find(Tile(3658, 3525, 1), "ectofuntus_bin")
+
+    private fun grinderPlayer(setup: Player.() -> Unit): Player {
+        val player = createPlayer(Tile(3659, 3523, 1))
+        player.setup()
+        return player
+    }
+
+    private fun worshipper(setup: Player.() -> Unit): Player {
+        val player = createPlayer(Tile(3660, 3519))
+        player.setup()
+        return player
+    }
+
+    @Test
+    fun `Grind bones into bonemeal manually`() {
+        val player = grinderPlayer {
+            inventory.add("dragon_bones")
+            inventory.add("empty_pot")
+        }
+
+        player.objectOption(hopper(), "Fill")
+        tick(6)
+        assertEquals(1, player.get("bone_grinder_stage", 0))
+        assertEquals("dragon_bones", player.get("bone_grinder_bones", ""))
+        assertEquals(0, player.inventory.count("dragon_bones"))
+
+        player.objectOption(mill(), "Wind")
+        tick(6)
+        assertEquals(2, player.get("bone_grinder_stage", 0))
+
+        player.objectOption(bin(), "Empty")
+        tick(6)
+        assertEquals(1, player.inventory.count("dragon_bonemeal"))
+        assertEquals(0, player.inventory.count("empty_pot"))
+        assertEquals(0, player.get("bone_grinder_stage", 0))
+    }
+
+    @Test
+    fun `Automatic mode grinds every set of bones`() {
+        val player = grinderPlayer {
+            set("bone_grinder_auto", true)
+            repeat(5) {
+                inventory.add("big_bones")
+                inventory.add("empty_pot")
+            }
+        }
+
+        player.objectOption(hopper(), "Fill")
+        tick(60)
+
+        assertEquals(5, player.inventory.count("big_bonemeal"))
+        assertEquals(0, player.inventory.count("big_bones"))
+        assertEquals(0, player.inventory.count("empty_pot"))
+    }
+
+    @Test
+    fun `Grinder refuses bones that have no bonemeal`() {
+        val player = grinderPlayer {
+            inventory.add("curved_bone")
+            inventory.add("empty_pot")
+        }
+
+        player.objectOption(hopper(), "Fill")
+        tick(6)
+
+        assertEquals(0, player.get("bone_grinder_stage", 0))
+        assertEquals(1, player.inventory.count("curved_bone"))
+    }
+
+    @Test
+    fun `Worship gives four times the burying experience`() {
+        val player = worshipper {
+            inventory.add("dragon_bonemeal")
+            inventory.add("bucket_of_slime")
+        }
+
+        player.objectOption(ectofuntus(), "Worship")
+        tick(6)
+
+        assertEquals(288.0, player.experience.get(Skill.Prayer))
+        assertEquals(1, player.inventory.count("bucket"))
+        assertEquals(1, player.inventory.count("empty_pot"))
+        assertEquals(0, player.inventory.count("dragon_bonemeal"))
+        assertEquals(0, player.inventory.count("bucket_of_slime"))
+        assertEquals(1, player.get("ectofuntus_charges", 0))
+    }
+
+    @Test
+    fun `Worship without ectoplasm or bonemeal`() {
+        val player = worshipper {}
+
+        player.objectOption(ectofuntus(), "Worship")
+        tick(6)
+
+        assertTrue(player.containsMessage("You don't have any ectoplasm or crushed bones"))
+    }
+
+    @Test
+    fun `Worship without bonemeal`() {
+        val player = worshipper { inventory.add("bucket_of_slime") }
+
+        player.objectOption(ectofuntus(), "Worship")
+        tick(6)
+
+        assertTrue(player.containsMessage("You need a pot of crushed bones"))
+        assertEquals(1, player.inventory.count("bucket_of_slime"))
+    }
+
+    @Test
+    fun `Worship without ectoplasm`() {
+        val player = worshipper { inventory.add("dragon_bonemeal") }
+
+        player.objectOption(ectofuntus(), "Worship")
+        tick(6)
+
+        assertTrue(player.containsMessage("You need ectoplasm"))
+        assertEquals(1, player.inventory.count("dragon_bonemeal"))
+    }
+
+    @Test
+    fun `Worship is blocked once the Ectofuntus is full`() {
+        val player = worshipper {
+            set("ectofuntus_charges", 53)
+            inventory.add("dragon_bonemeal")
+            inventory.add("bucket_of_slime")
+        }
+
+        player.objectOption(ectofuntus(), "Worship")
+        tick(6)
+
+        assertTrue(player.containsMessage("The Ectofuntus is full."))
+        assertEquals(1, player.inventory.count("dragon_bonemeal"))
+        assertEquals(0.0, player.experience.get(Skill.Prayer))
+    }
+
+    @Test
+    fun `Collect five ecto-tokens for every worship`() {
+        val player = createPlayer(Tile(3656, 3517))
+        player.set("ectofuntus_charges", 3)
+        val disciple = createNPC("ahoy_disciple", Tile(3655, 3517))
+
+        player.npcOption(disciple, "Collect")
+        tick(6)
+
+        assertEquals(15, player.inventory.count("ecto_token"))
+        assertEquals(0, player.get("ectofuntus_charges", 0))
+    }
+
+    @Test
+    fun `Fill every bucket at the pool of slime`() {
+        val player = createPlayer(Tile(3683, 9887))
+        repeat(5) { player.inventory.add("bucket") }
+        val pool = GameObjects.find(Tile(3682, 9887), "pool_of_slime_4")
+
+        player.itemOnObject(pool, 0)
+        tick(30)
+
+        assertEquals(5, player.inventory.count("bucket_of_slime"))
+        assertEquals(0, player.inventory.count("bucket"))
+    }
+
+    @Test
+    fun `Settings switches the grinder between manual and automatic`() {
+        val player = grinderPlayer {}
+
+        player.objectOption(mill(), "Settings")
+        tick(6)
+        player.dialogueOption(1)
+        tick(2)
+        assertTrue(player.get("bone_grinder_auto", false))
+
+        player.objectOption(mill(), "Settings")
+        tick(6)
+        player.dialogueOption(2)
+        tick(2)
+        assertEquals(false, player.get("bone_grinder_auto", false))
+    }
+}


### PR DESCRIPTION
Adds the full Ectofuntus Prayer training loop: fill buckets at the ectopool, grind bones into pots of bonemeal at the grinder, worship the Ectofuntus for four times the burying experience, and collect ecto-tokens from a ghost disciple.

Most of the scenery was already in place from Ghosts Ahoy - the temple, the ectophial teleport and refill, the dungeon stairways, the agility 58 shortcut, the `ectofuntus` object and every bonemeal, slime and token item. What was missing was the activity itself.

Behaviour follows the 2011 article: https://runescape.wiki/w/Ectofuntus?oldid=3908798

## Worship

Clicking the Ectofuntus consumes a bucket of slime and a pot of bonemeal, returns the empty bucket and pot, and awards four times the experience the source bones would give when buried. Worship is blocked after 53 worships with "The Ectofuntus is full." until the ecto-tokens are collected.

## Bone grinder

Both modes the grinder offered in 2011:

- **Manual**: fill the hopper, wind the handle, empty the bin into a pot.
- **Automatic**: one click on the hopper grinds every set of bones in the inventory, a pot at a time.

The mode is switched with the grinder's `Settings` option and persists per player, as does the loaded bone type so the bin still knows which bonemeal to produce across a logout.

## Ghost disciples

Ghost disciples can now be spoken to for the Ectofuntus explanation, and pay out five ecto-tokens per worship either through dialogue or the `Collect` option. `Collect` deliberately does not require the ghostspeak amulet.

## Pool of slime

Using a bucket on the pool now fills every empty bucket in the inventory, with the correct animation and sound, rather than one at a time.

## Bone to bonemeal mapping

`bones.tables.toml` gains a `bonemeal` column so the grind output and the burying experience stay in one place. Curved and long bones have no bonemeal, so the grinder refuses them.

## Incidental fixes

- **Port Phasmatys barrier** transforms once Ghosts Ahoy is complete. Only the pre-quest object had a handler, so the free passage message could never be shown. Both transforms are now handled, and the toll uses the barrier's own `Pay-toll(2-Ecto)` option, costing two ecto-tokens when entering without the quest. Leaving the city is always free.
- **Object 17119** was declared as `ahoy_new_green_floor` but is a Pool of Slime. It is now declared alongside 17116-17118.
- **`Ectofuntus.kt`** in the port_phasmatys package only contained the temple door and coffin, so it is renamed to `NecrovarusTemple.kt` to free the name for the worship script.

## Testing

`EctofuntusTest` (11 tests) covers the manual grind cycle, automatic grinding of five sets, refusal of bones with no bonemeal, the `Settings` toggle both ways, worship experience and returned containers, the three missing-item guard messages, the 53 worship cap, token collection, and filling five buckets at the pool.

`PortPhasmatysBarrierTest` (5 tests) covers paying the toll, refusal without tokens, `Pass` asking for the toll before the quest, free passage after it, and free passage when leaving.

`gradle build` passes and the loop has been verified in game.

## Out of scope

Ecto-token sinks (ale yeast, the Dragontooth Island charter, the undead chicken) belong to separate NPCs and are left for a follow-up.

## Linked Issue
- Closes #1191 
