### PR TITLE
Guard invalid player indexes

### DIFF
--- a/engine/src/main/kotlin/world/gregs/voidps/engine/entity/character/player/Players.kt
+++ b/engine/src/main/kotlin/world/gregs/voidps/engine/entity/character/player/Players.kt
@@ -55,7 +55,7 @@ object Players : Iterable<Player>, CharacterSearch<Player> {
         return null
     }
 
-    fun indexed(index: Int): Player? = indexArray[index]
+    fun indexed(index: Int): Player? = indexArray.getOrNull(index)
 
     override fun at(tile: Tile): List<Player> {
         val list = mutableListOf<Player>()

--- a/engine/src/test/kotlin/world/gregs/voidps/engine/entity/character/player/PlayersTest.kt
+++ b/engine/src/test/kotlin/world/gregs/voidps/engine/entity/character/player/PlayersTest.kt
@@ -41,4 +41,10 @@ internal class PlayersTest {
 
         assertEquals(0, Players.size)
     }
+
+    @Test
+    fun `Indexed returns null for invalid player indexes`() {
+        assertNull(Players.indexed(-1))
+        assertNull(Players.indexed(Int.MAX_VALUE))
+    }
 }


### PR DESCRIPTION
## Summary

- Make `Players.indexed(index)` return `null` for negative or out-of-range indexes.
- Add a regression test for invalid indexes.

This prevents familiars without a valid `owner_index` from crashing the game loop during combat experience handling.

## Verification

- `./gradlew :engine:test --tests world.gregs.voidps.engine.entity.character.player.PlayersTest`
- `./gradlew :game:compileKotlin`