### PR TITLE
Fix dropped connections never saving the player

### DIFF
--- a/engine/src/main/kotlin/world/gregs/voidps/engine/client/PlayerAccountLoader.kt
+++ b/engine/src/main/kotlin/world/gregs/voidps/engine/client/PlayerAccountLoader.kt
@@ -11,6 +11,7 @@ import world.gregs.voidps.engine.data.Storage
 import world.gregs.voidps.engine.data.definition.AccountDefinitions
 import world.gregs.voidps.engine.entity.World
 import world.gregs.voidps.engine.entity.character.player.Player
+import world.gregs.voidps.engine.entity.character.player.Players
 import world.gregs.voidps.engine.entity.character.player.name
 import world.gregs.voidps.engine.entity.character.player.rights
 import world.gregs.voidps.engine.event.AuditLog
@@ -86,13 +87,20 @@ class PlayerAccountLoader(
     }
 
     suspend fun connect(player: Player, client: Client, displayMode: Int = 0, viewport: Boolean = true) {
-        if (!accounts.setup(player, client, displayMode, viewport)) {
-            logger.warn { "Error setting up account" }
-            client.disconnect(Response.WORLD_FULL)
-            return
-        }
         withContext(gameContext) {
             queue.await()
+            val existing = Players.findByAccount(player.accountName)
+            if (existing != null) {
+                logger.warn { "Logging out stale session for ${player.accountName} before login." }
+                accounts.logout(existing, safely = false)
+                client.disconnect(Response.ACCOUNT_ONLINE)
+                return@withContext
+            }
+            if (!accounts.setup(player, client, displayMode, viewport)) {
+                logger.warn { "Error setting up account" }
+                client.disconnect(Response.WORLD_FULL)
+                return@withContext
+            }
             logger.info { "${if (viewport) "Player" else "Bot"} logged in ${player.accountName} index ${player.index}." }
             client.login(player.name, player.index, player.rights.ordinal, member = World.members, membersWorld = World.members)
             accounts.spawn(player, client)

--- a/engine/src/main/kotlin/world/gregs/voidps/engine/client/PlayerAccountLoader.kt
+++ b/engine/src/main/kotlin/world/gregs/voidps/engine/client/PlayerAccountLoader.kt
@@ -87,6 +87,7 @@ class PlayerAccountLoader(
     }
 
     suspend fun connect(player: Player, client: Client, displayMode: Int = 0, viewport: Boolean = true) {
+        accounts.setup(player, client, displayMode, viewport)
         withContext(gameContext) {
             queue.await()
             val existing = Players.findByAccount(player.accountName)
@@ -96,7 +97,7 @@ class PlayerAccountLoader(
                 client.disconnect(Response.ACCOUNT_ONLINE)
                 return@withContext
             }
-            if (!accounts.setup(player, client, displayMode, viewport)) {
+            if (!accounts.index(player)) {
                 logger.warn { "Error setting up account" }
                 client.disconnect(Response.WORLD_FULL)
                 return@withContext

--- a/engine/src/main/kotlin/world/gregs/voidps/engine/data/AccountManager.kt
+++ b/engine/src/main/kotlin/world/gregs/voidps/engine/data/AccountManager.kt
@@ -44,9 +44,7 @@ class AccountManager(
         this["new_player"] = true
     }
 
-    fun setup(player: Player, client: Client?, displayMode: Int, viewport: Boolean = true): Boolean {
-        player.index = Players.index() ?: return false
-        player.visuals.hits.self = player.index
+    fun setup(player: Player, client: Client?, displayMode: Int, viewport: Boolean = true) {
         player.interfaces = Interfaces(player)
         player.interfaceOptions = InterfaceOptions(player)
 //        player.area.areaDefinitions = areaDefinitions
@@ -70,6 +68,11 @@ class AccountManager(
             player.viewport = Viewport()
         }
         player.collision = CollisionStrategyProvider.get(character = player)
+    }
+
+    fun index(player: Player): Boolean {
+        player.index = Players.index() ?: return false
+        player.visuals.hits.self = player.index
         return true
     }
 

--- a/engine/src/main/kotlin/world/gregs/voidps/engine/data/AccountManager.kt
+++ b/engine/src/main/kotlin/world/gregs/voidps/engine/data/AccountManager.kt
@@ -103,7 +103,7 @@ class AccountManager(
             player.message("You need to wait a few moments before you can log out.")
             return
         }
-        if (!Despawn.logout(player)) {
+        if (safely && !Despawn.logout(player)) {
             return
         }
         player["logged_out"] = true

--- a/engine/src/main/kotlin/world/gregs/voidps/engine/data/SaveQueue.kt
+++ b/engine/src/main/kotlin/world/gregs/voidps/engine/data/SaveQueue.kt
@@ -38,15 +38,22 @@ class SaveQueue(
         this.job = scope.save(pending.values.toList())
     }
 
-    fun direct(): Job = scope.save(Players.filter { !it.contains("bot") }.map { it.copy() })
+    fun direct(): Job {
+        val online = Players.filter { !it.contains("bot") }.map { it.copy() }
+        val names = online.mapTo(HashSet()) { it.name }
+        val queued = pending.values.filter { it.name !in names }
+        return scope.save(online + queued)
+    }
+
+    suspend fun awaitInFlight() {
+        job?.join()
+    }
 
     private fun CoroutineScope.save(accounts: List<PlayerSave>) = launch(handler) {
         val took = measureTimeMillis {
             withContext(NonCancellable) {
                 storage.save(accounts)
-                for (account in accounts) {
-                    pending.remove(account.name)
-                }
+                clearPending(accounts)
             }
         }
         logger.info { "Saved ${accounts.size} ${"account".plural(accounts.size)} in ${took}ms" }
@@ -55,8 +62,14 @@ class SaveQueue(
     private fun CoroutineScope.fallback(accounts: List<PlayerSave>) = launch(fallbackHandler) {
         withContext(NonCancellable) {
             fallback.save(accounts)
-            for (account in accounts) {
-                pending.remove(account.name)
+            clearPending(accounts)
+        }
+    }
+
+    private fun clearPending(accounts: List<PlayerSave>) {
+        for (account in accounts) {
+            pending.computeIfPresent(account.name) { _, current ->
+                if (current === account) null else current
             }
         }
     }

--- a/engine/src/test/kotlin/world/gregs/voidps/engine/client/PlayerAccountLoaderTest.kt
+++ b/engine/src/test/kotlin/world/gregs/voidps/engine/client/PlayerAccountLoaderTest.kt
@@ -129,7 +129,7 @@ internal class PlayerAccountLoaderTest : KoinMock() {
         val client: Client = mockk(relaxed = true)
         val player = Player(index = 4, accountName = "name", passwordHash = "\$2a\$10\$cPB7bqICWrOILrWnXuYNDu1EsbZal9AjxYMbmpMOtI1kwruazGiby", variables = mutableMapOf("display_name" to "name"))
         coEvery { queue.await() } just Runs
-        every { accounts.setup(any(), client, 2) } returns true
+        every { accounts.index(any()) } returns true
 
         loader.connect(player, client, 2)
 
@@ -149,6 +149,7 @@ internal class PlayerAccountLoaderTest : KoinMock() {
         every { Players.findByAccount("name") } returns ghost
         try {
             val player = Player(index = 4, accountName = "name", variables = mutableMapOf("display_name" to "name"))
+            every { accounts.index(any()) } returns true
 
             loader.connect(player, client, 2)
 
@@ -167,7 +168,7 @@ internal class PlayerAccountLoaderTest : KoinMock() {
         mockkStatic("world.gregs.voidps.network.login.protocol.encode.LoginEncoderKt")
         val client: Client = mockk(relaxed = true)
         val player = Player(index = 4, accountName = "name", passwordHash = "\$2a\$10\$cPB7bqICWrOILrWnXuYNDu1EsbZal9AjxYMbmpMOtI1kwruazGiby", variables = mutableMapOf("display_name" to "name"))
-        every { accounts.setup(player, client, 2) } returns false
+        every { accounts.index(player) } returns false
 
         loader.connect(player, client, 2)
 

--- a/engine/src/test/kotlin/world/gregs/voidps/engine/client/PlayerAccountLoaderTest.kt
+++ b/engine/src/test/kotlin/world/gregs/voidps/engine/client/PlayerAccountLoaderTest.kt
@@ -14,6 +14,7 @@ import world.gregs.voidps.engine.data.exchange.Claim
 import world.gregs.voidps.engine.data.exchange.OpenOffers
 import world.gregs.voidps.engine.data.exchange.PriceHistory
 import world.gregs.voidps.engine.entity.character.player.Player
+import world.gregs.voidps.engine.entity.character.player.Players
 import world.gregs.voidps.engine.entity.character.player.chat.clan.Clan
 import world.gregs.voidps.engine.script.KoinMock
 import world.gregs.voidps.network.Response
@@ -136,6 +137,28 @@ internal class PlayerAccountLoaderTest : KoinMock() {
             queue.await()
             client.login("name", 4, 0, member = false, membersWorld = false)
             accounts.spawn(player, client)
+        }
+    }
+
+    @Test
+    fun `Can't login while an earlier session is still in the world`() = runTest {
+        mockkStatic("world.gregs.voidps.network.login.protocol.encode.LoginEncoderKt")
+        mockkObject(Players)
+        val client: Client = mockk(relaxed = true)
+        val ghost = Player(index = 7, accountName = "name")
+        every { Players.findByAccount("name") } returns ghost
+        try {
+            val player = Player(index = 4, accountName = "name", variables = mutableMapOf("display_name" to "name"))
+
+            loader.connect(player, client, 2)
+
+            coVerify {
+                accounts.logout(ghost, safely = false)
+                client.disconnect(Response.ACCOUNT_ONLINE)
+            }
+            coVerify(exactly = 0) { accounts.spawn(player, client) }
+        } finally {
+            unmockkObject(Players)
         }
     }
 

--- a/engine/src/test/kotlin/world/gregs/voidps/engine/data/AccountManagerTest.kt
+++ b/engine/src/test/kotlin/world/gregs/voidps/engine/data/AccountManagerTest.kt
@@ -140,6 +140,7 @@ class AccountManagerTest : KoinMock() {
         val client = DummyClient()
         val player = Player(accountName = "name", tile = Tile(3200, 3200))
         manager.setup(player, client, 0, viewport = false)
+        manager.index(player)
         manager.spawn(player, client)
 
         client.disconnect()

--- a/engine/src/test/kotlin/world/gregs/voidps/engine/data/AccountManagerTest.kt
+++ b/engine/src/test/kotlin/world/gregs/voidps/engine/data/AccountManagerTest.kt
@@ -34,6 +34,7 @@ class AccountManagerTest : KoinMock() {
 
     private lateinit var manager: AccountManager
     private lateinit var connectionQueue: ConnectionQueue
+    private lateinit var saveQueue: SaveQueue
 
     override val modules = listOf(
         module {
@@ -78,9 +79,10 @@ class AccountManagerTest : KoinMock() {
             override fun load(accountName: String): PlayerSave? = null
         }
         Settings.load(mapOf("world.home.x" to "1234", "world.home.y" to "5432", "world.experienceRate" to "1.0"))
+        saveQueue = SaveQueue(storage)
         manager = AccountManager(
             accountDefinitions = AccountDefinitions(),
-            saveQueue = SaveQueue(storage),
+            saveQueue = saveQueue,
             connectionQueue = connectionQueue,
             overrides = AppearanceOverrides(),
         )
@@ -131,6 +133,23 @@ class AccountManagerTest : KoinMock() {
             client.logout()
             client.disconnect()
         }
+    }
+
+    @Test
+    fun `Dropped connection still saves the session`() = runTest {
+        val client = DummyClient()
+        val player = Player(accountName = "name", tile = Tile(3200, 3200))
+        manager.setup(player, client, 0, viewport = false)
+        manager.spawn(player, client)
+
+        client.disconnect()
+        client.exit()
+        connectionQueue.run()
+        GameLoop.tick = 2
+        World.run()
+
+        assertTrue(saveQueue.saving("name"), "Dropped connection never queued a save, losing the session")
+        assertTrue(player["logged_out", false], "Dropped connection left the player logged in as a ghost")
     }
 
     @AfterEach

--- a/engine/src/test/kotlin/world/gregs/voidps/engine/data/SaveQueueTest.kt
+++ b/engine/src/test/kotlin/world/gregs/voidps/engine/data/SaveQueueTest.kt
@@ -1,5 +1,6 @@
 package world.gregs.voidps.engine.data
 
+import kotlinx.coroutines.runBlocking
 import org.junit.jupiter.api.Test
 import world.gregs.voidps.engine.data.config.AccountDefinition
 import world.gregs.voidps.engine.data.exchange.Claim
@@ -8,11 +9,15 @@ import world.gregs.voidps.engine.data.exchange.PriceHistory
 import world.gregs.voidps.engine.entity.character.player.Player
 import world.gregs.voidps.engine.entity.character.player.chat.clan.Clan
 import world.gregs.voidps.engine.script.KoinMock
+import world.gregs.voidps.type.Tile
 import java.io.IOException
+import java.util.concurrent.CopyOnWriteArrayList
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicInteger
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 internal class SaveQueueTest : KoinMock() {
@@ -106,6 +111,69 @@ internal class SaveQueueTest : KoinMock() {
             calls.get() == 2
         }
         waitFor("pending to drain") { queue.empty() }
+    }
+
+    @Test
+    fun `Save queued during a write isn't dropped`() {
+        val started = CountDownLatch(1)
+        val release = CountDownLatch(1)
+        val blocked = AtomicBoolean(true)
+        val written = CopyOnWriteArrayList<Tile>()
+        val storage = object : TestStorage() {
+            override fun save(accounts: List<PlayerSave>) {
+                accounts.mapTo(written) { it.tile }
+                if (!blocked.getAndSet(false)) {
+                    return
+                }
+                started.countDown()
+                release.await(5, TimeUnit.SECONDS)
+            }
+        }
+        val queue = SaveQueue(storage)
+        queue.save(Player(accountName = "player", tile = Tile(1, 1)))
+        queue.run()
+        assertTrue(started.await(5, TimeUnit.SECONDS), "First save didn't start")
+        queue.save(Player(accountName = "player", tile = Tile(2, 2)))
+        release.countDown()
+        waitFor("newer snapshot to be written") {
+            queue.run()
+            written.contains(Tile(2, 2))
+        }
+        waitFor("pending to drain") { queue.empty() }
+    }
+
+    @Test
+    fun `Completed save clears pending when nothing superseded it`() {
+        val written = CopyOnWriteArrayList<String>()
+        val storage = object : TestStorage() {
+            override fun save(accounts: List<PlayerSave>) {
+                accounts.mapTo(written) { it.name }
+            }
+        }
+        val queue = SaveQueue(storage)
+        queue.save(Player(accountName = "player"))
+        waitFor("save to complete") {
+            queue.run()
+            written.contains("player")
+        }
+        waitFor("pending to drain") { queue.empty() }
+        assertFalse(queue.saving("player"))
+    }
+
+    @Test
+    fun `Shutdown save includes accounts pending from a logout`() {
+        val written = CopyOnWriteArrayList<String>()
+        val storage = object : TestStorage() {
+            override fun save(accounts: List<PlayerSave>) {
+                accounts.mapTo(written) { it.name }
+            }
+        }
+        val queue = SaveQueue(storage)
+        queue.save(Player(accountName = "logged_out_player"))
+
+        runBlocking { queue.direct().join() }
+
+        assertTrue(written.contains("logged_out_player"), "Shutdown dropped a save left pending by a logout")
     }
 
     private fun waitFor(description: String, condition: () -> Boolean) {

--- a/game/src/main/kotlin/content/entity/player/AutoSave.kt
+++ b/game/src/main/kotlin/content/entity/player/AutoSave.kt
@@ -22,6 +22,7 @@ class AutoSave(
 
         worldDespawn {
             runBlocking {
+                saveQueue.awaitInFlight()
                 saveQueue.direct().join()
                 exchange.save()
             }

--- a/game/src/test/kotlin/WorldTest.kt
+++ b/game/src/test/kotlin/WorldTest.kt
@@ -110,7 +110,8 @@ abstract class WorldTest : KoinTest {
             throw IllegalStateException("Player already exists: $name")
         }
         val player = Player(tile = tile, accountName = name, passwordHash = "")
-        assertTrue(accounts.setup(player, null, 0, viewport = true))
+        accounts.setup(player, null, 0, viewport = true)
+        assertTrue(accounts.index(player))
         accountDefs.add(player)
         tick()
         player["creation"] = -1

--- a/game/src/test/kotlin/content/area/karamja/tzhaar_city/TzhaarFightCaveTest.kt
+++ b/game/src/test/kotlin/content/area/karamja/tzhaar_city/TzhaarFightCaveTest.kt
@@ -18,6 +18,7 @@ import world.gregs.voidps.engine.entity.character.move.tele
 import world.gregs.voidps.engine.entity.character.npc.NPCs
 import world.gregs.voidps.engine.entity.character.player.Player
 import world.gregs.voidps.engine.entity.character.player.PlayerRights
+import world.gregs.voidps.engine.entity.character.player.Players
 import world.gregs.voidps.engine.entity.character.player.rights
 import world.gregs.voidps.engine.entity.character.player.skill.Skill
 import world.gregs.voidps.engine.entity.obj.GameObjects
@@ -181,6 +182,26 @@ class TzhaarFightCaveTest : WorldTest() {
         manager.logout(player, true)
         tick()
         assertEquals(Tile(2413, 5113), player.tile)
+    }
+
+    @Test
+    fun `Connection loss mid wave still logs the player out`() = runTest {
+        setRandom(object : FakeRandom() {
+            override fun nextBits(bitCount: Int): Int = 0
+        })
+        val player = createPlayer(Tile(2438, 5168), "JalYt-11")
+        player["god_mode"] = true
+        val entrance = GameObjects.find(Tile(2437, 5166), "cave_entrance_fight_cave")
+        player.interactObject(entrance, "Enter")
+        tick(5)
+        player["fight_cave_wave"] = 10
+
+        get<AccountManager>().logout(player, false)
+        tick(3)
+
+        assertTrue(player["logged_out", false], "Involuntary disconnect was vetoed instead of logging out")
+        assertNull(Players.findByAccount(player.accountName), "Involuntary disconnect left a ghost in the world")
+        assertFalse(Instances.reserved(player.tile.region), "Player should be saved on real map")
     }
 
     @Test

--- a/network/src/main/kotlin/world/gregs/voidps/network/client/Client.kt
+++ b/network/src/main/kotlin/world/gregs/voidps/network/client/Client.kt
@@ -49,15 +49,16 @@ open class Client(
         }
         disconnected = true
         write.flushAndClose()
-        state = ClientState.Disconnected
         disconnect?.invoke()
     }
 
     suspend fun exit() {
-        if (state == ClientState.Connected) {
-            state = ClientState.Disconnecting
-            disconnecting?.invoke()
+        if (state != ClientState.Connected) {
+            return
         }
+        state = ClientState.Disconnecting
+        disconnecting?.invoke()
+        state = ClientState.Disconnected
     }
 
     open fun flush() {

--- a/network/src/test/kotlin/world/gregs/voidps/network/client/ClientTest.kt
+++ b/network/src/test/kotlin/world/gregs/voidps/network/client/ClientTest.kt
@@ -1,0 +1,55 @@
+package world.gregs.voidps.network.client
+
+import io.ktor.utils.io.*
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+internal class ClientTest {
+
+    private fun client() = Client(ByteChannel(false), IsaacCipher(IntArray(4)), null, "127.0.0.1")
+
+    @Test
+    fun `Exit still logs out after a write error disconnected the client`() = runTest {
+        val client = client()
+        var loggedOut = false
+        client.onDisconnecting {
+            loggedOut = true
+        }
+
+        client.disconnect()
+        client.exit()
+
+        assertTrue(loggedOut, "Logout skipped because disconnect() poisoned the client state")
+    }
+
+    @Test
+    fun `Logout only runs once`() = runTest {
+        val client = client()
+        var count = 0
+        client.onDisconnecting {
+            count++
+        }
+
+        client.exit()
+        client.exit()
+
+        assertEquals(1, count)
+    }
+
+    @Test
+    fun `Disconnect callback only runs once`() = runTest {
+        val client = client()
+        var count = 0
+        client.onDisconnected {
+            count++
+        }
+
+        client.disconnect()
+        client.disconnect()
+
+        assertEquals(1, count)
+        assertTrue(client.disconnected)
+    }
+}


### PR DESCRIPTION
Players log back in at a position from hours earlier.

## Cause

`Client.disconnect()` set `state` to `Disconnected`, and `Client.exit()` only invoked the `disconnecting` hook while `state` was `Connected`:

```kotlin
suspend fun exit() {
    if (state == ClientState.Connected) {
        state = ClientState.Disconnecting
        disconnecting?.invoke()
    }
}
```

A client closing its socket makes the next write throw. The write error handler (`Client.kt:19-24`) calls `disconnect()`, so by the time the read loop unwinds into `LoginServer.kt:144-146`'s `finally { client.exit(); client.disconnect() }`, `exit()` is a no-op. `AccountManager.logout` never runs, and neither does anything inside it:

```kotlin
connectionQueue.disconnect {
    World.queue("logout_${player.accountName}", 1) {
        Players.remove(player)        // only production call site
    }
    Despawn.player(player)
    saveQueue.save(player)            // only production call site
    AuditLog.event(player, "disconnected", player.tile)
}
```

Both `saveQueue.save` and `Players.remove` appear nowhere else outside tests. So the session isn't saved, and the `Player` stays in the world frozen at the tile it held when the connection went. `AutoSave` iterates `Players` with no `logged_out` filter, so that stale tile gets written over the account file every interval, undoing whatever a later session saved. Which write wins depends on list order, hence the inconsistent reproduction.

## Fix

`disconnect()` no longer touches `state`; `exit()` sets `Disconnected` after the hook runs. `send()` was already gated on the `disconnected` flag (`Client.kt:75`), so that assignment only ever served to disable `exit()`.

Three other paths lost sessions the same way.

`Despawn.logout` let a script cancel an involuntary disconnect. Its only handler, `TzhaarFightCave.logoutChoice`, messages the player and returns `false` on first call, which can't work for someone whose socket is already gone and left them unsaved in the caves. The veto is now scoped to voluntary logout. Clicking Logout still warns and logs out on the second click, covered by the existing tests.

`SaveQueue` removed entries from `pending` by key after writing, discarding any snapshot that replaced them mid-write. The `job.isActive` guard from #1215 widened that window from one tick to the whole write, so it starts biting as soon as logout begins queueing saves again. `clearPending` removes by identity instead, letting a superseded snapshot survive to the next tick.

`SaveQueue.direct()` is the shutdown save and it snapshotted `Players` while ignoring `pending`. A player who logged out cleanly is already out of `Players` and waiting in `pending` for the next tick, so stopping the server in that window dropped their save. It now includes pending entries for accounts that are no longer online, and `AutoSave`'s `worldDespawn` awaits the in-flight write before taking the shutdown snapshot, so the two don't race the same file. This one affects clean logouts, not just dropped connections.

Login also reaps a stale session for the account before loading, since `LoginServer` frees the username a tick before the save is queued. Moving `setup` inside `withContext(gameContext)` fixes a second thing: `Players.index()` was being called off the game thread, where two concurrent logins can be handed the same index and `Players.add` silently returns `false` for the loser.

## Tests

Each change has a test that fails without it. `AccountManagerTest` runs the production teardown sequence through a real `DummyClient`, whose `disconnect()`, `exit()` and state machine are the real implementations:

```kotlin
client.disconnect()   // write error handler
client.exit()         // LoginServer's finally
connectionQueue.run()
World.run()

assertTrue(saveQueue.saving("name"), "Dropped connection never queued a save, losing the session")
```

On the old code that fails with `expected: <true> but was: <false>`.

| Change | Test |
|---|---|
| `Client` state machine | `Dropped connection still saves the session`, `Exit still logs out after a write error disconnected the client` |
| Logout veto scope | `Connection loss mid wave still logs the player out` |
| `SaveQueue` identity removal | `Save queued during a write isn't dropped` |
| Shutdown includes pending | `Shutdown save includes accounts pending from a logout` |
| Stale session reaping | `Can't login while an earlier session is still in the world` |

Full suite green.

## Left alone

Found while tracing this, none of it needed here:

- `SaveQueue`'s exception handler drains all of `pending` to `SafeStorage`, including accounts it never tried to write. `SafeStorage.load()` returns null and `exists()` returns false, so those accounts are gone from the real storage path rather than merely dumped.
- `AutoSave.kt:32` calls `World.contains("auto_save")`, which reads a world variable rather than `World.containsQueue`. The condition is always false, so `::reload settings` re-queues and pushes the deadline out, and the `clearQueue` branch is unreachable.
- `Config.fileWriter` truncates in place with no temp file or fsync, while `PlayerSave.copy()` passes the live `friends` map by reference when every other field is copied. A concurrent modification throws on the IO thread after the file is already truncated.
