### PR TITLE
Fix assistance not applying to ancient effigy investigations

### DIFF
--- a/game/src/main/kotlin/content/social/assist/Assistance.kt
+++ b/game/src/main/kotlin/content/social/assist/Assistance.kt
@@ -1,11 +1,11 @@
 package content.social.assist
 
+import world.gregs.voidps.engine.client.variable.hasClock
 import world.gregs.voidps.engine.client.variable.remaining
 import world.gregs.voidps.engine.entity.character.player.Player
 import world.gregs.voidps.engine.entity.character.player.skill.Skill
 import world.gregs.voidps.engine.timer.epochSeconds
 import java.util.concurrent.TimeUnit
-import kotlin.math.max
 
 object Assistance {
 
@@ -46,12 +46,20 @@ object Assistance {
         if (remaining <= 0) {
             return 0
         }
-        return max(0, TimeUnit.MILLISECONDS.toHours(remaining.toLong()).toInt())
+        val seconds = TimeUnit.HOURS.toSeconds(1)
+        return ((remaining + seconds - 1) / seconds).toInt()
     }
 
     fun hasEarnedMaximumExperience(player: Player): Boolean {
         val earned = player["total_xp_earned", 0.0]
-        return exceededMaximum(earned)
+        if (!exceededMaximum(earned)) {
+            return false
+        }
+        if (player.hasClock("assist_timeout", epochSeconds())) {
+            return true
+        }
+        player.clear("total_xp_earned")
+        return false
     }
 
     fun exceededMaximum(earned: Double): Boolean = earned >= MAX_EXPERIENCE

--- a/game/src/main/kotlin/content/social/assist/RequestAssist.kt
+++ b/game/src/main/kotlin/content/social/assist/RequestAssist.kt
@@ -83,6 +83,7 @@ class RequestAssist : Script {
                 val maxed = exceededMaximum(gained)
                 player.exp(skill, exp)
                 player["total_xp_earned"] = gained.toInt()
+                // Capped assistants can keep assisting but no longer gain any experience
                 if (maxed) {
                     player.interfaces.sendText(
                         "assist_xp",
@@ -93,7 +94,6 @@ class RequestAssist : Script {
                         """,
                     )
                     player.start("assist_timeout", TimeUnit.HOURS.toSeconds(24).toInt())
-                    stopRedirectingAllExp(this)
                 }
             }
         }
@@ -141,7 +141,7 @@ class RequestAssist : Script {
             sendText("assist_xp", "description", "The Assist System is available for you to use.")
             sendText("assist_xp", "title", "Assist System XP Display - You are assisting ${assisted.name}")
         }
-        applyExistingSkillRedirects(player, assisted)
+        shareSkillsByDefault(player, assisted)
         setAssistAreaStatus(player, true)
         player.sendVariable("total_xp_earned")
         player.anim("assist")
@@ -149,20 +149,20 @@ class RequestAssist : Script {
         toggleInventory(player, enabled = false)
     }
 
-    fun applyExistingSkillRedirects(player: Player, assisted: Player) {
-        var clearedAny = false
+    // All skills are shared by default; the assistant can click any skill to switch it off
+    fun shareSkillsByDefault(player: Player, assisted: Player) {
+        var skippedAny = false
         for (skill in skills) {
             val key = "assist_toggle_${skill.name.lowercase()}"
-            if (player[key, false]) {
-                if (!canAssist(player, assisted, skill)) {
-                    player[key] = false
-                    clearedAny = true
-                } else {
-                    redirectSkillExperience(assisted, skill)
-                }
+            if (canAssist(player, assisted, skill)) {
+                player[key] = true
+                redirectSkillExperience(assisted, skill)
+            } else {
+                player[key] = false
+                skippedAny = true
             }
         }
-        if (clearedAny) {
+        if (skippedAny) {
             player.message("You can only assist skills which are higher than whom you are helping.")
         }
     }

--- a/game/src/main/kotlin/content/social/assist/RequestAssist.kt
+++ b/game/src/main/kotlin/content/social/assist/RequestAssist.kt
@@ -25,6 +25,7 @@ import world.gregs.voidps.engine.entity.character.player.req.request
 import world.gregs.voidps.engine.entity.character.player.skill.Skill
 import world.gregs.voidps.engine.entity.character.player.skill.exp.exp
 import world.gregs.voidps.engine.timer.TICKS
+import world.gregs.voidps.engine.timer.epochSeconds
 import java.util.concurrent.TimeUnit
 import kotlin.math.min
 
@@ -76,8 +77,8 @@ class RequestAssist : Script {
         blockedExperience { skill, experience ->
             val player: Player = get("assistant") ?: return@blockedExperience
             val active = player["assist_toggle_${skill.name.lowercase()}", false]
-            var gained = player["total_xp_earned", 0].toDouble()
-            if (active && !exceededMaximum(gained)) {
+            if (active && !hasEarnedMaximumExperience(player)) {
+                var gained = player["total_xp_earned", 0].toDouble()
                 val exp = min(experience / 10.0, (MAX_EXPERIENCE - gained) / 10)
                 gained += exp * 10.0
                 val maxed = exceededMaximum(gained)
@@ -93,7 +94,7 @@ class RequestAssist : Script {
                             You can assist again in 24 hours.
                         """,
                     )
-                    player.start("assist_timeout", TimeUnit.HOURS.toSeconds(24).toInt())
+                    player.start("assist_timeout", TimeUnit.HOURS.toSeconds(24).toInt(), epochSeconds())
                 }
             }
         }

--- a/game/src/test/kotlin/content/activity/ancient_effigies/AncientEffigiesTest.kt
+++ b/game/src/test/kotlin/content/activity/ancient_effigies/AncientEffigiesTest.kt
@@ -184,21 +184,75 @@ class AncientEffigiesTest : WorldTest() {
         assertEquals(1, player.inventory.count("nourished_ancient_effigy"))
     }
 
-    private fun setupAssistedInvestigator(assistantLevel: Int): Pair<Player, Player> {
+    private fun setupAssistedInvestigator(assistantLevel: Int, effigy: String = "starved_ancient_effigy"): Pair<Player, Player> {
         val assistant = createPlayer(emptyTile, "assistant")
         assistant["skip_level_up"] = true
         assistant.experience.set(Skill.Crafting, Level.experience(Skill.Crafting, assistantLevel))
         assistant.levels.set(Skill.Crafting, assistantLevel)
         val player = createPlayer(emptyTile.addY(1), "receiver")
-        player.inventory.add("starved_ancient_effigy")
-        player["effigy_starved"] = 0 // Agility and Crafting
+        player.inventory.add(effigy)
+        player["effigy_${effigy.removeSuffix("_ancient_effigy")}"] = 0 // Agility and Crafting
         player.playerOption(assistant, "Req Assist")
         tick()
         assistant.playerOption(player, "Req Assist")
         tick()
+        return Pair(player, assistant)
+    }
+
+    @Test
+    fun `An assistant can help with a nourished effigy`() {
+        assertAssistedStage("nourished_ancient_effigy", level = 93, xp = 20000.0, next = "sated_ancient_effigy")
+    }
+
+    @Test
+    fun `An assistant can help with a sated effigy`() {
+        assertAssistedStage("sated_ancient_effigy", level = 95, xp = 25000.0, next = "gorged_ancient_effigy")
+    }
+
+    @Test
+    fun `An assistant can help with a gorged effigy`() {
+        assertAssistedStage("gorged_ancient_effigy", level = 97, xp = 30000.0, next = "dragonkin_lamp")
+    }
+
+    @Test
+    fun `A capped assistant can still help investigate every stage without gaining xp`() {
+        val (player, assistant) = setupAssistedInvestigator(assistantLevel = 97)
+        val experience = assistant.experience.get(Skill.Crafting)
+
+        player.investigate("starved_ancient_effigy", option = 2)
+        player["effigy_nourished"] = 0 // Agility and Crafting
+        player.investigate("nourished_ancient_effigy", option = 2) // 35k total hits the 30k cap
+        player["effigy_sated"] = 0
+        player.investigate("sated_ancient_effigy", option = 2)
+        player["effigy_gorged"] = 0
+        player.investigate("gorged_ancient_effigy", option = 2)
+
+        assertEquals(experience + 30000.0, assistant.experience.get(Skill.Crafting))
+        assertEquals(0.0, player.experience.get(Skill.Crafting))
+        assertEquals(1, player.inventory.count("dragonkin_lamp"))
+    }
+
+    private fun assertAssistedStage(effigy: String, level: Int, xp: Double, next: String) {
+        val (player, assistant) = setupAssistedInvestigator(assistantLevel = level, effigy = effigy)
+        val experience = assistant.experience.get(Skill.Crafting)
+
+        player.investigate(effigy, option = 2)
+
+        assertEquals(experience + xp, assistant.experience.get(Skill.Crafting), effigy)
+        assertEquals(0.0, player.experience.get(Skill.Crafting), effigy)
+        assertEquals(1, player.inventory.count(next), next)
+    }
+
+    @Test
+    fun `A skill the assistant switched off can't be used to investigate`() {
+        val (player, assistant) = setupAssistedInvestigator(assistantLevel = 91)
         assistant.interfaceOption("assist_xp", "crafting", "Toggle Skill On / Off")
         tick()
-        return Pair(player, assistant)
+
+        player.investigate("starved_ancient_effigy", option = 2)
+
+        assertEquals(1, player.inventory.count("starved_ancient_effigy"))
+        assertTrue(player.containsMessage("You require at least level 91 Crafting to investigate the ancient effigy further."))
     }
 
     @Test

--- a/game/src/test/kotlin/content/social/assist/RequestAssistTest.kt
+++ b/game/src/test/kotlin/content/social/assist/RequestAssistTest.kt
@@ -9,11 +9,14 @@ import org.junit.jupiter.api.Test
 import playerOption
 import walk
 import world.gregs.voidps.engine.client.ui.hasOpen
+import world.gregs.voidps.engine.client.variable.start
+import world.gregs.voidps.engine.timer.epochSeconds
 import world.gregs.voidps.engine.entity.character.player.Player
 import world.gregs.voidps.engine.entity.character.player.req.hasRequest
 import world.gregs.voidps.engine.entity.character.player.skill.Skill
 import world.gregs.voidps.engine.inv.add
 import world.gregs.voidps.engine.inv.inventory
+import java.util.concurrent.TimeUnit
 import kotlin.test.assertFalse
 
 internal class RequestAssistTest : WorldTest() {
@@ -95,6 +98,34 @@ internal class RequestAssistTest : WorldTest() {
 
         receiver.playerOption(assistant, "Req Assist")
         assertFalse(receiver.hasRequest(assistant, "assist"))
+    }
+
+    @Test
+    fun `Capped assistants are refused with the hours remaining`() {
+        val assistant = createPlayer(emptyTile, "assistant")
+        val receiver = createPlayer(emptyTile.addY(1), "receiver")
+        assistant["total_xp_earned"] = 300000
+        assistant.start("assist_timeout", TimeUnit.HOURS.toSeconds(24).toInt(), epochSeconds())
+
+        receiver.playerOption(assistant, "Req Assist")
+        tick()
+
+        assertFalse(receiver.hasRequest(assistant, "assist"))
+        assertTrue(assistant.containsMessage("An assist request has been refused. You can assist again in 24 hours."))
+    }
+
+    @Test
+    fun `The experience cap resets once the timeout expires`() {
+        val assistant = createPlayer(emptyTile, "assistant")
+        val receiver = createPlayer(emptyTile.addY(1), "receiver")
+        assistant["total_xp_earned"] = 300000
+        assistant["assist_timeout"] = epochSeconds() - 100
+
+        receiver.playerOption(assistant, "Req Assist")
+        tick()
+
+        assertTrue(receiver.hasRequest(assistant, "assist"))
+        assertEquals(0, assistant["total_xp_earned", 0])
     }
 
     @Test

--- a/game/src/test/kotlin/content/social/assist/RequestAssistTest.kt
+++ b/game/src/test/kotlin/content/social/assist/RequestAssistTest.kt
@@ -10,12 +10,12 @@ import playerOption
 import walk
 import world.gregs.voidps.engine.client.ui.hasOpen
 import world.gregs.voidps.engine.client.variable.start
-import world.gregs.voidps.engine.timer.epochSeconds
 import world.gregs.voidps.engine.entity.character.player.Player
 import world.gregs.voidps.engine.entity.character.player.req.hasRequest
 import world.gregs.voidps.engine.entity.character.player.skill.Skill
 import world.gregs.voidps.engine.inv.add
 import world.gregs.voidps.engine.inv.inventory
+import world.gregs.voidps.engine.timer.epochSeconds
 import java.util.concurrent.TimeUnit
 import kotlin.test.assertFalse
 

--- a/game/src/test/kotlin/content/social/assist/RequestAssistTest.kt
+++ b/game/src/test/kotlin/content/social/assist/RequestAssistTest.kt
@@ -1,6 +1,7 @@
 package content.social.assist
 
 import WorldTest
+import containsMessage
 import interfaceOption
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
@@ -19,7 +20,8 @@ internal class RequestAssistTest : WorldTest() {
 
     @Test
     fun `Grant exp to assistant`() {
-        val (assistant, receiver) = setupAssist()
+        val assistant = createPlayer(emptyTile, "assistant")
+        val receiver = createPlayer(emptyTile.addY(1), "receiver")
         assistant.experience.set(Skill.Magic, 15000000.0)
         assistant.levels.set(Skill.Magic, 99)
         receiver.experience.set(Skill.Magic, 10000000.0)
@@ -27,14 +29,42 @@ internal class RequestAssistTest : WorldTest() {
         receiver.inventory.add("fire_rune")
         receiver.inventory.add("air_rune", 3)
         receiver.inventory.add("law_rune")
-
-        assistant.interfaceOption("assist_xp", "magic", "Toggle Skill On / Off")
+        receiver.playerOption(assistant, "Req Assist")
         tick()
+        assistant.playerOption(receiver, "Req Assist")
+        tick()
+
         receiver.interfaceOption("modern_spellbook", "varrock_teleport", "Cast")
         tickIf { receiver.tile == emptyTile.addY(1) }
 
         assertTrue(assistant.experience.get(Skill.Magic) > 15000000.0)
         assertEquals(10000000.0, receiver.experience.get(Skill.Magic))
+    }
+
+    @Test
+    fun `All skills the assistant can help with are shared by default`() {
+        val (assistant, _) = setupAssist()
+
+        for (skill in listOf("runecrafting", "crafting", "fletching", "construction", "farming", "magic", "smithing", "cooking", "herblore")) {
+            assertTrue(assistant["assist_toggle_$skill", false], skill)
+        }
+    }
+
+    @Test
+    fun `Skills lower than the assisted player's aren't shared`() {
+        val assistant = createPlayer(emptyTile, "assistant")
+        val receiver = createPlayer(emptyTile.addY(1), "receiver")
+        receiver["skip_level_up"] = true
+        receiver.experience.set(Skill.Cooking, 200000.0)
+        receiver.levels.set(Skill.Cooking, 50)
+        receiver.playerOption(assistant, "Req Assist")
+        tick()
+        assistant.playerOption(receiver, "Req Assist")
+        tick()
+
+        assertFalse(assistant["assist_toggle_cooking", false])
+        assertTrue(assistant["assist_toggle_crafting", false])
+        assertTrue(assistant.containsMessage("You can only assist skills which are higher than whom you are helping."))
     }
 
     @Test


### PR DESCRIPTION
Follow-up to #1221. Manual testing showed the level check still blocked an assisted player even when the assistant had the required level. Two separate bugs:

**Skill toggles defaulted to off.** `Assistance.assistant()` only accepts an assistant whose `assist_toggle_<skill>` is on, but every toggle started disabled, so assistance did nothing until the assistant manually clicked each skill. Authentic behaviour is the opposite: "All of the skills are shared by default, though the assisting player can click on any skill to switch it off" ([Assist System](https://runescape.wiki/w/Assist_System), same text in the June 2011 revision). `setupAssistant` now enables every skill the assistant is high enough to share (existing `canAssist` check, with the existing message when some are skipped), and clicking a skill still toggles it off.

**The 30k cap ended assistance mid-session.** Per the wiki, capped assistants "can continue to assist without receiving any extra experience", so the redirects now stay in place: the effigy keeps advancing, overflow experience is lost, and the 24-hour timeout still starts once at the cap (the `exceededMaximum` guard stops it restarting on later drops). New assist requests are still refused while capped.

Tests: effigy assist setup no longer toggles a skill, so it covers the default-share path; added per-stage assist tests for nourished/sated/gorged, a full four-stage chain with one capped assistant (exactly +30,000 to the assistant, lamp produced), a test that a switched-off skill blocks investigation, and RequestAssist tests for default sharing and for lower-level skills being skipped. `Grant exp to assistant` now sets levels before the session starts, since redirects begin at setup and `Experience.set` ignores blocked skills.