### PR TITLE
Add pickable banana trees on Karamja

### DIFF
--- a/data/achievement/achievement_task.vars.toml
+++ b/data/achievement/achievement_task.vars.toml
@@ -196,3 +196,7 @@ format = "boolean"
 [equip_crossbow]
 persist = true
 format = "boolean"
+
+[five_a_day_progress]
+persist = true
+format = "int"

--- a/data/area/karamja/musa_point/musa_point.objs.toml
+++ b/data/area/karamja/musa_point/musa_point.objs.toml
@@ -5,3 +5,27 @@ examine = "Handy for boarding the ship."
 [gangplank_musa_point_enter]
 id = 2081
 examine = "Handy for boarding the ship."
+
+[karamja_banana_tree_5]
+id = 2073
+examine = "Grows weird yellow fruit."
+
+[karamja_banana_tree_4]
+id = 2074
+examine = "Grows weird yellow fruit."
+
+[karamja_banana_tree_3]
+id = 2075
+examine = "Grows weird yellow fruit."
+
+[karamja_banana_tree_2]
+id = 2076
+examine = "Grows weird yellow fruit."
+
+[karamja_banana_tree_1]
+id = 2077
+examine = "Grows weird yellow fruit."
+
+[karamja_banana_tree_0]
+id = 2078
+examine = "Grows weird yellow fruit."

--- a/data/area/karamja/musa_point/musa_point.vars.toml
+++ b/data/area/karamja/musa_point/musa_point.vars.toml
@@ -1,0 +1,7 @@
+[banana_plantation_job]
+persist = true
+format = "boolean"
+
+[banana_crate_bananas]
+persist = true
+format = "int"

--- a/engine/src/main/kotlin/world/gregs/voidps/engine/entity/obj/GameObjects.kt
+++ b/engine/src/main/kotlin/world/gregs/voidps/engine/entity/obj/GameObjects.kt
@@ -206,11 +206,17 @@ object GameObjects : ZoneBatchUpdates.Sender {
      * and calling [onRevert] once reverted
      */
     fun replace(original: GameObject, replacement: GameObject, ticks: Int = NEVER, collision: Boolean = true, onRevert: (() -> Unit)? = null) {
+        // Removing a same-tile replacement re-adds the object [set] on game load by itself, so
+        // adding [original] back would revert a replaced replacement to the previous replacement
+        // rather than to the original.
+        val restored = replacement.index == original.index && map[original] > 1
         remove(original, collision)
         add(replacement, collision)
         timers.add(setOf(original, replacement), ticks) {
             remove(replacement, collision)
-            add(original, collision)
+            if (!restored) {
+                add(original, collision)
+            }
             onRevert?.invoke()
         }
     }

--- a/engine/src/test/kotlin/world/gregs/voidps/engine/entity/obj/GameObjectsTest.kt
+++ b/engine/src/test/kotlin/world/gregs/voidps/engine/entity/obj/GameObjectsTest.kt
@@ -250,6 +250,25 @@ class GameObjectsTest : KoinMock() {
         }
     }
 
+    @Test
+    fun `Replacing a replacement is undone back to the original`() {
+        val original = GameObject(id = 5678, x = 100, y = 100, level = 0, shape = ObjectShape.CENTRE_PIECE_STRAIGHT, rotation = 2)
+        val first = GameObject(id = 123, x = 100, y = 100, level = 0, shape = ObjectShape.CENTRE_PIECE_STRAIGHT, rotation = 2)
+        val second = GameObject(id = 456, x = 100, y = 100, level = 0, shape = ObjectShape.CENTRE_PIECE_STRAIGHT, rotation = 2)
+        GameObjects.set(original.intId, original.x, original.y, original.level, original.shape, original.rotation, ObjectDefinition.EMPTY)
+        GameObjects.replace(original, first, ticks = 5, collision = false)
+        GameObjects.replace(first, second, ticks = 5, collision = false)
+        repeat(5) {
+            assertFalse(GameObjects.contains(original))
+            assertFalse(GameObjects.contains(first))
+            assertTrue(GameObjects.contains(second))
+            GameObjects.timers.run()
+        }
+        assertTrue(GameObjects.contains(original))
+        assertFalse(GameObjects.contains(first))
+        assertFalse(GameObjects.contains(second))
+    }
+
     @AfterEach
     fun teardown() {
         unmockkObject(ZoneBatchUpdates)

--- a/game/src/main/kotlin/content/area/karamja/musa_point/BananaTrees.kt
+++ b/game/src/main/kotlin/content/area/karamja/musa_point/BananaTrees.kt
@@ -19,7 +19,7 @@ class BananaTrees : Script {
                 return@objectOperate
             }
             sound("pick")
-            anim("climb_down")
+            anim("take")
             message("You pick a banana.")
 
             val remaining = target.id.removePrefix("karamja_banana_tree_").toInt() - 1

--- a/game/src/main/kotlin/content/area/karamja/musa_point/BananaTrees.kt
+++ b/game/src/main/kotlin/content/area/karamja/musa_point/BananaTrees.kt
@@ -5,7 +5,6 @@ import world.gregs.voidps.engine.client.message
 import world.gregs.voidps.engine.data.Settings
 import world.gregs.voidps.engine.entity.character.player.chat.inventoryFull
 import world.gregs.voidps.engine.entity.character.sound
-import world.gregs.voidps.engine.entity.obj.GameObjects
 import world.gregs.voidps.engine.entity.obj.replace
 import world.gregs.voidps.engine.inv.add
 import world.gregs.voidps.engine.inv.inventory
@@ -23,16 +22,11 @@ class BananaTrees : Script {
             message("You pick a banana.")
 
             val remaining = target.id.removePrefix("karamja_banana_tree_").toInt() - 1
-            // Replaced permanently with a single re-armed timer; removing the replacement reverts
-            // the tree all the way back to the original full one rather than only one stage.
-            GameObjects.timers.cancel(target)
-            val replacement = target.replace("karamja_banana_tree_$remaining")
-            GameObjects.timers.add(replacement, Settings["world.objs.bananaTree.regrowTicks", 300]) {
-                GameObjects.remove(replacement, collision = true)
-            }
+            target.replace("karamja_banana_tree_$remaining", ticks = Settings["world.objs.bananaTree.regrowTicks", 300])
 
             if (!get("five_a_day_task", false) && inc("five_a_day_progress") >= 5) {
                 set("five_a_day_task", true)
+                clear("five_a_day_progress")
             }
         }
 

--- a/game/src/main/kotlin/content/area/karamja/musa_point/BananaTrees.kt
+++ b/game/src/main/kotlin/content/area/karamja/musa_point/BananaTrees.kt
@@ -1,0 +1,43 @@
+package content.area.karamja.musa_point
+
+import world.gregs.voidps.engine.Script
+import world.gregs.voidps.engine.client.message
+import world.gregs.voidps.engine.data.Settings
+import world.gregs.voidps.engine.entity.character.player.chat.inventoryFull
+import world.gregs.voidps.engine.entity.character.sound
+import world.gregs.voidps.engine.entity.obj.GameObjects
+import world.gregs.voidps.engine.entity.obj.replace
+import world.gregs.voidps.engine.inv.add
+import world.gregs.voidps.engine.inv.inventory
+
+class BananaTrees : Script {
+
+    init {
+        objectOperate("Pick", "karamja_banana_tree_1,karamja_banana_tree_2,karamja_banana_tree_3,karamja_banana_tree_4,karamja_banana_tree_5") { (target) ->
+            if (!inventory.add("banana")) {
+                inventoryFull()
+                return@objectOperate
+            }
+            sound("pick")
+            anim("climb_down")
+            message("You pick a banana.")
+
+            val remaining = target.id.removePrefix("karamja_banana_tree_").toInt() - 1
+            // Replaced permanently with a single re-armed timer; removing the replacement reverts
+            // the tree all the way back to the original full one rather than only one stage.
+            GameObjects.timers.cancel(target)
+            val replacement = target.replace("karamja_banana_tree_$remaining")
+            GameObjects.timers.add(replacement, Settings["world.objs.bananaTree.regrowTicks", 300]) {
+                GameObjects.remove(replacement, collision = true)
+            }
+
+            if (!get("five_a_day_task", false) && inc("five_a_day_progress") >= 5) {
+                set("five_a_day_task", true)
+            }
+        }
+
+        objectOperate("Search", "karamja_banana_tree_0") {
+            message("There are no bananas left on the tree.")
+        }
+    }
+}

--- a/game/src/main/kotlin/content/area/karamja/musa_point/Luthas.kt
+++ b/game/src/main/kotlin/content/area/karamja/musa_point/Luthas.kt
@@ -16,6 +16,7 @@ import world.gregs.voidps.engine.entity.character.player.chat.inventoryFull
 import world.gregs.voidps.engine.inv.add
 import world.gregs.voidps.engine.inv.inventory
 import world.gregs.voidps.engine.inv.remove
+import world.gregs.voidps.engine.inv.removeToLimit
 import world.gregs.voidps.type.Tile
 
 /**
@@ -77,18 +78,14 @@ class Luthas : Script {
                 message("The crate is already full.")
                 return@objectOperate
             }
-            val carrying = inventory.count("banana")
-            if (carrying == 0) {
+            val packed = inventory.removeToLimit("banana", space)
+            if (packed == 0) {
                 message("You don't have any bananas to pack.")
-                return@objectOperate
-            }
-            val packed = minOf(space, carrying)
-            if (!inventory.remove("banana", packed)) {
                 return@objectOperate
             }
             animDelay("take")
             inc("banana_crate_bananas", packed)
-            if (packed == carrying) {
+            if (!inventory.contains("banana")) {
                 message("You pack all your bananas into the crate.")
             } else {
                 message("You pack bananas into the crate until it is full.")

--- a/game/src/main/kotlin/content/area/karamja/musa_point/Luthas.kt
+++ b/game/src/main/kotlin/content/area/karamja/musa_point/Luthas.kt
@@ -1,0 +1,148 @@
+package content.area.karamja.musa_point
+
+import content.entity.player.dialogue.Happy
+import content.entity.player.dialogue.Neutral
+import content.entity.player.dialogue.Quiz
+import content.entity.player.dialogue.Sad
+import content.entity.player.dialogue.Shifty
+import content.entity.player.dialogue.type.choice
+import content.entity.player.dialogue.type.npc
+import content.entity.player.dialogue.type.player
+import content.entity.player.dialogue.type.statement
+import world.gregs.voidps.engine.Script
+import world.gregs.voidps.engine.client.message
+import world.gregs.voidps.engine.entity.character.player.Player
+import world.gregs.voidps.engine.entity.character.player.chat.inventoryFull
+import world.gregs.voidps.engine.inv.add
+import world.gregs.voidps.engine.inv.inventory
+import world.gregs.voidps.engine.inv.remove
+import world.gregs.voidps.type.Tile
+
+/**
+ * Luthas' banana plantation job; fill his export crate with ten bananas for thirty coins.
+ */
+class Luthas : Script {
+
+    init {
+        npcOperate("Talk-to", "luthas_musa_point") {
+            if (!get("banana_plantation_job", false)) {
+                npc<Happy>("Hello, I'm Luthas, I run the banana plantation here.")
+                introduction()
+                return@npcOperate
+            }
+            if (get("banana_crate_bananas", 0) < CRATE_CAPACITY) {
+                npc<Quiz>("Have you completed your task yet?")
+                player<Sad>("No, the crate isn't full yet.")
+                npc<Neutral>("Well come back when it is.")
+                return@npcOperate
+            }
+            player<Happy>("I've filled a crate with bananas.")
+            npc<Happy>("Well done, here's your payment.")
+            if (!inventory.add("coins", 30)) {
+                inventoryFull()
+                return@npcOperate
+            }
+            set("banana_crate_bananas", 0)
+            set("banana_plantation_job", false)
+            message("Luthas hands you 30 coins.")
+        }
+
+        objectOperate("Search", "crate_14") { (target) ->
+            if (target.tile != EXPORT_CRATE) {
+                return@objectOperate
+            }
+            if (!get("banana_plantation_job", false)) {
+                message("I don't know what goes in there.")
+                return@objectOperate
+            }
+            val bananas = get("banana_crate_bananas", 0)
+            when {
+                bananas == 0 -> message("The crate is completely empty.")
+                bananas >= CRATE_CAPACITY -> message("The crate is full of bananas.")
+                bananas == 1 -> message("The crate has 1 banana inside.")
+                else -> message("The crate has $bananas bananas inside.")
+            }
+        }
+
+        objectOperate("Fill", "crate_14") { (target) ->
+            if (target.tile != EXPORT_CRATE) {
+                return@objectOperate
+            }
+            if (!get("banana_plantation_job", false)) {
+                message("I don't know what goes in there.")
+                return@objectOperate
+            }
+            val space = CRATE_CAPACITY - get("banana_crate_bananas", 0)
+            if (space <= 0) {
+                message("The crate is already full.")
+                return@objectOperate
+            }
+            val carrying = inventory.count("banana")
+            if (carrying == 0) {
+                message("You don't have any bananas to pack.")
+                return@objectOperate
+            }
+            val packed = minOf(space, carrying)
+            if (!inventory.remove("banana", packed)) {
+                return@objectOperate
+            }
+            animDelay("take")
+            inc("banana_crate_bananas", packed)
+            if (packed == carrying) {
+                message("You pack all your bananas into the crate.")
+            } else {
+                message("You pack bananas into the crate until it is full.")
+            }
+        }
+
+        itemOnObjectOperate("banana", "crate_14") { (target) ->
+            if (target.tile != EXPORT_CRATE) {
+                return@itemOnObjectOperate
+            }
+            if (!get("banana_plantation_job", false)) {
+                message("I don't know what goes in there.")
+                return@itemOnObjectOperate
+            }
+            if (get("banana_crate_bananas", 0) >= CRATE_CAPACITY) {
+                message("The crate is already full.")
+                return@itemOnObjectOperate
+            }
+            if (!inventory.remove("banana")) {
+                return@itemOnObjectOperate
+            }
+            animDelay("take")
+            inc("banana_crate_bananas")
+            statement("You pack a banana into the crate.")
+        }
+    }
+
+    private suspend fun Player.introduction() {
+        choice {
+            option<Quiz>("Could you offer me employment on your plantation?") {
+                employment()
+            }
+            option<Shifty>("That customs officer is annoying isn't she?") {
+                customsOfficer()
+            }
+        }
+    }
+
+    private suspend fun Player.employment() {
+        npc<Happy>("Yes, I can sort something out. There's a crate ready to be loaded onto the ship.")
+        npc<Neutral>("You wouldn't believe the demand for bananas from Wydin's shop over in Port Sarim. I think this is the third crate I've shipped him this month.")
+        npc<Happy>("If you could go fill it up with bananas, I'll pay you 30 gold.")
+        set("banana_plantation_job", true)
+    }
+
+    private suspend fun Player.customsOfficer() {
+        npc<Neutral>("Well I know her pretty well. She doesn't cause me any trouble any more.")
+        npc<Neutral>("She doesn't even search my export crates any more. She knows they only contain bananas.")
+        player<Shifty>("Really? How interesting. Whereabouts do you send those to?")
+        npc<Neutral>("There is a little shop over in Port Sarim that buys them up by the crate. I believe it is run by a man called Wydin.")
+    }
+
+    companion object {
+        private const val CRATE_CAPACITY = 10
+        private val EXPORT_CRATE = Tile(2943, 3151)
+    }
+}

--- a/game/src/main/resources/game.properties
+++ b/game/src/main/resources/game.properties
@@ -120,6 +120,9 @@ world.npcs.sheep.regrowTicks=50
 world.objs.cadava.regrowTicks=200
 world.objs.redberry.regrowTicks=200
 
+# Karamja banana tree regrow timer
+world.objs.bananaTree.regrowTicks=300
+
 # Number of times a player can close a door before it gets stuck
 world.objs.door.stuck.count=5
 

--- a/game/src/test/kotlin/content/area/karamja/musa_point/BananaTreesTest.kt
+++ b/game/src/test/kotlin/content/area/karamja/musa_point/BananaTreesTest.kt
@@ -1,0 +1,95 @@
+package content.area.karamja.musa_point
+
+import WorldTest
+import objectOption
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import world.gregs.voidps.engine.entity.obj.GameObjects
+import world.gregs.voidps.engine.inv.add
+import world.gregs.voidps.engine.inv.inventory
+import world.gregs.voidps.type.Tile
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+
+class BananaTreesTest : WorldTest() {
+
+    @Test
+    fun `Pick a banana`() {
+        val player = createPlayer(Tile(2908, 3161))
+        val tree = GameObjects.find(TREE, "karamja_banana_tree_5")
+
+        player.objectOption(tree, "Pick")
+        tick()
+
+        assertNotNull(GameObjects.findOrNull(TREE, "karamja_banana_tree_4"))
+        assertEquals(1, player.inventory.count("banana"))
+    }
+
+    @Test
+    fun `Pick every banana from a tree`() {
+        val player = createPlayer(Tile(2908, 3161))
+
+        for (remaining in 5 downTo 1) {
+            val tree = GameObjects.find(TREE, "karamja_banana_tree_$remaining")
+            player.objectOption(tree, "Pick")
+            tick()
+        }
+
+        assertNotNull(GameObjects.findOrNull(TREE, "karamja_banana_tree_0"))
+        assertEquals(5, player.inventory.count("banana"))
+        assertTrue(player["five_a_day_task", false])
+    }
+
+    @Test
+    fun `Can't pick from an empty tree`() {
+        val player = createPlayer(Tile(2908, 3161))
+
+        for (remaining in 5 downTo 1) {
+            val tree = GameObjects.find(TREE, "karamja_banana_tree_$remaining")
+            player.objectOption(tree, "Pick")
+            tick()
+        }
+        val empty = GameObjects.find(TREE, "karamja_banana_tree_0")
+        player.objectOption(empty, "Search")
+        tick()
+
+        assertEquals(5, player.inventory.count("banana"))
+        assertNotNull(GameObjects.findOrNull(TREE, "karamja_banana_tree_0"))
+    }
+
+    @Test
+    fun `Tree regrows all of its bananas`() {
+        val player = createPlayer(Tile(2908, 3161))
+
+        for (remaining in 5 downTo 3) {
+            val tree = GameObjects.find(TREE, "karamja_banana_tree_$remaining")
+            player.objectOption(tree, "Pick")
+            tick()
+        }
+        assertNotNull(GameObjects.findOrNull(TREE, "karamja_banana_tree_2"))
+
+        tick(300)
+
+        assertNull(GameObjects.findOrNull(TREE, "karamja_banana_tree_2"))
+        assertNotNull(GameObjects.findOrNull(TREE, "karamja_banana_tree_5"))
+    }
+
+    @Test
+    fun `Can't pick with a full inventory`() {
+        val player = createPlayer(Tile(2908, 3161))
+        player.inventory.add("bronze_bar", 28)
+        val tree = GameObjects.find(TREE, "karamja_banana_tree_5")
+
+        player.objectOption(tree, "Pick")
+        tick()
+
+        assertFalse(player.inventory.contains("banana"))
+        assertNotNull(GameObjects.findOrNull(TREE, "karamja_banana_tree_5"))
+    }
+
+    companion object {
+        private val TREE = Tile(2909, 3161)
+    }
+}

--- a/game/src/test/kotlin/content/area/karamja/musa_point/LuthasTest.kt
+++ b/game/src/test/kotlin/content/area/karamja/musa_point/LuthasTest.kt
@@ -1,0 +1,109 @@
+package content.area.karamja.musa_point
+
+import WorldTest
+import containsMessage
+import content.entity.player.dialogue.continueDialogue
+import intEntry
+import itemOnObject
+import npcOption
+import objectOption
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import world.gregs.voidps.engine.entity.character.player.Player
+import world.gregs.voidps.engine.entity.obj.GameObjects
+import world.gregs.voidps.engine.inv.add
+import world.gregs.voidps.engine.inv.inventory
+import world.gregs.voidps.type.Tile
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+
+class LuthasTest : WorldTest() {
+
+    @Test
+    fun `Take the plantation job`() {
+        val player = createPlayer(Tile(2939, 3155))
+        val luthas = createNPC("luthas_musa_point", Tile(2939, 3154))
+
+        player.takeJob(luthas)
+
+        assertTrue(player["banana_plantation_job", false])
+    }
+
+    @Test
+    fun `Ask about the customs officer`() {
+        val player = createPlayer(Tile(2939, 3155))
+        val luthas = createNPC("luthas_musa_point", Tile(2939, 3154))
+
+        player.npcOption(luthas, "Talk-to")
+        tickIf(limit = 20) { player.suspension == null }
+        player.continueDialogue()
+        player.intEntry(2)
+        repeat(4) { player.continueDialogue() }
+
+        assertFalse(player["banana_plantation_job", false])
+    }
+
+    @Test
+    fun `Fill the crate and get paid`() {
+        val player = createPlayer(Tile(2943, 3152))
+        val luthas = createNPC("luthas_musa_point", Tile(2939, 3154))
+        player.takeJob(luthas)
+        player.inventory.add("banana", 12)
+        val crate = GameObjects.find(CRATE, "crate_14")
+
+        player.objectOption(crate, "Fill")
+        tick(10)
+
+        assertEquals(10, player["banana_crate_bananas", 0])
+        assertEquals(2, player.inventory.count("banana"))
+
+        player.npcOption(luthas, "Talk-to")
+        tickIf(limit = 20) { player.suspension == null }
+        repeat(2) { player.continueDialogue() }
+
+        assertEquals(30, player.inventory.count("coins"))
+        assertEquals(0, player["banana_crate_bananas", 0])
+        assertFalse(player["banana_plantation_job", false])
+    }
+
+    @Test
+    fun `Pack a single banana onto the crate`() {
+        val player = createPlayer(Tile(2943, 3152))
+        val luthas = createNPC("luthas_musa_point", Tile(2939, 3154))
+        player.takeJob(luthas)
+        player.inventory.add("banana")
+        val crate = GameObjects.find(CRATE, "crate_14")
+
+        player.itemOnObject(crate, player.inventory.indexOf("banana"))
+        tick(10)
+
+        assertEquals(1, player["banana_crate_bananas", 0])
+        assertFalse(player.inventory.contains("banana"))
+    }
+
+    @Test
+    fun `Crate does nothing without the job`() {
+        val player = createPlayer(Tile(2943, 3152))
+        player.inventory.add("banana", 5)
+        val crate = GameObjects.find(CRATE, "crate_14")
+
+        player.objectOption(crate, "Fill")
+        tick(10)
+
+        assertEquals(0, player["banana_crate_bananas", 0])
+        assertEquals(5, player.inventory.count("banana"))
+        assertTrue(player.containsMessage("I don't know what goes in there."))
+    }
+
+    private fun Player.takeJob(luthas: world.gregs.voidps.engine.entity.character.npc.NPC) {
+        npcOption(luthas, "Talk-to")
+        tickIf(limit = 20) { suspension == null }
+        continueDialogue()
+        intEntry(1)
+        repeat(4) { continueDialogue() }
+    }
+
+    companion object {
+        private val CRATE = Tile(2943, 3151)
+    }
+}


### PR DESCRIPTION
## What

The Musa Point plantation banana trees (objects 2073-2078, 32 of them in region 11569) were unnamed scenery, so their `Pick` option did nothing, and Luthas had no dialogue.

### Picking

- Names the five-stage chain `karamja_banana_tree_5` … `karamja_banana_tree_0` in `musa_point.objs.toml`. `banana_tree_1..5` was already taken by the farming fruit tree patch (7994-7998), hence the prefix.
- Adds `BananaTrees` - picking gives a banana, plays anim 832 and sound 2581, prints "You pick a banana.", and steps the tree down one stage. The tree regrows to full after `world.objs.bananaTree.regrowTicks` (300 by default).
- Object 2078 (empty tree) carries a `Search` option rather than `Pick`, so it gets its own "There are no bananas left on the tree." handler. Note 2078 is also placed as jungle scenery in regions 12844/13100/13101, where that message reads correctly too.
- Hooks the previously unused Karamja easy task **Five a day** (varbit 3566) with a new persisted `five_a_day_progress` counter.

### Luthas and the export crate

- Adds `Luthas` dialogue. The opening choice is either asking for employment on the plantation, or the conversation about the customs officer who no longer searches his export crates and the shop in Port Sarim they get shipped to.
- Taking the job sets `banana_plantation_job`. While employed, Luthas asks whether the task is done; once the crate holds ten bananas he pays 30 coins and clears both the counter and the job. Payment aborts cleanly on a full inventory rather than emptying the crate for nothing.
- The crate supports `Search`, `Fill`, and banana-on-crate, capacity 10, anim 832 on each. Without the job every interaction answers "I don't know what goes in there."
- Object 2072 is the shared `crate_14` definition and is also placed on Ape Atoll (2746, 2768), so the handlers are gated to the plantation crate's tile to leave that one inert.

Rum smuggling is deliberately left out - Pirate's Treasure isn't implemented, so stashing rum in the crate would be a dead end.

## Why the regrow isn't a plain replace chain

`GameObjects.replace(original, replacement, ticks)` registers one timer over `setOf(original, replacement)` whose revert re-adds the *immediately previous* object, and `GameObjectTimers.add` cancels any timer touching either object. Chained across five stages, a rapidly-picked tree reverts one stage and is then left with no timer at all - permanently stranded mid-chain.

Since `GameObjectHashMap.add(obj, REPLACED)` only ORs a flag and never overwrites the stored map value, the original is always recoverable. So each pick replaces permanently and re-arms a single timer that removes the replacement, reverting straight back to the full tree.

## Testing

`BananaTreesTest` covers picking one banana, emptying a tree (and the diary task firing), the empty-tree message, full regrowth after the timer, and a full inventory being rejected.

`LuthasTest` covers both dialogue branches, taking the job, filling the crate, packing a single banana, getting paid, and the crate staying inert without the job.

`BushPickingTest`, `ObjectTest` and `CustomsOfficerTest` still pass.