### PR TITLE
Fix SaveQueue scope dying after a failed save and overlapping tick saves

### DIFF
--- a/engine/src/main/kotlin/world/gregs/voidps/engine/data/Reports.kt
+++ b/engine/src/main/kotlin/world/gregs/voidps/engine/data/Reports.kt
@@ -5,6 +5,7 @@ import kotlinx.coroutines.CoroutineExceptionHandler
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.NonCancellable
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 
@@ -14,7 +15,8 @@ import kotlinx.coroutines.withContext
 class Reports(
     private val storage: Storage,
     private val fallback: Storage = storage,
-    private val scope: CoroutineScope = CoroutineScope(Dispatchers.IO),
+    // SupervisorJob so a failed save doesn't cancel the scope and kill future saves
+    private val scope: CoroutineScope = CoroutineScope(Dispatchers.IO + SupervisorJob()),
 ) {
     private val logger = InlineLogger()
 

--- a/engine/src/main/kotlin/world/gregs/voidps/engine/data/SaveQueue.kt
+++ b/engine/src/main/kotlin/world/gregs/voidps/engine/data/SaveQueue.kt
@@ -12,10 +12,12 @@ import kotlin.system.measureTimeMillis
 class SaveQueue(
     private val storage: Storage,
     private val fallback: Storage = storage,
-    private val scope: CoroutineScope = CoroutineScope(Dispatchers.IO),
+    // SupervisorJob so a failed save doesn't cancel the scope and kill future saves
+    private val scope: CoroutineScope = CoroutineScope(Dispatchers.IO + SupervisorJob()),
 ) : Runnable {
     private val pending = ConcurrentHashMap<String, PlayerSave>()
     private val logger = InlineLogger()
+    private var job: Job? = null
 
     private val handler = CoroutineExceptionHandler { _, exception ->
         logger.error(exception) { "Error saving players!" }
@@ -29,7 +31,11 @@ class SaveQueue(
         if (pending.isEmpty()) {
             return
         }
-        scope.save(pending.values.toList())
+        val job = job
+        if (job != null && job.isActive) {
+            return
+        }
+        this.job = scope.save(pending.values.toList())
     }
 
     fun direct(): Job = scope.save(Players.filter { !it.contains("bot") }.map { it.copy() })

--- a/engine/src/test/kotlin/world/gregs/voidps/engine/data/SaveQueueTest.kt
+++ b/engine/src/test/kotlin/world/gregs/voidps/engine/data/SaveQueueTest.kt
@@ -1,0 +1,118 @@
+package world.gregs.voidps.engine.data
+
+import org.junit.jupiter.api.Test
+import world.gregs.voidps.engine.data.config.AccountDefinition
+import world.gregs.voidps.engine.data.exchange.Claim
+import world.gregs.voidps.engine.data.exchange.OpenOffers
+import world.gregs.voidps.engine.data.exchange.PriceHistory
+import world.gregs.voidps.engine.entity.character.player.Player
+import world.gregs.voidps.engine.entity.character.player.chat.clan.Clan
+import world.gregs.voidps.engine.script.KoinMock
+import java.io.IOException
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+internal class SaveQueueTest : KoinMock() {
+
+    private open class TestStorage : Storage {
+        override fun names(): Map<String, AccountDefinition> = emptyMap()
+
+        override fun clans(): Map<String, Clan> = emptyMap()
+
+        override fun save(accounts: List<PlayerSave>) {
+        }
+
+        override fun offers(days: Int): OpenOffers = OpenOffers()
+
+        override fun saveOffers(offers: OpenOffers) {
+        }
+
+        override fun claims(): Map<Int, Claim> = emptyMap()
+
+        override fun saveClaims(claims: Map<Int, Claim>) {
+        }
+
+        override fun priceHistory(): Map<String, PriceHistory> = emptyMap()
+
+        override fun savePriceHistory(history: Map<String, PriceHistory>) {
+        }
+
+        override fun saveReport(report: AbuseReport) {
+        }
+
+        override fun exists(accountName: String): Boolean = false
+
+        override fun load(accountName: String): PlayerSave? = null
+    }
+
+    @Test
+    fun `Failed save falls back and doesn't kill the queue`() {
+        val fallbackSaved = CountDownLatch(1)
+        val saved = CountDownLatch(1)
+        var fail = true
+        val storage = object : TestStorage() {
+            override fun save(accounts: List<PlayerSave>) {
+                if (fail) {
+                    throw IOException("Disk full")
+                }
+                saved.countDown()
+            }
+        }
+        val fallback = object : TestStorage() {
+            override fun save(accounts: List<PlayerSave>) {
+                fallbackSaved.countDown()
+            }
+        }
+        val queue = SaveQueue(storage, fallback)
+        queue.save(Player(accountName = "player"))
+        queue.run()
+        assertTrue(fallbackSaved.await(5, TimeUnit.SECONDS), "Fallback didn't run after failed save")
+        waitFor("fallback to clear pending") { queue.empty() }
+        fail = false
+        queue.save(Player(accountName = "player"))
+        waitFor("save after a failure") {
+            queue.run()
+            saved.count == 0L
+        }
+    }
+
+    @Test
+    fun `Only one save in flight at a time`() {
+        val started = CountDownLatch(1)
+        val release = CountDownLatch(1)
+        val calls = AtomicInteger()
+        val storage = object : TestStorage() {
+            override fun save(accounts: List<PlayerSave>) {
+                calls.incrementAndGet()
+                started.countDown()
+                release.await(5, TimeUnit.SECONDS)
+            }
+        }
+        val queue = SaveQueue(storage)
+        queue.save(Player(accountName = "player"))
+        queue.run()
+        assertTrue(started.await(5, TimeUnit.SECONDS), "First save didn't start")
+        queue.run()
+        queue.run()
+        assertEquals(1, calls.get(), "Ticks launched overlapping saves")
+        assertTrue(queue.saving("player"), "Account not pending while save in flight")
+        release.countDown()
+        queue.save(Player(accountName = "player2"))
+        waitFor("second save after first completes") {
+            queue.run()
+            calls.get() == 2
+        }
+        waitFor("pending to drain") { queue.empty() }
+    }
+
+    private fun waitFor(description: String, condition: () -> Boolean) {
+        val deadline = System.currentTimeMillis() + 5000
+        while (!condition()) {
+            check(System.currentTimeMillis() < deadline) { "Timed out waiting for $description" }
+            Thread.sleep(10)
+        }
+    }
+}


### PR DESCRIPTION
Closes #1212 

**SupervisorJob** -`CoroutineScope(Dispatchers.IO)` installs a plain `Job`, so the first failed save cancelled the scope permanently. Every later launch, tick saves, the `SafeStorage` fallback in the exception handler, and the shutdown `direct()` save, went into a dead scope and silently no-oped, and the stale `pending` entries locked those accounts out of login via the `saving()` check. Scope is now `Dispatchers.IO + SupervisorJob()`, same as `Script` and `AccountDefinitionsReloader`.

**In-flight guard**, `run()` now holds the launched `Job` and skips the tick while it's active, so a slow save no longer gets a duplicate save of the same accounts launched every tick (the source of the self-inflicted serialization conflicts that triggered the scope cancellation). `pending` removal stays at save completion rather than launch, so the `saving()` login block keeps its meaning.

`Reports` had the identical plain-Job scope with the same failure mode (one failed report save kills all future report saves and their fallback), so the same one-line fix is applied there.

Added `SaveQueueTest` covering both defects: a failed save runs the fallback and leaves the queue usable, and overlapping ticks launch only one save at a time. Both tests fail against the previous code.