### PR TITLE
Fix Kalphite Queen respawn form

### DIFF
--- a/game/src/main/kotlin/content/area/kharidian_desert/kalphite_lair/KalphiteQueen.kt
+++ b/game/src/main/kotlin/content/area/kharidian_desert/kalphite_lair/KalphiteQueen.kt
@@ -36,6 +36,9 @@ import java.util.concurrent.TimeUnit
 
 class KalphiteQueen(val lineOfSight: LineValidator) : Script {
     init {
+        npcSpawn("kalphite_queen") {
+            clearTransform()
+        }
         npcCombatDamage("kalphite_queen") {
             if (random.nextInt(20) != 0) {
                 return@npcCombatDamage

--- a/game/src/test/kotlin/content/area/kharidian_desert/kalphite_lair/KalphiteQueenTest.kt
+++ b/game/src/test/kotlin/content/area/kharidian_desert/kalphite_lair/KalphiteQueenTest.kt
@@ -1,0 +1,20 @@
+package content.area.kharidian_desert.kalphite_lair
+
+import WorldTest
+import content.entity.effect.transform
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+internal class KalphiteQueenTest : WorldTest() {
+    @Test
+    fun `Kalphite Queen returns to original form after respawning`() {
+        val queen = createNPC("kalphite_queen", emptyTile)
+        queen.transform("kalphite_queen_airborne")
+
+        queen.respawn(1)
+        tick(2)
+
+        assertEquals("", queen.transform)
+        assertEquals("kalphite_queen", queen.transformId)
+    }
+}


### PR DESCRIPTION
## Summary
- restore the Kalphite Queen to her original form when she respawns
- add a regression test for the respawn transformation

## Verification
- `./gradlew :game:test --tests content.area.kharidian_desert.kalphite_lair.KalphiteQueenTest`