### PR TITLE
Fix rope being consumed without attaching at Saradomin rocks

### DIFF
--- a/game/src/main/kotlin/content/area/troll_country/god_wars_dungeon/SaradominRock.kt
+++ b/game/src/main/kotlin/content/area/troll_country/god_wars_dungeon/SaradominRock.kt
@@ -2,7 +2,6 @@ package content.area.troll_country.god_wars_dungeon
 
 import world.gregs.voidps.engine.Script
 import world.gregs.voidps.engine.client.message
-import world.gregs.voidps.engine.entity.character.mode.interact.ItemOnObjectInteract
 import world.gregs.voidps.engine.entity.character.player.Player
 import world.gregs.voidps.engine.entity.character.player.skill.Skill
 import world.gregs.voidps.engine.entity.character.player.skill.level.Level.has
@@ -16,12 +15,9 @@ class SaradominRock : Script {
             tieRope(this, target.def(this).stringId)
         }
 
-        itemOnObjectOperate("rope", "godwars_saradomin_rock_top", handler = ::tieRope)
-        itemOnObjectOperate("rope", "godwars_saradomin_rock_bottom", handler = ::tieRope)
-    }
-
-    fun tieRope(player: Player, interact: ItemOnObjectInteract) {
-        tieRope(player, interact.target.def.stringId)
+        itemOnObjectOperate("rope", "godwars_saradomin_rock_top,godwars_saradomin_rock_bottom") { (target) ->
+            tieRope(this, target.def(this).stringId)
+        }
     }
 
     fun tieRope(player: Player, id: String) {

--- a/game/src/test/kotlin/content/area/troll_country/god_wars_dungeon/SaradominRockTest.kt
+++ b/game/src/test/kotlin/content/area/troll_country/god_wars_dungeon/SaradominRockTest.kt
@@ -2,6 +2,7 @@ package content.area.troll_country.god_wars_dungeon
 
 import WorldTest
 import containsMessage
+import itemOnObject
 import objectOption
 import org.junit.jupiter.api.Test
 import world.gregs.voidps.engine.entity.character.player.skill.Skill
@@ -119,5 +120,39 @@ class SaradominRockTest : WorldTest() {
         tick(4)
 
         assertEquals(Tile(2920, 5276, 1), player.tile)
+    }
+
+    @Test
+    fun `Use rope on top rock and climb down`() {
+        val player = createPlayer(Tile(2912, 5300, 2))
+        player.inventory.add("rope")
+        player.levels.set(Skill.Agility, 70)
+        val rock = GameObjects.find(Tile(2913, 5300, 2), "godwars_saradomin_rock_top_base")
+
+        player.itemOnObject(rock, itemSlot = 0)
+        tick(2)
+        assertFalse(player.inventory.contains("rope"))
+        assertTrue(player["godwars_saradomin_rope_top", false])
+        player.objectOption(rock, optionIndex = 1) // Climb-down
+        tick(5)
+
+        assertEquals(Tile(2915, 5300, 1), player.tile)
+    }
+
+    @Test
+    fun `Use rope on bottom rock and climb down`() {
+        val player = createPlayer(Tile(2920, 5276, 1))
+        player.inventory.add("rope")
+        player.levels.set(Skill.Agility, 70)
+        val rock = GameObjects.find(Tile(2920, 5274, 1), "godwars_saradomin_rock_bottom_base")
+
+        player.itemOnObject(rock, itemSlot = 0)
+        tick(2)
+        assertFalse(player.inventory.contains("rope"))
+        assertTrue(player["godwars_saradomin_rope_bottom", false])
+        player.objectOption(rock, optionIndex = 1) // Climb-down
+        tick(5)
+
+        assertEquals(Tile(2919, 5274), player.tile)
     }
 }


### PR DESCRIPTION
Fixes #1257

Using a rope on the God Wars Dungeon Saradomin rocks consumed the rope but left the ledge bare.

The map objects are the varbit-transform bases (`godwars_saradomin_rock_top_base` / `_bottom_base`). Dispatch resolves the definition per player, so the handler registered for `rope:godwars_saradomin_rock_top` fired correctly, but inside it re-read the unresolved `target.def` and set `godwars_saradomin_rope_top_base`, not a defined variable, so `PlayerVariables` stored it in the temp map and never transmitted it. The rope was already removed by then.

The `Tie-rope` object option was unaffected because it resolves with `target.def(this)`, which is why this only showed up when players used the rope on the rock (the fallback when combat interrupts the right-click option).

- Resolve the definition against the player on the item-on-object path, and merge the two registrations into one comma list to match the object option above it.
- Add regression tests for the item-on-object route on both rocks; both fail before the change on the varbit assertion.