### PR TITLE
Stop run energy restoring while running

### DIFF
--- a/game/src/main/kotlin/content/entity/player/effect/energy/Energy.kt
+++ b/game/src/main/kotlin/content/entity/player/effect/energy/Energy.kt
@@ -47,6 +47,10 @@ class Energy : Script {
             if (runEnergy >= MAX_RUN_ENERGY) {
                 return@timerTick Timer.CANCEL
             }
+            // Energy only recovers when not running; drains the tick before restores run
+            if (get("last_energy_drain", -1) == GameLoop.tick - 1) {
+                return@timerTick Timer.CONTINUE
+            }
             runEnergy += getRestoreAmount(this)
             return@timerTick Timer.CONTINUE
         }
@@ -63,7 +67,7 @@ class Energy : Script {
     }
 
     fun getDrainAmount(player: Player): Int {
-        val weight = player["weight", 0].coerceIn(0, 64)
+        val weight = player["weight", 0.0].toInt().coerceIn(0, 64)
         var decrement = 67 + ((67 * weight) / 64)
         if (player.hasClock("hamstring")) {
             decrement *= 4

--- a/game/src/test/kotlin/content/entity/player/PlayerTest.kt
+++ b/game/src/test/kotlin/content/entity/player/PlayerTest.kt
@@ -1,13 +1,17 @@
 package content.entity.player
 
 import WorldTest
+import content.entity.player.effect.energy.MAX_RUN_ENERGY
 import content.entity.player.effect.energy.runEnergy
 import interfaceOption
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import world.gregs.voidps.engine.client.instruction.InstructionHandlers
+import world.gregs.voidps.engine.entity.character.player.skill.Skill
 import world.gregs.voidps.engine.get
+import world.gregs.voidps.engine.inv.add
+import world.gregs.voidps.engine.inv.inventory
 import world.gregs.voidps.network.client.instruction.Walk
 
 internal class PlayerTest : WorldTest() {
@@ -61,5 +65,46 @@ internal class PlayerTest : WorldTest() {
         tick(5)
 
         assertTrue(player.runEnergy > energy)
+    }
+
+    @Test
+    fun `Energy doesn't restore while running`() {
+        val player = createPlayer(emptyTile)
+        player.levels.set(Skill.Agility, 99)
+        val handler: InstructionHandlers = get()
+
+        player.interfaceOption("energy_orb", "run_background", "Turn Run mode on")
+        handler.walk(Walk(emptyTile.x, emptyTile.y + 20), player)
+        tick(5)
+
+        assertEquals(MAX_RUN_ENERGY - 67 * 5, player.runEnergy)
+    }
+
+    @Test
+    fun `Energy restores after running stops`() {
+        val player = createPlayer(emptyTile)
+        val handler: InstructionHandlers = get()
+
+        player.interfaceOption("energy_orb", "run_background", "Turn Run mode on")
+        handler.walk(Walk(emptyTile.x, emptyTile.y + 4), player)
+        tick(3)
+        val energy = player.runEnergy
+
+        tick(3)
+
+        assertTrue(player.runEnergy > energy)
+    }
+
+    @Test
+    fun `Weight increases energy drain`() {
+        val player = createPlayer(emptyTile)
+        player.inventory.add("iron_ore", 28)
+        val handler: InstructionHandlers = get()
+
+        player.interfaceOption("energy_orb", "run_background", "Turn Run mode on")
+        handler.walk(Walk(emptyTile.x, emptyTile.y + 20), player)
+        tick(5)
+
+        assertEquals(MAX_RUN_ENERGY - 132 * 5, player.runEnergy)
     }
 }


### PR DESCRIPTION
Fixes #1214

## Problem

The `energy_restore` soft timer fires every game tick and restored energy regardless of movement state. While running, both restore and drain applied on the same tick, so the observed drain rate was `restore - drain`. Restore scales with Agility (27 to 157 per tick, in hundredths of a percent) while drain is flat 67 per tick at 0kg, so from roughly Agility 50 upwards running was free and energy never depleted.

## Changes

- `Energy.kt`: skip the passive restore on the tick after a run step drained energy. `last_energy_drain` is already stamped once per tick by the drain hook, and only when an actual run step was taken, so a player standing still with run toggled on still recovers as expected. Per the [2011 wiki](https://runescape.wiki/w/Energy?oldid=3597013), energy only recovers while walking or standing, never while running.
- `Energy.kt`: read the `weight` variable as `Double` to match what `Weight.kt` stores. It was previously read with an `Int` default through the erased-generic variable getter, so carried weight never increased drain correctly.

## Tests

Added to `PlayerTest`:
- Energy doesn't restore while running (99 Agility, exact drain of 67 per tick)
- Energy restores again after running stops
- Weight increases energy drain (28 iron ore, ~63kg, exact drain of 132 per tick)