### PR TITLE
Fix cross-patch planting and remaining invalid variable values

### DIFF
--- a/game/src/main/kotlin/content/achievement/TaskSystem.kt
+++ b/game/src/main/kotlin/content/achievement/TaskSystem.kt
@@ -17,6 +17,14 @@ import world.gregs.voidps.engine.event.AuditLog
 class TaskSystem : Script {
 
     init {
+        playerSpawn {
+            // Migrate saves the unlock command wrote a boolean into; set directly to avoid re-completing the task
+            if (variables.data["introducing_explorer_jack_task"] == true) {
+                variables.data["introducing_explorer_jack_task"] = "completed"
+                sendVariable("introducing_explorer_jack_task")
+            }
+        }
+
         interfaceOpened("task_system") {
             sendVariable("task_pin_slot")
             sendVariable("task_pinned")

--- a/game/src/main/kotlin/content/achievement/TaskSystem.kt
+++ b/game/src/main/kotlin/content/achievement/TaskSystem.kt
@@ -23,6 +23,10 @@ class TaskSystem : Script {
                 variables.data["introducing_explorer_jack_task"] = "completed"
                 sendVariable("introducing_explorer_jack_task")
             }
+            // Migrate the invalid "incomplete" value this script used to write
+            if (this["unstable_foundations", ""] == "incomplete") {
+                set("unstable_foundations", "started")
+            }
         }
 
         interfaceOpened("task_system") {
@@ -37,7 +41,7 @@ class TaskSystem : Script {
                 set("task_pinned", 3520) // Talk to explorer jack
                 set("task_pin_slot", 1)
                 set("task_slot_selected", 1)
-                set("unstable_foundations", "incomplete")
+                set("unstable_foundations", "started")
             }
         }
 

--- a/game/src/main/kotlin/content/skill/farming/Farming.kt
+++ b/game/src/main/kotlin/content/skill/farming/Farming.kt
@@ -28,11 +28,13 @@ class Farming(
 
     init {
         playerSpawn {
-            // Repair saves corrupted by disease handling matching "herb" inside "catherby"
-            for (variable in listOf("farming_fruit_tree_patch_catherby", "farming_veg_patch_catherby_north", "farming_veg_patch_catherby_south", "farming_flower_patch_catherby")) {
-                val value: String? = this[variable]
-                if (value != null && value.startsWith("herb_dead_")) {
-                    clear(variable)
+            // Repair patches stuck on values missing from their varbit map; they can't be sent or grow
+            for (patches in FarmingPatches.patches.values) {
+                for (variable in patches) {
+                    val value: String = this[variable] ?: continue
+                    if (varbitMap(variable)?.containsKey(value) == false) {
+                        clear(variable)
+                    }
                 }
             }
             if (!contains("farming_offset_mins")) {
@@ -247,7 +249,7 @@ class Farming(
 
     private fun varbitMap(varbit: String): Map<String, Int>? {
         val definition = VariableDefinitions.get(varbit) ?: return null
-        return (definition.values as MapValues).values as Map<String, Int>
+        return (definition.values as? MapValues)?.values as? Map<String, Int>
     }
 
     private fun amuletOfFarming(player: Player, patch: String) {

--- a/game/src/main/kotlin/content/skill/farming/FarmingPatchPlant.kt
+++ b/game/src/main/kotlin/content/skill/farming/FarmingPatchPlant.kt
@@ -46,22 +46,32 @@ class FarmingPatchPlant : Script {
             return
         }
         val patch: String = item.def.getOrNull("farming_patch") ?: return
-        val patchName = target.patchName()
-        if (patchName.removeSuffix(" patch") != patch) {
+        if (!matches(target.id, patch)) {
+            val patchName = target.patchName()
             player.statement("You can only plant ${item.def.name.plural(amount)} in ${patchName.an()} $patchName.")
             return
         }
+    }
+
+    private fun matches(variable: String, patch: String): Boolean {
+        val type = variable.removePrefix("farming_").substringBefore("_patch")
+        return patch == if (type == "veg") "allotment" else type
     }
 
     private suspend fun plant(player: Player, interact: ItemOnObjectInteract) {
         val item = interact.item
         val amount = item.def["farming_amount", 1]
         val variable = interact.target.id
+        val patchName = interact.target.patchName()
+        val patch: String = item.def.getOrNull("farming_patch") ?: return
+        if (!matches(variable, patch)) {
+            player.statement("You can only plant ${item.def.name.plural(amount)} in ${patchName.an()} $patchName.")
+            return
+        }
         if (variable.startsWith("farming_spirit_tree_patch") && hasSpiritTree(player)) {
             player.message("You can only plant one spirit tree at a time.") // TODO proper message
             return
         }
-        val patchName = interact.target.patchName()
         if (patchName.contains("tree") && !player.inventory.contains("spade")) {
             player.message("You need a spade to do that.")
             return

--- a/game/src/test/kotlin/content/achievement/TaskSystemTest.kt
+++ b/game/src/test/kotlin/content/achievement/TaskSystemTest.kt
@@ -28,6 +28,17 @@ class TaskSystemTest : WorldTest() {
     }
 
     @Test
+    fun `Legacy incomplete quest value is migrated on spawn`() {
+        val player = createPlayer(Tile(3221, 3218))
+        player.variables.data["unstable_foundations"] = "incomplete"
+
+        Spawn.player(player)
+        tick(1)
+
+        assertEquals("started", player["unstable_foundations", ""])
+    }
+
+    @Test
     fun `Dismissing unrelated completed task details doesn't remove pinned task`() {
         val player = createPlayer(Tile(3207, 3224, 2))
         player["unstable_foundations"] = "completed"

--- a/game/src/test/kotlin/content/achievement/TaskSystemTest.kt
+++ b/game/src/test/kotlin/content/achievement/TaskSystemTest.kt
@@ -5,6 +5,7 @@ import interfaceOption
 import itemOption
 import objectOption
 import org.junit.jupiter.api.Test
+import world.gregs.voidps.engine.entity.Spawn
 import world.gregs.voidps.engine.entity.character.move.tele
 import world.gregs.voidps.engine.entity.obj.GameObjects
 import world.gregs.voidps.engine.inv.add
@@ -13,6 +14,18 @@ import world.gregs.voidps.type.Tile
 import kotlin.test.assertEquals
 
 class TaskSystemTest : WorldTest() {
+
+    @Test
+    fun `Boolean task value is migrated on spawn without re-completing`() {
+        val player = createPlayer(Tile(3221, 3218))
+        player.variables.data["introducing_explorer_jack_task"] = true
+
+        Spawn.player(player)
+        tick(1)
+
+        assertEquals("completed", player["introducing_explorer_jack_task", ""])
+        assertEquals(0, player["task_progress_overall", 0])
+    }
 
     @Test
     fun `Dismissing unrelated completed task details doesn't remove pinned task`() {

--- a/game/src/test/kotlin/content/skill/farming/FlowerPatchTest.kt
+++ b/game/src/test/kotlin/content/skill/farming/FlowerPatchTest.kt
@@ -7,7 +7,9 @@ import objectOption
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DynamicTest.dynamicTest
+import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestFactory
+import world.gregs.voidps.engine.entity.Spawn
 import world.gregs.voidps.engine.entity.character.player.skill.Skill
 import world.gregs.voidps.engine.entity.item.Item
 import world.gregs.voidps.engine.entity.obj.GameObjects
@@ -80,6 +82,34 @@ class FlowerPatchTest : WorldTest() {
 
             assertEquals("${id}_$count", player["farming_flower_patch_falador", "empty"])
         }
+    }
+
+    @Test
+    fun `Bush seed can't be planted in a flower patch`() {
+        val tile = Tile(3054, 3306)
+        val player = createPlayer(tile)
+        player.inventory.add("whiteberry_seed")
+        player.inventory.add("seed_dibber")
+        player.levels.set(Skill.Farming, 99)
+        player["farming_flower_patch_falador"] = "weeds_0"
+        val patch = GameObjects.find(tile.addY(1), "farming_flower_patch_falador")
+
+        player.itemOnObject(patch, 0)
+        tick(10)
+
+        assertEquals("weeds_0", player["farming_flower_patch_falador", "empty"])
+        assertEquals(1, player.inventory.count("whiteberry_seed"))
+    }
+
+    @Test
+    fun `Invalid patch value is repaired on spawn`() {
+        val player = createPlayer(Tile(2809, 3462))
+        player["farming_flower_patch_catherby"] = "whiteberry_watered_0"
+
+        Spawn.player(player)
+        tick(1)
+
+        assertEquals("empty", player["farming_flower_patch_catherby", "empty"])
     }
 
     @TestFactory


### PR DESCRIPTION
Follow-up to #1223 (these two commits landed on that branch after it merged). More unknown-value warnings turned up in testing:

```
WARN [VariableDefinition] Unknown value 'whiteberry_watered_0' for map variable 729; not sent.
WARN [VariableDefinition] Unknown value 'true' for map variable 6494; not sent.
WARN [VariableDefinition] Unknown value 'incomplete' for map variable 281; not sent.
```

**Cross-patch planting (varbit 729)**

The weeded branch of `FarmingPatchPlant.plantSeed` calls `plant()` without ever checking the item's `farming_patch` type, so any seed could be planted in any patch — a whiteberry (bush) seed in the Catherby flower patch produced `whiteberry_0`, and watering made it `whiteberry_watered_0`, neither of which exist in the flower patch map. The check in the non-weeded branch was also dead for tree seeds: it compared the space-cased patch name ("fruit tree") against the underscore id ("fruit_tree"). Both branches now share one check derived from the variable name (`veg` maps to `allotment`).

The login repair from #1223 is generalised to clear any patch value missing from its varbit map instead of only Catherby `herb_dead` values, stuck values can never be sent or grow, so there's nothing to preserve. `varbitMap` uses a safe cast so patches without map defs are skipped instead of throwing.

**Boolean task values (varbit 6494)**

Saves the old `unlock` command wrote `true` into are migrated to `"completed"` on login. The migration writes `variables.data` directly because `set()` would re-fire `completeTask` and double-count `task_progress_overall`.

**Invalid quest value (varp 281)**

This one wasn't a stale save: `TaskSystem` writes `"incomplete"` every time the task system opens before the tutorial is completed, and the `unstable_foundations` map only has `unstarted`/`started`/`completed`. It writes `"started"` now, with a login migration for saves holding the old value. Nothing reads `"incomplete"` anywhere.

Tests cover the rejected cross-patch plant, the spawn repairs, and both migrations (including that task completion doesn't fire twice).