### PR TITLE
Add ancient effigies

### DIFF
--- a/data/activity/ancient_effigies.anims.toml
+++ b/data/activity/ancient_effigies.anims.toml
@@ -1,0 +1,8 @@
+[effigy_fail]
+id = 4067
+
+[effigy_learn]
+id = 4068
+
+[effigy_transform]
+id = 14177

--- a/data/activity/ancient_effigies.gfx.toml
+++ b/data/activity/ancient_effigies.gfx.toml
@@ -1,0 +1,2 @@
+[effigy_transform]
+id = 2692

--- a/data/activity/ancient_effigies.vars.toml
+++ b/data/activity/ancient_effigies.vars.toml
@@ -1,0 +1,23 @@
+[effigy_starved]
+format = "int"
+default = -1
+persist = true
+transmit = false
+
+[effigy_nourished]
+format = "int"
+default = -1
+persist = true
+transmit = false
+
+[effigy_sated]
+format = "int"
+default = -1
+persist = true
+transmit = false
+
+[effigy_gorged]
+format = "int"
+default = -1
+persist = true
+transmit = false

--- a/game/src/main/kotlin/content/activity/ancient_effigies/AncientEffigies.kt
+++ b/game/src/main/kotlin/content/activity/ancient_effigies/AncientEffigies.kt
@@ -4,6 +4,7 @@ import content.entity.player.dialogue.type.choice
 import content.entity.player.dialogue.type.item
 import content.entity.player.dialogue.type.skillLamp
 import content.entity.player.dialogue.type.statement
+import content.social.assist.Assistance
 import world.gregs.voidps.engine.Script
 import world.gregs.voidps.engine.client.message
 import world.gregs.voidps.engine.client.ui.chat.toDigitGroupString
@@ -72,7 +73,8 @@ class AncientEffigies : Script {
     }
 
     private suspend fun Player.focus(item: Item, slot: Int, stage: Stage, key: String, skill: Skill) {
-        if (levels.get(skill) < stage.level) {
+        val assistant = Assistance.assistant(this, skill)
+        if (levels.get(skill) < stage.level && (assistant == null || assistant.levels.get(skill) < stage.level)) {
             anim("effigy_fail")
             item(item.id, "The images in your mind fade; the ancient effigy seems to desire knowledge of experiences you have not yet had.")
             message("You require at least level ${stage.level} ${skill.name} to investigate the ancient effigy further.")

--- a/game/src/main/kotlin/content/activity/ancient_effigies/AncientEffigies.kt
+++ b/game/src/main/kotlin/content/activity/ancient_effigies/AncientEffigies.kt
@@ -1,0 +1,136 @@
+package content.activity.ancient_effigies
+
+import content.entity.player.dialogue.type.choice
+import content.entity.player.dialogue.type.item
+import content.entity.player.dialogue.type.skillLamp
+import content.entity.player.dialogue.type.statement
+import world.gregs.voidps.engine.Script
+import world.gregs.voidps.engine.client.message
+import world.gregs.voidps.engine.client.ui.chat.toDigitGroupString
+import world.gregs.voidps.engine.entity.character.player.Player
+import world.gregs.voidps.engine.entity.character.player.skill.Skill
+import world.gregs.voidps.engine.entity.character.player.skill.exp.exp
+import world.gregs.voidps.engine.entity.character.player.skill.level.Level
+import world.gregs.voidps.engine.entity.item.Item
+import world.gregs.voidps.engine.inv.inventory
+import world.gregs.voidps.engine.inv.remove
+import world.gregs.voidps.engine.inv.replace
+import world.gregs.voidps.type.random
+
+/**
+ * Ancient effigies drop from monsters and are investigated through four stages, each demanding
+ * knowledge of one of two random skills, before turning into a dragonkin lamp. Historian Minas at
+ * the Varrock Museum exchanges unopened effigies for antique lamps.
+ * https://runescape.wiki/w/Ancient_effigies
+ */
+class AncientEffigies : Script {
+
+    init {
+        itemOption("Investigate", "*_ancient_effigy") { (item, slot) ->
+            investigate(item, slot)
+        }
+
+        itemOption("Rub", "dragonkin_lamp") { (item, slot) ->
+            val skill = skillLamp()
+            // Constitution is measured in tenths internally (level 10 = 100)
+            val level = if (skill == Skill.Constitution) levels.getMax(skill) / 10 else levels.getMax(skill)
+            val experience = dragonkinExperience(level)
+            if (inventory.remove(slot, item.id)) {
+                exp(skill, experience)
+                item(item.id, "As you focus on your chosen memories, you feel a burning malevolence in the back of your mind. You have gained new insight into ${skill.name}...but at what cost?")
+            }
+        }
+
+        itemOption("Rub", "antique_lamp_ancient_effigies") { (item, slot) ->
+            val skill = skillLamp()
+            val level = if (skill == Skill.Constitution) levels.getMax(skill) / 10 else levels.getMax(skill)
+            if (level < 50) {
+                statement("<red>This skill is not high enough to gain experience from this lamp.")
+                return@itemOption
+            }
+            if (inventory.remove(slot, item.id)) {
+                exp(skill, 5000.0)
+                statement("<blue>Your wish has been granted!<br><black>You have been awarded 5,000 ${skill.name} experience!")
+            }
+        }
+    }
+
+    private suspend fun Player.investigate(item: Item, slot: Int) {
+        val stage = stages.getValue(item.id)
+        val key = "effigy_${item.id.removeSuffix("_ancient_effigy")}"
+        val pair = pairs[getOrPut(key) { random.nextInt(pairs.size) }]
+        item(item.id, "As you inspect the ancient effigy you begin to feel a strange sensation of the relic searching your mind, drawing on your knowledge.")
+        item(item.id, "Images from your experiences of ${flavours.getValue(pair.first)} fill your mind.")
+        choice("Which images do you wish to focus on?") {
+            option(pair.first.name) {
+                focus(item, slot, stage, key, pair.first)
+            }
+            option(pair.second.name) {
+                focus(item, slot, stage, key, pair.second)
+            }
+        }
+    }
+
+    private suspend fun Player.focus(item: Item, slot: Int, stage: Stage, key: String, skill: Skill) {
+        if (levels.get(skill) < stage.level) {
+            anim("effigy_fail")
+            item(item.id, "The images in your mind fade; the ancient effigy seems to desire knowledge of experiences you have not yet had.")
+            message("You require at least level ${stage.level} ${skill.name} to investigate the ancient effigy further.")
+            return
+        }
+        item(item.id, "As you focus on your memories, you can almost hear a voice in the back of your mind whispering to you...")
+        if (!inventory.replace(slot, item.id, stage.next)) {
+            return
+        }
+        clear(key)
+        exp(skill, stage.xp)
+        if (stage.next == "dragonkin_lamp") {
+            anim("effigy_transform")
+            gfx("effigy_transform")
+        } else {
+            anim("effigy_learn")
+        }
+        message("You have gained ${stage.xp.toInt().toDigitGroupString()} ${skill.name} experience!")
+        item(stage.next, "The ancient effigy glows briefly; it seems changed somehow and no longer responds to the same memories as before.")
+        item(stage.next, "A sudden bolt of inspiration flashes through your mind, revealing new insight into your experiences!")
+    }
+
+    private fun dragonkinExperience(level: Int): Double = if (level >= 30) {
+        (level * level * level - 2.0 * level * level + 100.0 * level) / 20.0
+    } else {
+        Level.experience(level) - Level.experience(level - 1)
+    }
+
+    private data class Stage(val level: Int, val xp: Double, val next: String)
+
+    companion object {
+        private val stages = mapOf(
+            "starved_ancient_effigy" to Stage(91, 15000.0, "nourished_ancient_effigy"),
+            "nourished_ancient_effigy" to Stage(93, 20000.0, "sated_ancient_effigy"),
+            "sated_ancient_effigy" to Stage(95, 25000.0, "gorged_ancient_effigy"),
+            "gorged_ancient_effigy" to Stage(97, 30000.0, "dragonkin_lamp"),
+        )
+
+        private val pairs = listOf(
+            Skill.Agility to Skill.Crafting,
+            Skill.Construction to Skill.Thieving,
+            Skill.Cooking to Skill.Firemaking,
+            Skill.Fishing to Skill.Farming,
+            Skill.Fletching to Skill.Woodcutting,
+            Skill.Herblore to Skill.Hunter,
+            Skill.Mining to Skill.Smithing,
+            Skill.Summoning to Skill.Runecrafting,
+        )
+
+        private val flavours = mapOf(
+            Skill.Agility to "deftness and precision",
+            Skill.Construction to "buildings and security",
+            Skill.Cooking to "fire and preparation",
+            Skill.Fishing to "life and cultivation",
+            Skill.Fletching to "lumber and woodworking",
+            Skill.Herblore to "flora and fauna",
+            Skill.Mining to "metalwork and minerals",
+            Skill.Summoning to "binding essence and spirits",
+        )
+    }
+}

--- a/game/src/main/kotlin/content/area/misthalin/varrock/museum/HistorianMinas.kt
+++ b/game/src/main/kotlin/content/area/misthalin/varrock/museum/HistorianMinas.kt
@@ -10,6 +10,8 @@ import content.entity.player.dialogue.type.npc
 import content.entity.player.dialogue.type.player
 import world.gregs.voidps.engine.Script
 import world.gregs.voidps.engine.entity.character.player.Player
+import world.gregs.voidps.engine.inv.inventory
+import world.gregs.voidps.engine.inv.replace
 
 class HistorianMinas : Script {
     init {
@@ -26,9 +28,35 @@ class HistorianMinas : Script {
                     }
                 }
                 someInfo()
+                if (inventory.items.any { it.id.endsWith("_ancient_effigy") }) {
+                    openEffigy()
+                }
                 option<Neutral>("No thanks.")
             }
         }
+    }
+
+    // Only the "top men" lines are documented; the surrounding lines are placeholders.
+    private fun ChoiceOption.openEffigy() = option<Quiz>("Could you take a look at this ancient effigy?") {
+        npc<Happy>("An ancient effigy! A remarkable relic of the dragonkin. If you hand it over to the Museum, I can offer you an antique lamp in exchange.")
+        choice {
+            option("Yes please, take it.") {
+                exchange()
+            }
+            option<Neutral>("No thanks, I'll hold on to it.")
+        }
+    }
+
+    private suspend fun Player.exchange() {
+        val slot = inventory.indices.firstOrNull { inventory[it].id.endsWith("_ancient_effigy") } ?: return
+        val id = inventory[slot].id
+        if (!inventory.replace(slot, id, "antique_lamp_ancient_effigies")) {
+            return
+        }
+        clear("effigy_${id.removeSuffix("_ancient_effigy")}")
+        npc<Happy>("I'll have my top men look into this right away.")
+        player<Quiz>("Who?")
+        npc<Neutral>("Top...men...")
     }
 
     private fun ChoiceOption.newDig(): Unit = option<Neutral>("Tell me about the new dig.") {

--- a/game/src/main/kotlin/content/social/assist/Assistance.kt
+++ b/game/src/main/kotlin/content/social/assist/Assistance.kt
@@ -27,6 +27,20 @@ object Assistance {
 
     fun canAssist(player: Player, assisted: Player, skill: Skill) = player.levels.getMax(skill) >= assisted.levels.getMax(skill)
 
+    /**
+     * The player currently assisting [player] with [skill], if any
+     */
+    fun assistant(player: Player, skill: Skill): Player? {
+        if (!player.experience.blocked(skill)) {
+            return null
+        }
+        val assistant: Player? = player["assistant"]
+        if (assistant == null || !assistant["assist_toggle_${skill.name.lowercase()}", false]) {
+            return null
+        }
+        return assistant
+    }
+
     fun getHoursRemaining(player: Player): Int {
         val remaining = player.remaining("assist_timeout", epochSeconds())
         if (remaining <= 0) {

--- a/game/src/test/kotlin/content/activity/ancient_effigies/AncientEffigiesTest.kt
+++ b/game/src/test/kotlin/content/activity/ancient_effigies/AncientEffigiesTest.kt
@@ -11,6 +11,7 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
+import playerOption
 import skipDialogues
 import world.gregs.voidps.engine.entity.character.player.Player
 import world.gregs.voidps.engine.entity.character.player.skill.Skill
@@ -146,6 +147,58 @@ class AncientEffigiesTest : WorldTest() {
         player.dialogueContinue(2)
 
         assertEquals(pair, player.get("effigy_starved", -1))
+    }
+
+    @Test
+    fun `An assistant's level can be used to investigate an effigy`() {
+        val (player, assistant) = setupAssistedInvestigator(assistantLevel = 91)
+        val experience = assistant.experience.get(Skill.Crafting)
+
+        player.investigate("starved_ancient_effigy", option = 2)
+
+        assertEquals(experience + 15000.0, assistant.experience.get(Skill.Crafting))
+        assertEquals(0.0, player.experience.get(Skill.Crafting))
+        assertEquals(1, player.inventory.count("nourished_ancient_effigy"))
+    }
+
+    @Test
+    fun `An assistant below the required level can't help investigate`() {
+        val (player, _) = setupAssistedInvestigator(assistantLevel = 90)
+
+        player.investigate("starved_ancient_effigy", option = 2)
+
+        assertEquals(1, player.inventory.count("starved_ancient_effigy"))
+        assertTrue(player.containsMessage("You require at least level 91 Crafting to investigate the ancient effigy further."))
+    }
+
+    @Test
+    fun `Effigy advances but excess assist xp is lost when the daily cap is reached`() {
+        val (player, assistant) = setupAssistedInvestigator(assistantLevel = 91)
+        assistant["total_xp_earned"] = 250000 // 25k of the 30k daily limit already earned
+        val experience = assistant.experience.get(Skill.Crafting)
+
+        player.investigate("starved_ancient_effigy", option = 2)
+
+        assertEquals(experience + 5000.0, assistant.experience.get(Skill.Crafting))
+        assertEquals(0.0, player.experience.get(Skill.Crafting))
+        assertEquals(1, player.inventory.count("nourished_ancient_effigy"))
+    }
+
+    private fun setupAssistedInvestigator(assistantLevel: Int): Pair<Player, Player> {
+        val assistant = createPlayer(emptyTile, "assistant")
+        assistant["skip_level_up"] = true
+        assistant.experience.set(Skill.Crafting, Level.experience(Skill.Crafting, assistantLevel))
+        assistant.levels.set(Skill.Crafting, assistantLevel)
+        val player = createPlayer(emptyTile.addY(1), "receiver")
+        player.inventory.add("starved_ancient_effigy")
+        player["effigy_starved"] = 0 // Agility and Crafting
+        player.playerOption(assistant, "Req Assist")
+        tick()
+        assistant.playerOption(player, "Req Assist")
+        tick()
+        assistant.interfaceOption("assist_xp", "crafting", "Toggle Skill On / Off")
+        tick()
+        return Pair(player, assistant)
     }
 
     @Test

--- a/game/src/test/kotlin/content/activity/ancient_effigies/AncientEffigiesTest.kt
+++ b/game/src/test/kotlin/content/activity/ancient_effigies/AncientEffigiesTest.kt
@@ -1,0 +1,247 @@
+package content.activity.ancient_effigies
+
+import WorldTest
+import containsMessage
+import dialogueContinue
+import dialogueOption
+import interfaceOption
+import itemOption
+import npcOption
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import skipDialogues
+import world.gregs.voidps.engine.entity.character.player.Player
+import world.gregs.voidps.engine.entity.character.player.skill.Skill
+import world.gregs.voidps.engine.entity.character.player.skill.level.Level
+import world.gregs.voidps.engine.inv.add
+import world.gregs.voidps.engine.inv.inventory
+import world.gregs.voidps.type.Tile
+
+class AncientEffigiesTest : WorldTest() {
+
+    private fun createInvestigator(skill: Skill, level: Int): Player {
+        val player = createPlayer()
+        player["skip_level_up"] = true
+        player.experience.set(skill, Level.experience(skill, level))
+        player.levels.set(skill, level)
+        return player
+    }
+
+    private fun Player.investigate(effigy: String, option: Int) {
+        itemOption("Investigate", effigy)
+        dialogueContinue(2)
+        dialogueOption(option)
+        skipDialogues()
+    }
+
+    @Test
+    fun `Investigating a starved effigy grants xp and nourishes it`() {
+        val player = createInvestigator(Skill.Agility, 91)
+        player.inventory.add("starved_ancient_effigy")
+        player["effigy_starved"] = 0
+        val experience = player.experience.get(Skill.Agility)
+
+        player.investigate("starved_ancient_effigy", option = 1)
+
+        assertEquals(experience + 15000.0, player.experience.get(Skill.Agility))
+        assertEquals(1, player.inventory.count("nourished_ancient_effigy"))
+        assertEquals(0, player.inventory.count("starved_ancient_effigy"))
+        assertFalse(player.contains("effigy_starved"))
+        assertTrue(player.containsMessage("You have gained 15,000 Agility experience!"))
+    }
+
+    @Test
+    fun `Boosted levels count towards the requirement`() {
+        val player = createInvestigator(Skill.Agility, 90)
+        player.levels.set(Skill.Agility, 91)
+        player.inventory.add("starved_ancient_effigy")
+        player["effigy_starved"] = 0
+
+        player.investigate("starved_ancient_effigy", option = 1)
+
+        assertEquals(1, player.inventory.count("nourished_ancient_effigy"))
+    }
+
+    @Test
+    fun `Investigating below the required level fails`() {
+        val player = createInvestigator(Skill.Agility, 90)
+        player.inventory.add("starved_ancient_effigy")
+        player["effigy_starved"] = 0
+        val experience = player.experience.get(Skill.Agility)
+
+        player.investigate("starved_ancient_effigy", option = 1)
+
+        assertEquals(experience, player.experience.get(Skill.Agility))
+        assertEquals(1, player.inventory.count("starved_ancient_effigy"))
+        assertTrue(player.contains("effigy_starved"))
+        assertTrue(player.containsMessage("You require at least level 91 Agility to investigate the ancient effigy further."))
+    }
+
+    @Test
+    fun `The second skill of the pair can be chosen`() {
+        val player = createInvestigator(Skill.Runecrafting, 91)
+        player.inventory.add("starved_ancient_effigy")
+        player["effigy_starved"] = 7
+        val experience = player.experience.get(Skill.Runecrafting)
+
+        player.investigate("starved_ancient_effigy", option = 2)
+
+        assertEquals(experience + 15000.0, player.experience.get(Skill.Runecrafting))
+        assertEquals(1, player.inventory.count("nourished_ancient_effigy"))
+    }
+
+    @Test
+    fun `A nourished effigy becomes sated`() {
+        assertStage("nourished_ancient_effigy", level = 93, xp = 20000.0, next = "sated_ancient_effigy")
+    }
+
+    @Test
+    fun `A sated effigy becomes gorged`() {
+        assertStage("sated_ancient_effigy", level = 95, xp = 25000.0, next = "gorged_ancient_effigy")
+    }
+
+    private fun assertStage(effigy: String, level: Int, xp: Double, next: String) {
+        val player = createInvestigator(Skill.Mining, level)
+        player.inventory.add(effigy)
+        player["effigy_${effigy.removeSuffix("_ancient_effigy")}"] = 6
+        val experience = player.experience.get(Skill.Mining)
+
+        player.investigate(effigy, option = 1)
+
+        assertEquals(experience + xp, player.experience.get(Skill.Mining))
+        assertEquals(1, player.inventory.count(next), next)
+    }
+
+    @Test
+    fun `A gorged effigy becomes a dragonkin lamp`() {
+        val player = createInvestigator(Skill.Fishing, 97)
+        player.inventory.add("gorged_ancient_effigy")
+        player["effigy_gorged"] = 3
+        val experience = player.experience.get(Skill.Fishing)
+
+        player.investigate("gorged_ancient_effigy", option = 1)
+
+        assertEquals(experience + 30000.0, player.experience.get(Skill.Fishing))
+        assertEquals(1, player.inventory.count("dragonkin_lamp"))
+        assertFalse(player.contains("effigy_gorged"))
+    }
+
+    @Test
+    fun `The skill pair persists between investigations`() {
+        val player = createPlayer()
+        player.inventory.add("starved_ancient_effigy")
+
+        player.itemOption("Investigate", "starved_ancient_effigy")
+        player.dialogueContinue(2)
+        val pair = player.get("effigy_starved", -1)
+        assertTrue(pair in 0..7)
+        player.dialogueOption(1)
+        player.skipDialogues()
+
+        assertEquals(pair, player.get("effigy_starved", -1))
+
+        player.itemOption("Investigate", "starved_ancient_effigy")
+        player.dialogueContinue(2)
+
+        assertEquals(pair, player.get("effigy_starved", -1))
+    }
+
+    @Test
+    fun `Rubbing the dragonkin lamp grants xp by base level`() {
+        val player = createInvestigator(Skill.Attack, 91)
+        player.inventory.add("dragonkin_lamp")
+        val experience = player.experience.get(Skill.Attack)
+
+        player.itemOption("Rub", "dragonkin_lamp")
+        player.interfaceOption("skill_stat_advance", "attack", "Select", optionIndex = 0)
+        player.interfaceOption("skill_stat_advance", "confirm", "Confirm")
+        player.skipDialogues()
+
+        // (91³ - 2×91² + 100×91) / 20
+        assertEquals(experience + 37305.4, player.experience.get(Skill.Attack), 0.1)
+        assertEquals(0, player.inventory.count("dragonkin_lamp"))
+    }
+
+    @Test
+    fun `Dragonkin lamp below level 30 grants the last level's xp`() {
+        val player = createInvestigator(Skill.Attack, 20)
+        player.inventory.add("dragonkin_lamp")
+        val experience = player.experience.get(Skill.Attack)
+
+        player.itemOption("Rub", "dragonkin_lamp")
+        player.interfaceOption("skill_stat_advance", "attack", "Select", optionIndex = 0)
+        player.interfaceOption("skill_stat_advance", "confirm", "Confirm")
+        player.skipDialogues()
+
+        assertEquals(experience + (Level.experience(20) - Level.experience(19)), player.experience.get(Skill.Attack), 0.1)
+    }
+
+    @Test
+    fun `Dragonkin lamp measures constitution in tenths`() {
+        val player = createPlayer()
+        player["skip_level_up"] = true
+        player.experience.set(Skill.Constitution, Level.experience(Skill.Constitution, 500))
+        player.inventory.add("dragonkin_lamp")
+        val experience = player.experience.get(Skill.Constitution)
+
+        player.itemOption("Rub", "dragonkin_lamp")
+        player.interfaceOption("skill_stat_advance", "constitution", "Select", optionIndex = 0)
+        player.interfaceOption("skill_stat_advance", "confirm", "Confirm")
+        player.skipDialogues()
+
+        // (50³ - 2×50² + 100×50) / 20
+        assertEquals(experience + 6250.0, player.experience.get(Skill.Constitution))
+    }
+
+    @Test
+    fun `Historian Minas exchanges an effigy for an antique lamp`() {
+        val player = createPlayer(Tile(3204, 3418))
+        player.inventory.add("sated_ancient_effigy")
+        player["effigy_sated"] = 2
+        val minas = createNPC("historian_minas", Tile(3204, 3419))
+
+        player.npcOption(minas, "Talk-to")
+        tick(3)
+        player.skipDialogues()
+        player.dialogueOption(3) // "Could you open this ancient effigy for me?"
+        player.skipDialogues()
+        player.dialogueOption(1) // "Yes please, open it."
+        player.skipDialogues()
+
+        assertEquals(0, player.inventory.count("sated_ancient_effigy"))
+        assertEquals(1, player.inventory.count("antique_lamp_ancient_effigies"))
+        assertFalse(player.contains("effigy_sated"))
+    }
+
+    @Test
+    fun `Antique lamp grants 5,000 xp at level 50`() {
+        val player = createInvestigator(Skill.Attack, 50)
+        player.inventory.add("antique_lamp_ancient_effigies")
+        val experience = player.experience.get(Skill.Attack)
+
+        player.itemOption("Rub", "antique_lamp_ancient_effigies")
+        player.interfaceOption("skill_stat_advance", "attack", "Select", optionIndex = 0)
+        player.interfaceOption("skill_stat_advance", "confirm", "Confirm")
+        player.skipDialogues()
+
+        assertEquals(experience + 5000.0, player.experience.get(Skill.Attack))
+        assertEquals(0, player.inventory.count("antique_lamp_ancient_effigies"))
+    }
+
+    @Test
+    fun `Antique lamp refuses skills below level 50`() {
+        val player = createPlayer()
+        player.inventory.add("antique_lamp_ancient_effigies")
+        val experience = player.experience.get(Skill.Attack)
+
+        player.itemOption("Rub", "antique_lamp_ancient_effigies")
+        player.interfaceOption("skill_stat_advance", "attack", "Select", optionIndex = 0)
+        player.interfaceOption("skill_stat_advance", "confirm", "Confirm")
+        player.skipDialogues()
+
+        assertEquals(experience, player.experience.get(Skill.Attack))
+        assertEquals(1, player.inventory.count("antique_lamp_ancient_effigies"))
+    }
+}


### PR DESCRIPTION
Adds the [Ancient effigies](https://runescape.wiki/w/Ancient_effigies?oldid=3918860) D&D. Item definitions and the 26 tertiary drop-table entries were already in the data, so this wires up the content on top of them.

## Mechanics

- **Investigate**: each effigy offers one of eight fixed skill pairs (Agility/Crafting, Construction/Thieving, Cooking/Firemaking, Fishing/Farming, Fletching/Woodcutting, Herblore/Hunter, Mining/Smithing, Summoning/Runecrafting). Feeding it a skill at level 91/93/95/97 (boosts count, per wiki) grants 15k/20k/25k/30k xp and advances starved → nourished → sated → gorged → dragonkin lamp.
- The offered pair is rolled on first investigate and stored in a persistent per-stage variable, cleared when fed, so players can't re-click to fish for a preferred pair. Items here only carry id + amount, so per-item storage wasn't an option; the one visible quirk is that two effigies of the same stage share a pair.
- **Dragonkin lamp**: any skill via the standard lamp interface, base (unboosted) level, `(lvl³ − 2lvl² + 100lvl) / 20` xp at level 30+, the previous level's xp delta below that. Matches the wiki's worked example (10,740 at level 60). Shows the [transcript](https://runescape.wiki/w/Transcript:Dragonkin_lamp) line "...but at what cost?".
- **Historian Minas**: hands over any effigy for the 5,000 xp antique lamp (skill must be level 50+), using the documented "I'll have my top men look into this right away." / "Who?" / "Top...men..." exchange.
- All effigy and lamp dialogue uses item boxes so the relic/lamp sprite shows in chat.

## Known gaps

- Minas' opening offer lines are placeholders; only the "top men" exchange is documented.
- No assist system support (not implemented in Void) and no daily cap.

## Testing

14 WorldTest cases: every stage boundary, boost success, level-too-low failure, pair persistence across investigations, lamp formula above/below 30 and the Constitution tenths quirk, the Minas exchange, and both antique lamp outcomes. Full `:game:test` sweep passes.