### PR TITLE
Fix Zaryte bow weapon style

### DIFF
--- a/data/area/troll_country/god_wars_dungeon/god_wars_dungeon.items.toml
+++ b/data/area/troll_country/god_wars_dungeon/god_wars_dungeon.items.toml
@@ -863,6 +863,7 @@ price = 108200000
 limit = 2
 bank_stacks = false
 attack_range = 7
+weapon_style = 16
 weight = 1.814
 charges = 1
 degrade = "zaryte_bow_used"


### PR DESCRIPTION
The Zaryte bow was missing weapon_style = 16. This item-definition-only fix classifies it as ranged instead of melee.