### PR TITLE
Fix invalid map variable values from farming and unlock command

### DIFF
--- a/game/src/main/kotlin/content/entity/player/command/PlayerCommands.kt
+++ b/game/src/main/kotlin/content/entity/player/command/PlayerCommands.kt
@@ -17,6 +17,7 @@ import world.gregs.voidps.engine.Script
 import world.gregs.voidps.engine.client.command.*
 import world.gregs.voidps.engine.client.message
 import world.gregs.voidps.engine.client.ui.open
+import world.gregs.voidps.engine.client.variable.MapValues
 import world.gregs.voidps.engine.client.variable.PlayerVariables
 import world.gregs.voidps.engine.client.variable.hasClock
 import world.gregs.voidps.engine.client.variable.start
@@ -304,7 +305,8 @@ class PlayerCommands(
         if (type == "all" || type == "tasks" || type == "achievements") {
             for (struct in StructDefinitions.definitions) {
                 if (struct.stringId.endsWith("_task")) {
-                    target[struct.stringId] = true
+                    val definition = VariableDefinitions.get(struct.stringId)
+                    target[struct.stringId] = if (definition?.values is MapValues) "completed" else true
                 }
             }
             target.message("All tasks completed.")

--- a/game/src/main/kotlin/content/skill/farming/Farming.kt
+++ b/game/src/main/kotlin/content/skill/farming/Farming.kt
@@ -28,6 +28,13 @@ class Farming(
 
     init {
         playerSpawn {
+            // Repair saves corrupted by disease handling matching "herb" inside "catherby"
+            for (variable in listOf("farming_fruit_tree_patch_catherby", "farming_veg_patch_catherby_north", "farming_veg_patch_catherby_south", "farming_flower_patch_catherby")) {
+                val value: String? = this[variable]
+                if (value != null && value.startsWith("herb_dead_")) {
+                    clear(variable)
+                }
+            }
             if (!contains("farming_offset_mins")) {
                 set("farming_offset_mins", random.nextInt(0, 30))
             }

--- a/game/src/main/kotlin/content/skill/farming/Farming.kt
+++ b/game/src/main/kotlin/content/skill/farming/Farming.kt
@@ -90,7 +90,7 @@ class Farming(
                 }
                 val produce = current.substringBeforeLast("_")
                 if (produce.endsWith("diseased")) {
-                    if (variable.contains("herb") && !produce.startsWith("goutweed")) {
+                    if (variable.contains("herb_patch") && !produce.startsWith("goutweed")) {
                         val stage = current.removeSuffix("_diseased").substringAfterLast("_")
                         player[variable] = "herb_dead_$stage"
                     } else {
@@ -201,7 +201,7 @@ class Farming(
 
     fun disease(player: Player, spot: String, produce: String, type: String): Boolean {
         // https://x.com/JagexKieren/status/905860041240137729
-        if (spot == "patch_my_arm_herb" || type == "0" || produce.endsWith("_watered")) {
+        if (spot == "farming_herb_patch_my_arm" || type == "0" || produce.endsWith("_watered")) {
             return false
         }
         if (player["${spot}_protect", false]) {

--- a/game/src/test/kotlin/content/skill/farming/FruitTreePatchTest.kt
+++ b/game/src/test/kotlin/content/skill/farming/FruitTreePatchTest.kt
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DynamicTest.dynamicTest
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestFactory
+import world.gregs.voidps.engine.entity.Spawn
 import world.gregs.voidps.engine.entity.character.player.skill.Skill
 import world.gregs.voidps.engine.entity.item.Item
 import world.gregs.voidps.engine.entity.obj.GameObjects
@@ -104,6 +105,17 @@ class FruitTreePatchTest : WorldTest() {
 
             assertEquals("${id}_life3", player["farming_fruit_tree_patch_gnome_stronghold", "empty"])
         }
+    }
+
+    @Test
+    fun `Corrupted herb dead value is repaired on spawn`() {
+        val player = createPlayer(Tile(2860, 3432))
+        player["farming_fruit_tree_patch_catherby"] = "herb_dead_2"
+
+        Spawn.player(player)
+        tick(1)
+
+        assertEquals("empty", player["farming_fruit_tree_patch_catherby", "empty"])
     }
 
     @Test

--- a/game/src/test/kotlin/content/skill/farming/FruitTreePatchTest.kt
+++ b/game/src/test/kotlin/content/skill/farming/FruitTreePatchTest.kt
@@ -7,6 +7,7 @@ import objectOption
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DynamicTest.dynamicTest
+import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestFactory
 import world.gregs.voidps.engine.entity.character.player.skill.Skill
 import world.gregs.voidps.engine.entity.item.Item
@@ -103,6 +104,18 @@ class FruitTreePatchTest : WorldTest() {
 
             assertEquals("${id}_life3", player["farming_fruit_tree_patch_gnome_stronghold", "empty"])
         }
+    }
+
+    @Test
+    fun `Diseased fruit tree at catherby dies`() {
+        val tile = Tile(2860, 3432)
+        val player = createPlayer(tile)
+        player["farming_fruit_tree_patch_catherby"] = "apple_diseased_2"
+
+        val farming = scripts.filterIsInstance<Farming>().first()
+        farming.grow(player, 32 * 5)
+
+        assertEquals("apple_dead_2", player["farming_fruit_tree_patch_catherby", "empty"])
     }
 
     @TestFactory


### PR DESCRIPTION
Investigation of #1218. Of the six warnings, two come from write paths still in the code; the rest are stale saved values.

## Live bugs fixed

**Varbit 707, `herb_dead_2` (Catherby fruit tree)**
The diseased-to-dead transition in `Farming.kt` checked `variable.contains("herb")`, which also matches "cat**herb**y". A diseased apple tree at stage 2 in the Catherby patch was written `herb_dead_2`, a value only herb patch varbit maps define, so the varbit was never sent and the patch stopped rendering its real state. The same applied to the Catherby veg and flower patches. Now matches on `"herb_patch"`, which all five herb patch variables contain. Added a regression test: diseased Catherby apple tree now dies to `apple_dead_2`.

**Varbit 6494, `true` (`introducing_explorer_jack_task`)**
The `unlock tasks` command wrote `true` to every `*_task` struct id, but this task is the one `*_task` varbit with `format = "map"` (`unstarted`/`completed`), so the boolean never sent and the warning repeated on every login via the task list refresh. The command now checks the variable definition and writes `"completed"` for map-format tasks. `TaskSystem` already accepts both forms.

**Trollheim herb patch disease immunity**
`Farming.disease()` compared against `"patch_my_arm_herb"` but the variable is named `farming_herb_patch_my_arm`, so the check never matched and the canonically disease-free patch could disease and die. Low impact until My Arm's Big Adventure is implemented, but the fix is one string.

## Stale save data, no code change

- **Varp 281 `incomplete`**: #1007 renamed the `unstable_foundations` value `incomplete` to `started` with no migration.
- **Varp 293 `completed`** and **varbit 5733 `false`**: `big_chompy_bird_hunting` and `myths_of_the_white_lands` got map definitions in #1007; nothing in the codebase ever wrote those values, so they predate the defs on the dev account.
- **Varbit 740 `compostable_rotting_ready`**: already fixed and save-repaired on spawn by #1213; the logged lines predate that deploy.

Farming test suite passes (FruitTreePatchTest 34, HerbPatchTest 47, 0 failures).

Closes #1218