### PR TITLE
Fix charter ship interface at Port Tyras and quest requirements

### DIFF
--- a/game/src/main/kotlin/content/entity/obj/ship/CharterShip.kt
+++ b/game/src/main/kotlin/content/entity/obj/ship/CharterShip.kt
@@ -27,6 +27,7 @@ class CharterShip(val ships: CharterShips, val teles: ObjectTeleports) : Script 
         "brimhaven",
         "port_khazard",
         "port_sarim",
+        "musa_point",
     )
 
     init {
@@ -39,7 +40,6 @@ class CharterShip(val ships: CharterShips, val teles: ObjectTeleports) : Script 
             interfaces.sendVisibility(id, "port_phasmatys", hasQuestRequirements("port_phasmatys") && prices.containsKey("port_phasmatys"))
             interfaces.sendVisibility(id, "oo_glog", hasQuestRequirements("oo_glog") && prices.containsKey("oo_glog"))
             interfaces.sendVisibility(id, "crandor", false)
-            interfaces.sendVisibility(id, "musa_point", false)
             for (location in locations) {
                 interfaces.sendVisibility(id, location, location != currentLocation && prices.containsKey(location))
             }
@@ -153,7 +153,7 @@ class CharterShip(val ships: CharterShips, val teles: ObjectTeleports) : Script 
     fun Player.hasQuestRequirements(location: String): Boolean {
         return questCompleted(
             when (location) {
-                "mos_le_harmless" -> "mos_le_harmless"
+                "mos_le_harmless" -> "cabin_fever"
                 "shipyard" -> "the_grand_tree"
                 "port_tyras" -> "regicide"
                 "port_phasmatys" -> "priest_in_peril"
@@ -166,7 +166,7 @@ class CharterShip(val ships: CharterShips, val teles: ObjectTeleports) : Script 
     fun location(npc: NPC) = when (npc["spawn_tile", Tile.EMPTY]) {
         Tile(3033, 3192), Tile(3039, 3193), Tile(3042, 3192) -> "port_sarim"
         Tile(2759, 3239), Tile(2760, 3239) -> "brimhaven"
-        Tile(2144, 3122), Tile(2145, 3122) -> "tyras_camp"
+        Tile(2144, 3122), Tile(2145, 3122) -> "port_tyras"
         Tile(3001, 3033), Tile(3001, 3034) -> "shipyard"
         Tile(2673, 3144), Tile(2675, 3144) -> "port_khazard"
         Tile(3671, 2930), Tile(3672, 2930) -> "mos_le_harmless"

--- a/game/src/test/kotlin/content/entity/obj/ship/CharterShipTest.kt
+++ b/game/src/test/kotlin/content/entity/obj/ship/CharterShipTest.kt
@@ -34,6 +34,39 @@ class CharterShipTest : WorldTest() {
     }
 
     @Test
+    fun `Sail from Port Tyras`() {
+        val player = createPlayer(Tile(2146, 3122))
+        player.inventory.add("coins", 5000)
+        val crew = createNPC("trader_crewmember_black", Tile(2144, 3122))
+
+        player.npcOption(crew, "Charter")
+        tick()
+        assertEquals("port_tyras", player["charter_ship", ""])
+        player.interfaceOption("charter_ship_map", "catherby", "Ok")
+        tick()
+        player.dialogueContinue()
+        player.dialogueOption("line1")
+        tick(5)
+        assertEquals(Tile(2792, 3417, 1), player.tile)
+    }
+
+    @Test
+    fun `Sail to Musa Point`() {
+        val player = createPlayer(Tile(2796, 3414))
+        player.inventory.add("coins", 1000)
+        val crew = createNPC("trader_crewmember_blue", Tile(2795, 3414))
+
+        player.npcOption(crew, "Charter")
+        tick()
+        player.interfaceOption("charter_ship_map", "musa_point", "Ok")
+        tick()
+        player.dialogueContinue()
+        player.dialogueOption("line1")
+        tick(5)
+        assertEquals(Tile(2957, 3158, 1), player.tile)
+    }
+
+    @Test
     fun `Can't travel to same location`() {
         val player = createPlayer(Tile(2796, 3414))
         player.inventory.add("coins", 3000)


### PR DESCRIPTION
Fixes #1228

## Bugs

**Port Tyras map had no destinations** (NPCs 4651/4654): `location()` mapped the Tyras trader spawn tiles to `"tyras_camp"`, but the price config, gangplank teleports and interface components all use `"port_tyras"`. The price lookup returned an empty map, so every X mark on the travel interface was hidden. Verified all other ports' spawn tiles match their config keys.

**Wrong quest gate for Mos Le'Harmless**: gated on quest id `"mos_le_harmless"`, which doesn't exist. Now gated on `cabin_fever` per the quest requirements. The other gates (`the_grand_tree` for the Shipyard, `regicide` for Port Tyras, `as_a_first_resort` for Oo'glog, `priest_in_peril` for Port Phasmatys) were already correct.

**Musa Point was unreachable**: the map component was hardcoded invisible even though prices, gangplank teleports, spawns and Trader Stan's dialogue all support it. Now shown like the other ungated destinations. `crandor` stays hidden as it's never charterable, and `[port_sarim]` prices correctly omit Musa Point (that route is served by the 30gp sailors).

## Tests

- `Sail from Port Tyras`: charters from a Tyras trader crewmember, asserts the map opens with the correct origin and the player arrives at Catherby.
- `Sail to Musa Point`: charters from Catherby, asserts arrival on the Musa Point ship deck.