### PR TITLE
Add configurable player respawn points

### DIFF
--- a/data/entity/player/player.vars.toml
+++ b/data/entity/player/player.vars.toml
@@ -26,3 +26,7 @@ persist = true
 [insta_kill]
 format = "boolean"
 persist = true
+
+[respawn_tile]
+format = "int"
+persist = true

--- a/game/src/main/kotlin/content/area/asgarnia/falador/SirTiffyCashien.kt
+++ b/game/src/main/kotlin/content/area/asgarnia/falador/SirTiffyCashien.kt
@@ -1,0 +1,49 @@
+package content.area.asgarnia.falador
+
+import content.entity.death.setRespawnTile
+import content.entity.player.dialogue.Neutral
+import content.entity.player.dialogue.type.choice
+import content.entity.player.dialogue.type.npc
+import world.gregs.voidps.engine.Script
+import world.gregs.voidps.type.Tile
+
+class SirTiffyCashien : Script {
+
+    init {
+        npcOperate("Talk-to", "sir_tiffy_cashien") {
+            npc<Neutral>("Hello there. How can I help you?")
+            choice {
+                option("I'd like to change my respawn point.") {
+                    npc<Neutral>("Where would you like to respawn?")
+                    choice {
+                        option("Lumbridge - the initial, free respawn point.") {
+                            setRespawnTile(LUMBRIDGE)
+                            npc<Neutral>("Your respawn point is now Lumbridge.")
+                        }
+                        option("Falador - in the White Knights' castle courtyard.") {
+                            setRespawnTile(FALADOR)
+                            npc<Neutral>("Your respawn point is now Falador.")
+                        }
+                        option("Camelot - at the castle entrance.") {
+                            setRespawnTile(CAMELOT)
+                            npc<Neutral>("Your respawn point is now Camelot.")
+                        }
+                        option("Edgeville - next to the bank.") {
+                            setRespawnTile(EDGEVILLE)
+                            npc<Neutral>("Your respawn point is now Edgeville.")
+                        }
+                        option("Never mind.")
+                    }
+                }
+                option("Nothing, thank you.")
+            }
+        }
+    }
+
+    private companion object {
+        val LUMBRIDGE = Tile(3221, 3219)
+        val FALADOR = Tile(2966, 3379)
+        val CAMELOT = Tile(2757, 3477)
+        val EDGEVILLE = Tile(3087, 3497)
+    }
+}

--- a/game/src/main/kotlin/content/entity/death/PlayerDeath.kt
+++ b/game/src/main/kotlin/content/entity/death/PlayerDeath.kt
@@ -22,7 +22,6 @@ import content.skill.summoning.dismissFamiliar
 import world.gregs.voidps.engine.Script
 import world.gregs.voidps.engine.client.clearHinted
 import world.gregs.voidps.engine.client.message
-import world.gregs.voidps.engine.data.Settings
 import world.gregs.voidps.engine.data.definition.Areas
 import world.gregs.voidps.engine.entity.character.Character
 import world.gregs.voidps.engine.entity.character.Death
@@ -46,9 +45,6 @@ import world.gregs.voidps.type.random
 import java.util.concurrent.TimeUnit
 
 class PlayerDeath : Script {
-
-    val respawnTile: Tile
-        get() = Tile(Settings["world.home.x", 0], Settings["world.home.y", 0], Settings["world.home.level", 0])
 
     init {
         levelChanged(Skill.Constitution) { _, _, to ->
@@ -93,7 +89,7 @@ class PlayerDeath : Script {
                 if (onDeath.teleport != null) {
                     tele(onDeath.teleport!!)
                 } else {
-                    tele(respawnTile)
+                    tele(this@levelChanged.respawnTile())
                 }
                 face(Direction.SOUTH, update = false)
                 dead = false

--- a/game/src/main/kotlin/content/entity/death/Respawn.kt
+++ b/game/src/main/kotlin/content/entity/death/Respawn.kt
@@ -1,0 +1,25 @@
+package content.entity.death
+
+import world.gregs.voidps.engine.data.Settings
+import world.gregs.voidps.engine.entity.character.player.Player
+import world.gregs.voidps.type.Tile
+
+private fun defaultRespawnTile(): Tile = Tile(
+    Settings["world.home.x", 0],
+    Settings["world.home.y", 0],
+    Settings["world.home.level", 0],
+)
+
+fun Player.respawnTile(): Tile = when (val value = get<Any>("respawn_tile")) {
+    is Tile -> value
+    is Int -> Tile(value)
+    else -> defaultRespawnTile()
+}
+
+fun Player.setRespawnTile(tile: Tile) {
+    if (tile == defaultRespawnTile()) {
+        clear("respawn_tile")
+    } else {
+        set("respawn_tile", tile.id)
+    }
+}

--- a/game/src/main/kotlin/content/skill/magic/jewellery/RingOfLife.kt
+++ b/game/src/main/kotlin/content/skill/magic/jewellery/RingOfLife.kt
@@ -2,9 +2,9 @@ package content.skill.magic.jewellery
 
 import content.area.wilderness.inWilderness
 import content.area.wilderness.wildernessLevel
+import content.entity.death.respawnTile
 import content.skill.magic.book.modern.teleBlocked
 import world.gregs.voidps.engine.Script
-import world.gregs.voidps.engine.data.Settings
 import world.gregs.voidps.engine.entity.character.player.Player
 import world.gregs.voidps.engine.entity.character.player.Teleport
 import world.gregs.voidps.engine.entity.character.player.equip.equipped
@@ -12,7 +12,6 @@ import world.gregs.voidps.engine.entity.character.player.skill.Skill
 import world.gregs.voidps.engine.inv.discharge
 import world.gregs.voidps.engine.inv.equipment
 import world.gregs.voidps.network.login.protocol.visual.update.player.EquipSlot
-import world.gregs.voidps.type.Tile
 
 class RingOfLife : Script {
 
@@ -46,7 +45,7 @@ class RingOfLife : Script {
         if (!player.equipment.discharge(player, EquipSlot.Ring.index)) {
             return
         }
-        val destination = player["respawn_tile", Tile(Settings["world.home.x", 0], Settings["world.home.y", 0])]
+        val destination = player.respawnTile()
         Teleport.teleport(player, destination, "jewellery")
     }
 }

--- a/game/src/test/kotlin/content/area/asgarnia/falador/SirTiffyCashienTest.kt
+++ b/game/src/test/kotlin/content/area/asgarnia/falador/SirTiffyCashienTest.kt
@@ -1,0 +1,28 @@
+package content.area.asgarnia.falador
+
+import WorldTest
+import content.entity.death.respawnTile
+import dialogueContinue
+import dialogueOption
+import npcOption
+import org.junit.jupiter.api.Test
+import world.gregs.voidps.type.Tile
+import kotlin.test.assertEquals
+
+class SirTiffyCashienTest : WorldTest() {
+
+    @Test
+    fun `Sir Tiffy changes the respawn point`() {
+        val player = createPlayer(emptyTile)
+        val tiffy = createNPC("sir_tiffy_cashien", player.tile.addY(1))
+
+        player.npcOption(tiffy, 0)
+        tick()
+        player.dialogueContinue()
+        player.dialogueOption(1)
+        player.dialogueContinue()
+        player.dialogueOption(4)
+
+        assertEquals(Tile(3087, 3497), player.respawnTile())
+    }
+}


### PR DESCRIPTION
## Summary
- add a Sir Tiffy Cashien dialogue to choose Lumbridge, Falador, Camelot, or Edgeville as the player respawn point
- persist the selected respawn tile and use it for player death and Ring of Life teleports
- add dialogue coverage for the Edgeville selection

## Verification
- ./gradlew :game:test --tests content.area.asgarnia.falador.SirTiffyCashienTest
- ./gradlew :game:test --tests content.skill.magic.jewellery.RingOfLifeTest