### PR TITLE
Rat activity for bots

### DIFF
--- a/data/area/misthalin/lumbridge/lumbridge.bots.toml
+++ b/data/area/misthalin/lumbridge/lumbridge.bots.toml
@@ -1,4 +1,19 @@
 # Combat
+[kill_lumbridge_castle_rats_attack]
+template = "kill_rats"
+capacity = 2
+fields = { skill = "attack", location = "lumbridge_castle_courtyard", style = "style1" }
+
+[kill_lumbridge_castle_rats_strength]
+template = "kill_rats"
+capacity = 2
+fields = { skill = "strength", location = "lumbridge_castle_courtyard", style = "style2" }
+
+[kill_lumbridge_castle_rats_defence]
+template = "kill_rats"
+capacity = 2
+fields = { skill = "attack", location = "lumbridge_castle_courtyard", style = "style4" }
+
 [kill_freds_chickens_attack]
 template = "kill_chickens"
 capacity = 2

--- a/data/bot/combat.templates.toml
+++ b/data/bot/combat.templates.toml
@@ -1,3 +1,23 @@
+[kill_rats]
+requires = [
+    { skill = { id = "$skill", min = 1, max = 5 } },
+]
+setup = [
+    { equipment = { weapon = { id = "bronze_sword,bronze_dagger,bronze_scimitar" } } },
+    { area = { id = "$location" } },
+    { inventory = { id = "empty", min = 27 } },
+]
+actions = [
+    { interface = { option = "Select", id = "combat_styles:$style" } },
+    { npc = { option = "Attack", id = "rat", delay = 5, success = { inventory = { id = "empty", max = 0 } } } },
+]
+reactive = [
+    { eat = { heal_percent = 20 } }
+]
+produces = [
+    { skill = "$skill" }
+]
+
 [kill_chickens]
 requires = [
     { skill = { id = "$skill", min = 1, max = 5 } },


### PR DESCRIPTION
Added a kill_rats template to the combat.template.toml
Added kill_lumbridge_castle_rats_* for attack, defence, and strength.

Made the limit 2, though from early testing it might be able to be raised to 3 with little issues.