### PR TITLE
Retry failed player saves instead of draining them to SafeStorage

### DIFF
--- a/engine/src/main/kotlin/world/gregs/voidps/engine/data/SaveQueue.kt
+++ b/engine/src/main/kotlin/world/gregs/voidps/engine/data/SaveQueue.kt
@@ -7,24 +7,22 @@ import world.gregs.voidps.engine.entity.character.player.Player
 import world.gregs.voidps.engine.entity.character.player.Players
 import java.lang.Runnable
 import java.util.concurrent.ConcurrentHashMap
-import kotlin.system.measureTimeMillis
+import java.util.concurrent.TimeUnit
 
 class SaveQueue(
     private val storage: Storage,
     private val fallback: Storage = storage,
     // SupervisorJob so a failed save doesn't cancel the scope and kill future saves
     private val scope: CoroutineScope = CoroutineScope(Dispatchers.IO + SupervisorJob()),
+    private val retryMillis: Long = TimeUnit.MINUTES.toMillis(Settings["storage.save.retryMinutes", 5].toLong()),
 ) : Runnable {
     private val pending = ConcurrentHashMap<String, PlayerSave>()
+    private val failing = ConcurrentHashMap<String, Long>()
     private val logger = InlineLogger()
     private var job: Job? = null
 
     private val handler = CoroutineExceptionHandler { _, exception ->
-        logger.error(exception) { "Error saving players!" }
-        scope.fallback(pending.values.toList())
-    }
-    private val fallbackHandler = CoroutineExceptionHandler { _, exception ->
-        logger.error(exception) { "Fallback save failed!" }
+        logger.error(exception) { "Unexpected error in the save queue!" }
     }
 
     override fun run() {
@@ -42,27 +40,52 @@ class SaveQueue(
         val online = Players.filter { !it.contains("bot") }.map { it.copy() }
         val names = online.mapTo(HashSet()) { it.name }
         val queued = pending.values.filter { it.name !in names }
-        return scope.save(online + queued)
+        return scope.save(online + queued, retry = false)
     }
 
     suspend fun awaitInFlight() {
         job?.join()
     }
 
-    private fun CoroutineScope.save(accounts: List<PlayerSave>) = launch(handler) {
-        val took = measureTimeMillis {
-            withContext(NonCancellable) {
+    private fun CoroutineScope.save(accounts: List<PlayerSave>, retry: Boolean = true) = launch(handler) {
+        withContext(NonCancellable) {
+            val start = System.currentTimeMillis()
+            try {
                 storage.save(accounts)
-                clearPending(accounts)
+            } catch (e: Exception) {
+                failed(accounts, e, retry)
+                return@withContext
             }
+            clearPending(accounts)
+            clearFailing(accounts)
+            logger.info { "Saved ${accounts.size} ${"account".plural(accounts.size)} in ${System.currentTimeMillis() - start}ms" }
         }
-        logger.info { "Saved ${accounts.size} ${"account".plural(accounts.size)} in ${took}ms" }
     }
 
-    private fun CoroutineScope.fallback(accounts: List<PlayerSave>) = launch(fallbackHandler) {
-        withContext(NonCancellable) {
-            fallback.save(accounts)
-            clearPending(accounts)
+    private fun failed(accounts: List<PlayerSave>, exception: Exception, retry: Boolean) {
+        val exhausted = if (retry) exhausted(accounts) else accounts
+        if (exhausted.isEmpty()) {
+            logger.error(exception) { "Error saving ${accounts.size} ${"account".plural(accounts.size)}, retrying next tick." }
+            return
+        }
+        logger.error(exception) { "Giving up on ${exhausted.size} ${"account".plural(exhausted.size)}, writing to fallback storage: ${exhausted.joinToString { it.name }}" }
+        try {
+            fallback.save(exhausted)
+        } catch (e: Exception) {
+            logger.error(e) { "Fallback save failed!" }
+        }
+        clearPending(exhausted)
+        clearFailing(exhausted)
+    }
+
+    private fun exhausted(accounts: List<PlayerSave>): List<PlayerSave> {
+        val now = System.currentTimeMillis()
+        return accounts.filter { now - (failing.putIfAbsent(it.name, now) ?: now) >= retryMillis }
+    }
+
+    private fun clearFailing(accounts: List<PlayerSave>) {
+        for (account in accounts) {
+            failing.remove(account.name)
         }
     }
 

--- a/engine/src/test/kotlin/world/gregs/voidps/engine/data/SaveQueueTest.kt
+++ b/engine/src/test/kotlin/world/gregs/voidps/engine/data/SaveQueueTest.kt
@@ -54,34 +54,85 @@ internal class SaveQueueTest : KoinMock() {
     }
 
     @Test
-    fun `Failed save falls back and doesn't kill the queue`() {
-        val fallbackSaved = CountDownLatch(1)
+    fun `Failed save retries against real storage and doesn't kill the queue`() {
+        val attempted = AtomicInteger()
         val saved = CountDownLatch(1)
         var fail = true
         val storage = object : TestStorage() {
             override fun save(accounts: List<PlayerSave>) {
+                attempted.incrementAndGet()
                 if (fail) {
                     throw IOException("Disk full")
                 }
                 saved.countDown()
             }
         }
+        val dumped = CopyOnWriteArrayList<String>()
         val fallback = object : TestStorage() {
             override fun save(accounts: List<PlayerSave>) {
-                fallbackSaved.countDown()
+                accounts.mapTo(dumped) { it.name }
             }
         }
         val queue = SaveQueue(storage, fallback)
         queue.save(Player(accountName = "player"))
         queue.run()
-        assertTrue(fallbackSaved.await(5, TimeUnit.SECONDS), "Fallback didn't run after failed save")
-        waitFor("fallback to clear pending") { queue.empty() }
+        waitFor("first attempt") { attempted.get() >= 1 }
         fail = false
-        queue.save(Player(accountName = "player"))
-        waitFor("save after a failure") {
+        waitFor("retry to succeed") {
             queue.run()
             saved.count == 0L
         }
+        waitFor("pending to drain") { queue.empty() }
+        assertTrue(dumped.isEmpty(), "Transient failure gave up on the first attempt")
+    }
+
+    @Test
+    fun `Failure only touches the accounts that were attempted`() {
+        val started = CountDownLatch(1)
+        val release = CountDownLatch(1)
+        val dumped = CopyOnWriteArrayList<String>()
+        val storage = object : TestStorage() {
+            override fun save(accounts: List<PlayerSave>) {
+                started.countDown()
+                release.await(5, TimeUnit.SECONDS)
+                throw IOException("Disk full")
+            }
+        }
+        val fallback = object : TestStorage() {
+            override fun save(accounts: List<PlayerSave>) {
+                accounts.mapTo(dumped) { it.name }
+            }
+        }
+        val queue = SaveQueue(storage, fallback, retryMillis = 0)
+        queue.save(Player(accountName = "attempted"))
+        queue.run()
+        assertTrue(started.await(5, TimeUnit.SECONDS), "Save didn't start")
+        queue.save(Player(accountName = "queued_later"))
+        release.countDown()
+        waitFor("attempted account to be dumped") { dumped.contains("attempted") }
+        assertFalse(dumped.contains("queued_later"), "Failure dumped an account storage was never asked to write")
+        assertTrue(queue.saving("queued_later"), "Failure dropped an account storage was never asked to write")
+    }
+
+    @Test
+    fun `Shutdown save writes to the fallback before the job completes`() {
+        val dumped = CopyOnWriteArrayList<String>()
+        val storage = object : TestStorage() {
+            override fun save(accounts: List<PlayerSave>) {
+                throw IOException("Disk full")
+            }
+        }
+        val fallback = object : TestStorage() {
+            override fun save(accounts: List<PlayerSave>) {
+                accounts.mapTo(dumped) { it.name }
+            }
+        }
+        val queue = SaveQueue(storage, fallback)
+        queue.save(Player(accountName = "player"))
+
+        runBlocking { queue.direct().join() }
+
+        assertTrue(dumped.contains("player"), "Shutdown left a failed save nowhere on disk")
     }
 
     @Test

--- a/game/src/main/resources/game.properties
+++ b/game/src/main/resources/game.properties
@@ -422,6 +422,10 @@ storage.players.logs=./data/saves/logs/
 # How frequently to save logs to file
 storage.players.logs.seconds=10
 
+# How long to keep retrying a failed player save against real storage before
+# giving up and writing it to the failed saves directory instead
+storage.save.retryMinutes=5
+
 # The directory where failed player save files are stored
 storage.players.errors=./data/errors/
 


### PR DESCRIPTION
Fixes #1250. Rebased onto `main` now that #1249 has merged — the diff is the three files below and nothing else.

## The bug

`SaveQueue`'s exception handler closed over `pending` rather than the batch that failed:

```kotlin
private val handler = CoroutineExceptionHandler { _, exception ->
    logger.error(exception) { "Error saving players!" }
    scope.fallback(pending.values.toList())
}
```

`run()` snapshots `pending.values.toList()` and hands that to `storage.save`. If the write throws, the handler re-reads `pending`, which by then also holds accounts queued after the snapshot, ones storage was never asked to write. All of them go to `fallback`, which writes them out and clears them.

The fallback is `SafeStorage`, and it's write-only: `load` returns null, `exists` returns false, `names` returns an empty map, and the files are named `"$timestamp-$name.toml"` so nothing would find them anyway. So a failed batch meant those accounts were removed from `pending`, never retried, and invisible to every later `load`. The next login served whatever the account file held before the session, with no signal to the player and one `Error saving players!` line as the only trace.

Blast radius wider than the failure: a disk momentarily full took out every account queued at that instant, not the batch that failed.

## The fix

The handler goes away in favour of a try/catch inside the coroutine, so the failed batch is the one that gets handled.

On failure the accounts stay in `pending` and the next tick retries real storage. A transient error self-heals. `storage.save.retryMinutes` (default 5) bounds the retry per account; past it the account is written to the failed saves directory and dropped, so a permanently broken backend doesn't wedge the queue forever. Five minutes covers the #1212 shape, a host stall that pushed a tick to 25918ms, without being an indefinite hang.

While an account is pending it still can't log in (`PlayerAccountLoader` checks `saveQueue.saving`). That's the point: refusing the login is better than serving a stale file under a save that hasn't landed.

`direct()` passes `retry = false`. At shutdown there's no next tick, so a failure should dump immediately, and the dump now happens inside the job the caller joins, rather than in a sibling coroutine the process could exit before it runs. That second half was a real hole: `AutoSave`'s `worldDespawn` joins the save job, and the old handler's `scope.fallback(...)` was not that job.

A `CoroutineExceptionHandler` stays on the scope purely as a last-resort log, so an `Error` escaping the `catch (e: Exception)` isn't silent.

## Tests

Three in `SaveQueueTest`, each checked by reverting the corresponding production change and confirming the right test fails:

- `Failure only touches the accounts that were attempted` — blocks a save on a latch, queues a second account while the first is in flight, then fails the write. The second account must not be dumped and must stay pending. Fails when `failed()` is fed `pending.values.toList()`.
- `Failed save retries against real storage and doesn't kill the queue` — replaces the old `Failed save falls back and doesn't kill the queue`, which asserted the drain behaviour this PR removes. A transient failure must be retried and must not reach the fallback. Fails when the retry window is dropped.
- `Shutdown save writes to the fallback before the job completes` — `direct().join()` must return with the account already on disk somewhere. Fails when `direct()` retries instead.

Full suite green.

## Known limitation

`run()` submits all of `pending` as one batch, so an account whose data reliably breaks serialisation takes the whole batch with it for the retry window before everything gets dumped together. Isolating a poison account needs per-account writes, which is a bigger change than this one and would trade `DatabaseStorage`'s batched transaction for N of them. Left alone deliberately.
