### PR TITLE
Add the Duel Arena minigame

### DIFF
--- a/cache/src/main/kotlin/world/gregs/voidps/cache/definition/Params.kt
+++ b/cache/src/main/kotlin/world/gregs/voidps/cache/definition/Params.kt
@@ -140,6 +140,7 @@ object Params {
 
     /** Item ids a quest expects the player to bring; used by the questprep command. */
     const val REQ_ITEM_IDS = 5267
+    const val FUN_WEAPON = 5268
 
     const val REQ_QUEST_POINTS = 5139
     const val REQ_QUESTS = 5140
@@ -416,6 +417,7 @@ object Params {
         "food" -> FOOD
         "food2" -> FOOD2
         "freeze_ticks" -> FREEZE_TICKS
+        "fun_weapon" -> FUN_WEAPON
         "full" -> FULL
         "gate" -> GATE
         "god" -> GOD

--- a/data/activity/event/easter/easter.items.toml
+++ b/data/activity/event/easter/easter.items.toml
@@ -8,6 +8,7 @@ kept = "Wilderness"
 
 [basket_of_eggs]
 id = 4565
+fun_weapon = true
 tradeable = false
 weight = 0.1
 slot = "Weapon"
@@ -16,6 +17,7 @@ kept = "Reclaim"
 
 [rubber_chicken]
 id = 4566
+fun_weapon = true
 tradeable = false
 weight = 0.453
 slot = "Weapon"

--- a/data/client/client.scripts.toml
+++ b/data/client/client.scripts.toml
@@ -40,6 +40,10 @@ id = 3994
 [clear_dialogues]
 id = 571
 
+# Appends a text row to a scrollable layer: (indent, y, component, text)
+[duel_scoreboard_row]
+id = 2601
+
 [primary_options]
 id = 150
 params = [

--- a/data/client/client.scripts.toml
+++ b/data/client/client.scripts.toml
@@ -40,10 +40,6 @@ id = 3994
 [clear_dialogues]
 id = 571
 
-# Appends a text row to a scrollable layer: (indent, y, component, text)
-[duel_scoreboard_row]
-id = 2601
-
 [primary_options]
 id = 150
 params = [

--- a/data/entity/player/misc.invs.toml
+++ b/data/entity/player/misc.invs.toml
@@ -39,9 +39,13 @@ id = 133
 
 [dueloffer]
 id = 134
+width = 4
+height = 7
 
 [duelwinnings]
 id = 136
+width = 5
+height = 6
 
 [trail_puzzleinv]
 id = 140

--- a/data/minigame/duel_arena/duel_arena.areas.toml
+++ b/data/minigame/duel_arena/duel_arena.areas.toml
@@ -7,3 +7,74 @@ tags = ["teleport"]
 x = [3311, 3391]
 y = [3199, 3290]
 tags = ["no_cannon"]
+
+# Walkways and hospital where players can challenge each other
+[duel_arena_walkways]
+x = [3326, 3392]
+y = [3200, 3280]
+
+# Hospital north of the arenas, where players are sent after a duel
+[duel_arena_hospital]
+x = [3363, 3377]
+y = [3266, 3277]
+
+[duel_arena_1]
+x = [3332, 3357]
+y = [3244, 3258]
+tags = ["duel_arena"]
+
+[duel_arena_2]
+x = [3364, 3388]
+y = [3244, 3259]
+tags = ["duel_arena"]
+
+[duel_arena_3]
+x = [3333, 3357]
+y = [3224, 3239]
+tags = ["duel_arena"]
+
+[duel_arena_4]
+x = [3364, 3388]
+y = [3225, 3240]
+tags = ["duel_arena"]
+
+[duel_arena_5]
+x = [3333, 3357]
+y = [3205, 3220]
+tags = ["duel_arena"]
+
+[duel_arena_6]
+x = [3364, 3388]
+y = [3206, 3221]
+tags = ["duel_arena"]
+
+# Fight start positions inside each arena
+[duel_arena_1_spawn]
+x = [3337, 3351]
+y = [3246, 3256]
+tags = ["duel_spawn", "no_obstacles"]
+
+[duel_arena_2_spawn]
+x = [3367, 3381]
+y = [3246, 3256]
+tags = ["duel_spawn", "obstacles"]
+
+[duel_arena_3_spawn]
+x = [3336, 3350]
+y = [3227, 3237]
+tags = ["duel_spawn", "obstacles"]
+
+[duel_arena_4_spawn]
+x = [3367, 3381]
+y = [3227, 3237]
+tags = ["duel_spawn", "no_obstacles"]
+
+[duel_arena_5_spawn]
+x = [3336, 3352]
+y = [3208, 3218]
+tags = ["duel_spawn", "no_obstacles"]
+
+[duel_arena_6_spawn]
+x = [3367, 3383]
+y = [3208, 3218]
+tags = ["duel_spawn", "obstacles"]

--- a/data/minigame/duel_arena/duel_arena.ifaces.toml
+++ b/data/minigame/duel_arena/duel_arena.ifaces.toml
@@ -1,27 +1,516 @@
-[stake_confirm]
-id = 626
+# Component ids verified against the 634 cache.
+# Rule checkboxes are driven by varbits 4157-4183/4275 (varp 286) through cs2 566 (637) and 567 (631).
+[duel_request]
+id = 640
+type = "main_screen"
+
+[.friendly]
+id = 18
+
+[.friendly_box]
+id = 22
+
+[.staked]
+id = 19
+
+[.staked_box]
+id = 21
+
+[.challenge]
+id = 20
+
+[.close]
+id = 24
+
+[duel_overlay]
+id = 638
+type = "overlay"
 
 [warning_duel]
 id = 627
 
-[duel2_side]
-id = 628
-
+# Staked duel rules screen
 [stake]
 id = 631
+type = "main_screen"
+
+[.close]
+id = 23
+
+[.name]
+id = 25
+
+[.combat_level]
+id = 27
+
+[.status]
+id = 28
+
+[.no_ranged]
+id = 29
+
+[.no_ranged_box]
+id = 30
+
+[.no_melee]
+id = 31
+
+[.no_melee_box]
+id = 32
+
+[.no_magic]
+id = 33
+
+[.no_magic_box]
+id = 34
+
+[.fun_weapons]
+id = 35
+
+[.fun_weapons_box]
+id = 36
+
+[.no_forfeit]
+id = 37
+
+[.no_forfeit_box]
+id = 38
+
+[.no_drinks]
+id = 39
+
+[.no_drinks_box]
+id = 40
+
+[.no_food]
+id = 41
+
+[.no_food_box]
+id = 42
+
+[.no_prayer]
+id = 43
+
+[.no_prayer_box]
+id = 44
+
+[.no_movement]
+id = 45
+
+[.no_movement_box]
+id = 46
+
+[.obstacles]
+id = 47
+
+[.obstacles_box]
+id = 48
+
+[.no_special]
+id = 49
+
+[.no_special_box]
+id = 50
+
+[.summoning]
+id = 51
+
+[.summoning_box]
+id = 52
+
+[.no_hat]
+id = 56
+
+[.no_cape]
+id = 57
+
+[.no_amulet]
+id = 58
+
+[.no_ammo]
+id = 59
+
+[.no_weapon]
+id = 60
+
+[.no_body]
+id = 61
+
+[.no_shield]
+id = 62
+
+[.no_legs]
+id = 63
+
+[.no_ring]
+id = 64
+
+[.no_boots]
+id = 65
+
+[.no_gloves]
+id = 66
+
+[.max_stake]
+id = 91
+
+[.other_max_stake]
+id = 92
+
+[.max_stake_label]
+id = 93
+
+[.other_max_stake_label]
+id = 94
+
+[.accept]
+id = 101
+
+# Own stake, drawn by cs2 99 (ops Remove 1/5/10/All/X + Examine)
+[.offer]
+id = 102
+inventory = "dueloffer"
+options = { Remove-1 = 0, Remove-5 = 1, Remove-10 = 2, Remove-All = 3, Remove-X = 4, Examine = 9 }
+
+# Opponent's stake
+[.other_offer]
+id = 103
+inventory = "dueloffer"
+primary = false
+options = { Examine = 0 }
+
+[.decline]
+id = 106
+
+# Staking inventory side tab
+[duel2_side]
+id = 628
+type = "inventory_tab"
+
+[.offer]
+id = 0
+inventory = "inventory"
+options = { Stake-1 = 0, Stake-5 = 1, Stake-10 = 2, Stake-All = 3, Stake-X = 4, Examine = 9 }
+
+# Friendly duel rules screen
+[duel_confirm]
+id = 637
+type = "main_screen"
+
+[.close]
+id = 13
+
+[.name]
+id = 15
+
+[.combat_level]
+id = 17
+
+[.no_ranged]
+id = 18
+
+[.no_ranged_box]
+id = 19
+
+[.no_melee]
+id = 20
+
+[.no_melee_box]
+id = 21
+
+[.no_magic]
+id = 22
+
+[.no_magic_box]
+id = 23
+
+[.fun_weapons]
+id = 24
+
+[.fun_weapons_box]
+id = 25
+
+[.no_forfeit]
+id = 26
+
+[.no_forfeit_box]
+id = 27
+
+[.no_drinks]
+id = 28
+
+[.no_drinks_box]
+id = 29
+
+[.no_food]
+id = 30
+
+[.no_food_box]
+id = 31
+
+[.no_prayer]
+id = 32
+
+[.no_prayer_box]
+id = 33
+
+[.no_movement]
+id = 34
+
+[.no_movement_box]
+id = 35
+
+[.obstacles]
+id = 36
+
+[.obstacles_box]
+id = 37
+
+[.summoning]
+id = 38
+
+[.summoning_box]
+id = 39
+
+[.no_special]
+id = 40
+
+[.no_special_box]
+id = 41
+
+[.status]
+id = 44
+
+[.no_hat]
+id = 45
+
+[.no_cape]
+id = 46
+
+[.no_amulet]
+id = 47
+
+[.no_ammo]
+id = 48
+
+[.no_weapon]
+id = 49
+
+[.no_body]
+id = 50
+
+[.no_shield]
+id = 51
+
+[.no_legs]
+id = 52
+
+[.no_ring]
+id = 53
+
+[.no_boots]
+id = 54
+
+[.no_gloves]
+id = 55
+
+[.accept]
+id = 82
+
+[.decline]
+id = 85
+
+# Staked duel confirmation screen
+[stake_confirm]
+id = 626
+type = "main_screen"
+
+[.close]
+id = 7
+
+[.stake]
+id = 25
+
+[.other_stake]
+id = 26
+
+[.before_0]
+id = 41
+
+[.before_1]
+id = 28
+
+[.before_2]
+id = 29
+
+[.before_3]
+id = 30
+
+[.before_4]
+id = 31
+
+[.during_0]
+id = 33
+
+[.during_1]
+id = 34
+
+[.during_2]
+id = 35
+
+[.during_3]
+id = 36
+
+[.during_4]
+id = 37
+
+[.during_5]
+id = 38
+
+[.during_6]
+id = 39
+
+[.during_7]
+id = 40
+
+[.during_8]
+id = 42
+
+[.during_9]
+id = 43
+
+[.during_10]
+id = 44
+
+[.status]
+id = 45
+
+[.offer]
+id = 48
+inventory = "dueloffer"
+
+[.other_offer]
+id = 49
+inventory = "dueloffer"
+primary = false
+
+[.accept]
+id = 53
+
+[.decline]
+id = 55
+
+# Friendly duel confirmation screen
+[duel_rules_confirm]
+id = 639
+type = "main_screen"
+
+[.close]
+id = 10
+
+[.before_0]
+id = 16
+
+[.before_1]
+id = 17
+
+[.before_2]
+id = 18
+
+[.before_3]
+id = 19
+
+[.before_4]
+id = 20
+
+[.during_0]
+id = 22
+
+[.during_1]
+id = 24
+
+[.during_2]
+id = 23
+
+[.during_3]
+id = 25
+
+[.during_4]
+id = 26
+
+[.during_5]
+id = 27
+
+[.during_6]
+id = 28
+
+[.during_7]
+id = 29
+
+[.during_8]
+id = 30
+
+[.during_9]
+id = 31
+
+[.during_10]
+id = 32
+
+[.status]
+id = 33
+
+[.accept]
+id = 35
+
+[.decline]
+id = 37
 
 [duel_victory]
 id = 633
+type = "main_screen"
+
+[.claim]
+id = 17
+
+[.close]
+id = 25
+
+[.combat_level]
+id = 30
+
+[.name]
+id = 31
 
 [stake_victory]
 id = 634
+type = "main_screen"
 
-[duel_confirm]
-id = 637
+[.claim]
+id = 17
 
-[duel_rules_confirm]
-id = 639
+[.close]
+id = 26
 
-[duel_request]
-id = 640
+[.winnings]
+id = 28
+inventory = "duelwinnings"
+options = { Examine = 0 }
 
+[.combat_level]
+id = 32
+
+[.name]
+id = 33
+
+[duel_scoreboard]
+id = 632
+type = "main_screen"
+
+[.list]
+id = 15
+
+[.scrollbar]
+id = 16
+
+[.close]
+id = 17

--- a/data/minigame/duel_arena/duel_arena.npc-spawns.toml
+++ b/data/minigame/duel_arena/duel_arena.npc-spawns.toml
@@ -8,6 +8,7 @@ spawns = [
   { id = "jeed", x = 3361, y = 3242 },
   { id = "captain_daerkin", x = 3362, y = 3222 },
   # 13363
+  { id = "mubariz", x = 3316, y = 3238 },
   { id = "fadli", x = 3383, y = 3269 },
   { id = "a_abla", x = 3362, y = 3273 },
   { id = "sabreen", x = 3368, y = 3278 },

--- a/data/minigame/duel_arena/duel_arena.objs.toml
+++ b/data/minigame/duel_arena/duel_arena.objs.toml
@@ -1,0 +1,7 @@
+[duel_arena_forfeit_trapdoor]
+id = 3203
+examine = "Access to the duel arena."
+
+[duel_arena_scoreboard]
+id = 3192
+examine = "You can see the last 50 fights on here."

--- a/data/minigame/duel_arena/duel_arena.strings.toml
+++ b/data/minigame/duel_arena/duel_arena.strings.toml
@@ -1,0 +1,151 @@
+# Rows of the duel scoreboard (interface 632); cs2 1636/1638 read varc strings 224-273 when it opens
+
+[duel_scoreboard_0]
+id = 224
+
+[duel_scoreboard_1]
+id = 225
+
+[duel_scoreboard_2]
+id = 226
+
+[duel_scoreboard_3]
+id = 227
+
+[duel_scoreboard_4]
+id = 228
+
+[duel_scoreboard_5]
+id = 229
+
+[duel_scoreboard_6]
+id = 230
+
+[duel_scoreboard_7]
+id = 231
+
+[duel_scoreboard_8]
+id = 232
+
+[duel_scoreboard_9]
+id = 233
+
+[duel_scoreboard_10]
+id = 234
+
+[duel_scoreboard_11]
+id = 235
+
+[duel_scoreboard_12]
+id = 236
+
+[duel_scoreboard_13]
+id = 237
+
+[duel_scoreboard_14]
+id = 238
+
+[duel_scoreboard_15]
+id = 239
+
+[duel_scoreboard_16]
+id = 240
+
+[duel_scoreboard_17]
+id = 241
+
+[duel_scoreboard_18]
+id = 242
+
+[duel_scoreboard_19]
+id = 243
+
+[duel_scoreboard_20]
+id = 244
+
+[duel_scoreboard_21]
+id = 245
+
+[duel_scoreboard_22]
+id = 246
+
+[duel_scoreboard_23]
+id = 247
+
+[duel_scoreboard_24]
+id = 248
+
+[duel_scoreboard_25]
+id = 249
+
+[duel_scoreboard_26]
+id = 250
+
+[duel_scoreboard_27]
+id = 251
+
+[duel_scoreboard_28]
+id = 252
+
+[duel_scoreboard_29]
+id = 253
+
+[duel_scoreboard_30]
+id = 254
+
+[duel_scoreboard_31]
+id = 255
+
+[duel_scoreboard_32]
+id = 256
+
+[duel_scoreboard_33]
+id = 257
+
+[duel_scoreboard_34]
+id = 258
+
+[duel_scoreboard_35]
+id = 259
+
+[duel_scoreboard_36]
+id = 260
+
+[duel_scoreboard_37]
+id = 261
+
+[duel_scoreboard_38]
+id = 262
+
+[duel_scoreboard_39]
+id = 263
+
+[duel_scoreboard_40]
+id = 264
+
+[duel_scoreboard_41]
+id = 265
+
+[duel_scoreboard_42]
+id = 266
+
+[duel_scoreboard_43]
+id = 267
+
+[duel_scoreboard_44]
+id = 268
+
+[duel_scoreboard_45]
+id = 269
+
+[duel_scoreboard_46]
+id = 270
+
+[duel_scoreboard_47]
+id = 271
+
+[duel_scoreboard_48]
+id = 272
+
+[duel_scoreboard_49]
+id = 273

--- a/data/minigame/duel_arena/duel_arena.strings.toml
+++ b/data/minigame/duel_arena/duel_arena.strings.toml
@@ -1,3 +1,7 @@
+# Defeated player's name on the victory screens (633/634); cs2 1640 copies it into the name component on open
+[duel_victory_name]
+id = 274
+
 # Rows of the duel scoreboard (interface 632); cs2 1636/1638 read varc strings 224-273 when it opens
 
 [duel_scoreboard_0]

--- a/data/minigame/duel_arena/duel_arena.varbits.toml
+++ b/data/minigame/duel_arena/duel_arena.varbits.toml
@@ -1,0 +1,97 @@
+# Duel request type shown on interface 640: 1 = friendly, 2 = staked
+[duel_type]
+id = 4157
+format = "int"
+
+# Rules; key minus the "duel_" prefix is the rule name used by content.minigame.duel_arena
+[duel_no_forfeit]
+id = 4159
+format = "boolean"
+
+[duel_no_movement]
+id = 4160
+format = "boolean"
+
+[duel_no_ranged]
+id = 4161
+format = "boolean"
+
+[duel_no_melee]
+id = 4162
+format = "boolean"
+
+[duel_no_magic]
+id = 4163
+format = "boolean"
+
+[duel_no_drinks]
+id = 4164
+format = "boolean"
+
+[duel_no_food]
+id = 4165
+format = "boolean"
+
+[duel_no_prayer]
+id = 4166
+format = "boolean"
+
+[duel_obstacles]
+id = 4167
+format = "boolean"
+
+[duel_fun_weapons]
+id = 4168
+format = "boolean"
+
+[duel_no_special]
+id = 4169
+format = "boolean"
+
+[duel_no_hat]
+id = 4170
+format = "boolean"
+
+[duel_no_cape]
+id = 4171
+format = "boolean"
+
+[duel_no_amulet]
+id = 4172
+format = "boolean"
+
+[duel_no_weapon]
+id = 4173
+format = "boolean"
+
+[duel_no_body]
+id = 4174
+format = "boolean"
+
+[duel_no_shield]
+id = 4175
+format = "boolean"
+
+[duel_no_legs]
+id = 4177
+format = "boolean"
+
+[duel_no_gloves]
+id = 4179
+format = "boolean"
+
+[duel_no_boots]
+id = 4180
+format = "boolean"
+
+[duel_no_ring]
+id = 4182
+format = "boolean"
+
+[duel_no_ammo]
+id = 4183
+format = "boolean"
+
+[duel_summoning]
+id = 4275
+format = "boolean"

--- a/data/quest/members/waterfall_quest/waterfall_quest.items.toml
+++ b/data/quest/members/waterfall_quest/waterfall_quest.items.toml
@@ -54,6 +54,7 @@ kept = "Wilderness"
 
 [flowers_pastel]
 id = 2460
+fun_weapon = true
 price = 860
 limit = 1000
 weight = 0.028
@@ -65,6 +66,7 @@ id = 2461
 
 [red_flowers]
 id = 2462
+fun_weapon = true
 price = 1054
 limit = 1000
 weight = 0.028
@@ -76,6 +78,7 @@ id = 2463
 
 [blue_flowers]
 id = 2464
+fun_weapon = true
 price = 885
 limit = 1000
 weight = 0.028
@@ -87,6 +90,7 @@ id = 2465
 
 [yellow_flowers]
 id = 2466
+fun_weapon = true
 price = 788
 limit = 1000
 weight = 0.028
@@ -98,6 +102,7 @@ id = 2467
 
 [purple_flowers]
 id = 2468
+fun_weapon = true
 price = 834
 limit = 1000
 weight = 0.028
@@ -109,6 +114,7 @@ id = 2469
 
 [orange_flowers]
 id = 2470
+fun_weapon = true
 price = 800
 limit = 1000
 weight = 0.028
@@ -120,6 +126,7 @@ id = 2471
 
 [flowers_mixed]
 id = 2472
+fun_weapon = true
 price = 888
 limit = 1000
 weight = 0.028
@@ -131,6 +138,7 @@ id = 2473
 
 [white_flowers]
 id = 2474
+fun_weapon = true
 price = 21000
 limit = 100
 weight = 0.028
@@ -142,6 +150,7 @@ id = 2475
 
 [black_flowers]
 id = 2476
+fun_weapon = true
 price = 1537
 limit = 100
 weight = 0.028

--- a/data/skill/magic/magic.varbits.toml
+++ b/data/skill/magic/magic.varbits.toml
@@ -1,9 +1,3 @@
-[teleport_block]
-id = 4163 # osrs
-format = "int"
-persist = true
-transmit = false
-
 [vengeance]
 id = 2450 # osrs
 format = "boolean"

--- a/data/skill/magic/magic.vars.toml
+++ b/data/skill/magic/magic.vars.toml
@@ -17,3 +17,8 @@ persist = true
 [ibans_staff_charges]
 format = "int"
 default = 120
+
+# Ticks remaining on a Teleport Block; varbit 4163 belongs to the duel arena in 634
+[teleport_block]
+format = "int"
+persist = true

--- a/game/src/main/kotlin/content/area/kharidian_desert/al_kharid/duel_arena/Mubariz.kt
+++ b/game/src/main/kotlin/content/area/kharidian_desert/al_kharid/duel_arena/Mubariz.kt
@@ -66,7 +66,7 @@ class Mubariz : Script {
     suspend fun Player.duelling() {
         player<Confused>("How do I challenge someone to a duel?")
         npc<Idle>("When you go to the arena you'll go up an access ramp to the walkways that overlook the arenas. From the walkways you can watch the duels and challenge other players.")
-        npc<Idle>("You'll know you're in the right place as you'll have a Duel-with option when you right-click a player.")
+        npc<Idle>("You'll know you're in the right place as you'll have a Challenge option when you right-click a player.")
         choice {
             challenge()
             place()
@@ -77,7 +77,7 @@ class Mubariz : Script {
     }
 
     fun ChoiceOption.options(): Unit = option<Confused>("What kind of options are there?") {
-        npc<Idle>("You and your opponent can offer coins or platinum as a stake. If you win, you receive what your opponent staked minus some tax, but if you lose, your opponent will get whatever items you staked.")
+        npc<Idle>("You and your opponent can offer items as a stake. If you win, you receive whatever your opponent staked, but if you lose, your opponent will get whatever items you staked.")
         npc<Idle>("You can choose to use rules to spice things up a bit. For instance if you both agree to use the 'No Magic' rule then neither player can use magic to attack the other player. The fight will be restricted to ranging and")
         npc<Idle>("melee only.")
         npc<Idle>("The rules are fairly self-evident with lots of different combinations for you to try out!")

--- a/game/src/main/kotlin/content/entity/Movement.kt
+++ b/game/src/main/kotlin/content/entity/Movement.kt
@@ -3,6 +3,7 @@ package content.entity
 import content.area.misthalin.Border
 import world.gregs.voidps.engine.Script
 import world.gregs.voidps.engine.client.instruction.instruction
+import world.gregs.voidps.engine.client.message
 import world.gregs.voidps.engine.client.ui.closeInterfaces
 import world.gregs.voidps.engine.data.Settings
 import world.gregs.voidps.engine.data.definition.Areas
@@ -50,6 +51,11 @@ class Movement : Script {
 
         instruction<Walk> { player ->
             if (player.contains("delay")) {
+                return@instruction
+            }
+            val blocked: String? = player["no_movement_message"]
+            if (blocked != null) {
+                player.message(blocked)
                 return@instruction
             }
             if (player.mode is Interact) {

--- a/game/src/main/kotlin/content/entity/combat/Target.kt
+++ b/game/src/main/kotlin/content/entity/combat/Target.kt
@@ -7,6 +7,9 @@ import content.area.wilderness.inWilderness
 import content.entity.combat.hit.Hit
 import content.entity.combat.hit.directHit
 import content.entity.player.equip.Equipment
+import content.minigame.duel_arena.Duel
+import content.minigame.duel_arena.DuelStage
+import content.minigame.duel_arena.duel
 import content.skill.magic.spell.spell
 import content.skill.melee.weapon.combatStyle
 import content.skill.ranged.ammo
@@ -24,6 +27,7 @@ import world.gregs.voidps.engine.entity.character.mode.interact.InteractOption
 import world.gregs.voidps.engine.entity.character.npc.NPC
 import world.gregs.voidps.engine.entity.character.npc.NPCs
 import world.gregs.voidps.engine.entity.character.player.Player
+import world.gregs.voidps.engine.entity.character.player.Players
 import world.gregs.voidps.engine.entity.character.player.combatLevel
 import world.gregs.voidps.engine.entity.character.player.equip.equipped
 import world.gregs.voidps.engine.entity.character.player.skill.Skill
@@ -78,6 +82,10 @@ object Target {
         if (source.dead || target.dead || source["logged_out", false] || target["logged_out", false]) {
             return false
         }
+        val duel = duel(source) ?: duel(target)
+        if (duel != null) {
+            return duelAttackable(duel, source, target, message)
+        }
         if (source is Player && target is Player) {
             if (!source.inPvp && !source.inWilderness) {
                 if (message) source.message("You can only attack players in a player-vs-player area.")
@@ -118,6 +126,42 @@ object Target {
             return false
         }
         // PVP area, slayer requirements, in combat etc..
+        return true
+    }
+
+    private fun duel(character: Character): Duel? = dueller(character)?.duel
+
+    /**
+     * The player, or the familiar's owner
+     */
+    private fun dueller(character: Character): Player? {
+        if (character is Player) {
+            return character
+        }
+        val owner = character["owner_index", -1]
+        if (owner < 0) {
+            return null
+        }
+        return Players.indexed(owner)
+    }
+
+    /**
+     * Duellers and their familiars can only fight each other, and only once the countdown has finished
+     */
+    private fun duelAttackable(duel: Duel, source: Character, target: Character, message: Boolean): Boolean {
+        val attacker = dueller(source)
+        val defender = dueller(target)
+        if (attacker == null || defender == null || duel.opponent(attacker) != defender || attacker.duel != duel) {
+            if (message) (source as? Player)?.message("You can only attack your opponent!")
+            return false
+        }
+        if (duel.stage != DuelStage.Fighting) {
+            if (message) (source as? Player)?.message("The duel hasn't started yet.")
+            return false
+        }
+        if ((source is NPC || target is NPC) && !duel.hasRule("summoning")) {
+            return false
+        }
         return true
     }
 

--- a/game/src/main/kotlin/content/entity/player/Exit.kt
+++ b/game/src/main/kotlin/content/entity/player/Exit.kt
@@ -1,6 +1,8 @@
 package content.entity.player
 
 import content.entity.combat.underAttack
+import content.minigame.duel_arena.duel
+import content.minigame.duel_arena.forfeitDuel
 import world.gregs.voidps.engine.Script
 import world.gregs.voidps.engine.client.message
 import world.gregs.voidps.engine.client.ui.open
@@ -14,6 +16,11 @@ class Exit(val accounts: AccountManager) : Script {
         }
 
         interfaceOption(id = "logout:*") {
+            // Duellers are offered a forfeit instead of a refusal
+            if (duel?.active == true) {
+                forfeitDuel()
+                return@interfaceOption
+            }
             if (underAttack) {
                 message("You can't log out until 8 seconds after the end of combat.")
                 return@interfaceOption

--- a/game/src/main/kotlin/content/entity/player/equip/Equipping.kt
+++ b/game/src/main/kotlin/content/entity/player/equip/Equipping.kt
@@ -58,6 +58,11 @@ class Equipping : Script {
         if (!player.hasRequirements(item, true)) {
             return
         }
+        val blocked: Set<EquipSlot>? = player["blocked_equip_slots"]
+        if (blocked != null && (blocked.contains(item.slot) || (blocked.contains(EquipSlot.Shield) && item.type == EquipType.TwoHanded))) {
+            player.message(player["blocked_equip_message", "You can't equip that here."])
+            return
+        }
         if (item.id.contains("greegree") && player.tile !in Areas["ape_atoll"] && player.tile !in Areas["ape_atoll_agility_dungeon"]) {
             player.message("You attempt to use the Monkey Greegree but nothing happens.")
             return

--- a/game/src/main/kotlin/content/minigame/duel_arena/Duel.kt
+++ b/game/src/main/kotlin/content/minigame/duel_arena/Duel.kt
@@ -1,0 +1,58 @@
+package content.minigame.duel_arena
+
+import world.gregs.voidps.engine.entity.character.player.Player
+import world.gregs.voidps.engine.inv.Inventory
+
+enum class DuelStage {
+    Rules,
+    Confirm,
+    Countdown,
+    Fighting,
+    Finished,
+}
+
+/**
+ * Shared state for one duel, stored on both players as "duel".
+ */
+class Duel(
+    val requester: Player,
+    val acceptor: Player,
+    val staked: Boolean,
+) {
+    val id: Int = ++counter
+    val rules: MutableSet<String> = mutableSetOf()
+    val accepted: MutableSet<String> = mutableSetOf()
+    var stage: DuelStage = DuelStage.Rules
+
+    val players: List<Player>
+        get() = listOf(requester, acceptor)
+
+    val screen: String
+        get() = if (staked) "stake" else "duel_confirm"
+
+    val confirmScreen: String
+        get() = if (staked) "stake_confirm" else "duel_rules_confirm"
+
+    val active: Boolean
+        get() = stage == DuelStage.Countdown || stage == DuelStage.Fighting
+
+    fun opponent(player: Player): Player = if (player === requester) acceptor else requester
+
+    fun hasRule(rule: String): Boolean = rules.contains(rule)
+
+    companion object {
+        private var counter = 0
+    }
+}
+
+val Player.duel: Duel?
+    get() = get("duel")
+
+val Player.stake: Inventory
+    get() = inventories.inventory("dueloffer", false)
+
+val Player.otherStake: Inventory
+    get() = inventories.inventory("dueloffer", true)
+
+val Player.winnings: Inventory
+    get() = inventories.inventory("duelwinnings", false)

--- a/game/src/main/kotlin/content/minigame/duel_arena/DuelArena.kt
+++ b/game/src/main/kotlin/content/minigame/duel_arena/DuelArena.kt
@@ -45,7 +45,7 @@ class DuelArena : Script {
     }
 
     companion object {
-        const val CHALLENGE_SLOT = 3
+        const val CHALLENGE_SLOT = 1
 
         /**
          * Moves everything in [inventory] to the player's inventory, falling back to their bank

--- a/game/src/main/kotlin/content/minigame/duel_arena/DuelArena.kt
+++ b/game/src/main/kotlin/content/minigame/duel_arena/DuelArena.kt
@@ -1,11 +1,14 @@
 package content.minigame.duel_arena
 
-import content.entity.player.bank.bank
+import com.github.michaelbull.logging.InlineLogger
+import content.entity.player.bank.BankDeposit
 import world.gregs.voidps.engine.Script
 import world.gregs.voidps.engine.client.message
 import world.gregs.voidps.engine.client.ui.close
 import world.gregs.voidps.engine.client.ui.open
+import world.gregs.voidps.engine.data.SaveQueue
 import world.gregs.voidps.engine.entity.character.player.Player
+import world.gregs.voidps.engine.get
 import world.gregs.voidps.engine.inv.Inventory
 import world.gregs.voidps.engine.inv.clear
 import world.gregs.voidps.engine.inv.inventory
@@ -41,11 +44,13 @@ class DuelArena : Script {
             if (inventories.contains("duelwinnings")) {
                 returnItems(winnings)
             }
+            save(this)
         }
     }
 
     companion object {
         const val CHALLENGE_SLOT = 1
+        private val logger = InlineLogger()
 
         /**
          * Moves everything in [inventory] to the player's inventory, falling back to their bank
@@ -53,18 +58,32 @@ class DuelArena : Script {
         fun Player.returnItems(inventory: Inventory) {
             var banked = false
             for (index in inventory.indices) {
-                if (inventory[index].isEmpty()) {
+                val item = inventory[index]
+                if (item.isEmpty()) {
                     continue
                 }
                 if (inventory.move(index, this.inventory)) {
                     continue
                 }
-                if (inventory.move(index, bank)) {
+                BankDeposit.deposit(this, inventory, item, item.amount, index, check = false)
+                if (inventory[index].isEmpty()) {
                     banked = true
+                } else {
+                    logger.warn { "Unable to return duel item $item to $this" }
                 }
             }
             if (banked) {
                 message("Some of your duel items have been sent to your bank.")
+            }
+        }
+
+        /**
+         * Persist both sides straight after items change hands so a crash can't restore a stale stake
+         */
+        fun save(vararg players: Player) {
+            val queue: SaveQueue = get()
+            for (player in players) {
+                queue.save(player)
             }
         }
     }

--- a/game/src/main/kotlin/content/minigame/duel_arena/DuelArena.kt
+++ b/game/src/main/kotlin/content/minigame/duel_arena/DuelArena.kt
@@ -1,0 +1,71 @@
+package content.minigame.duel_arena
+
+import content.entity.player.bank.bank
+import world.gregs.voidps.engine.Script
+import world.gregs.voidps.engine.client.message
+import world.gregs.voidps.engine.client.ui.close
+import world.gregs.voidps.engine.client.ui.open
+import world.gregs.voidps.engine.entity.character.player.Player
+import world.gregs.voidps.engine.inv.Inventory
+import world.gregs.voidps.engine.inv.clear
+import world.gregs.voidps.engine.inv.inventory
+import world.gregs.voidps.engine.inv.move
+
+class DuelArena : Script {
+
+    init {
+        entered("duel_arena_walkways") {
+            open("duel_overlay")
+            if (duel == null) {
+                options.set(CHALLENGE_SLOT, "Challenge")
+            }
+        }
+
+        exited("duel_arena_walkways") {
+            close("duel_overlay")
+            options.remove("Challenge")
+        }
+
+        objectOperate("View", "duel_arena_scoreboard") {
+            DuelScoreboard.open(this)
+        }
+
+        // Stakes and winnings left behind by a crash or a full inventory
+        playerSpawn {
+            if (inventories.contains("_dueloffer")) {
+                otherStake.clear()
+            }
+            if (inventories.contains("dueloffer")) {
+                returnItems(stake)
+            }
+            if (inventories.contains("duelwinnings")) {
+                returnItems(winnings)
+            }
+        }
+    }
+
+    companion object {
+        const val CHALLENGE_SLOT = 3
+
+        /**
+         * Moves everything in [inventory] to the player's inventory, falling back to their bank
+         */
+        fun Player.returnItems(inventory: Inventory) {
+            var banked = false
+            for (index in inventory.indices) {
+                if (inventory[index].isEmpty()) {
+                    continue
+                }
+                if (inventory.move(index, this.inventory)) {
+                    continue
+                }
+                if (inventory.move(index, bank)) {
+                    banked = true
+                }
+            }
+            if (banked) {
+                message("Some of your duel items have been sent to your bank.")
+            }
+        }
+    }
+}

--- a/game/src/main/kotlin/content/minigame/duel_arena/DuelConfirm.kt
+++ b/game/src/main/kotlin/content/minigame/duel_arena/DuelConfirm.kt
@@ -1,0 +1,115 @@
+package content.minigame.duel_arena
+
+import world.gregs.voidps.engine.Script
+import world.gregs.voidps.engine.client.ui.chat.Colours
+import world.gregs.voidps.engine.client.ui.chat.toDigitGroupString
+import world.gregs.voidps.engine.client.ui.chat.toTag
+import world.gregs.voidps.engine.entity.character.player.Player
+import world.gregs.voidps.engine.inv.Inventory
+
+class DuelConfirm : Script {
+
+    init {
+        interfaceOption("Accept", "stake_confirm:accept,duel_rules_confirm:accept") {
+            val duel = duel ?: return@interfaceOption
+            if (duel.stage != DuelStage.Confirm) {
+                return@interfaceOption
+            }
+            DuelRulesScreen.accept(duel, this, duel.confirmScreen)
+            if (duel.accepted.size == 2) {
+                DuelFight.start(duel)
+            }
+        }
+    }
+
+    companion object {
+        private const val BEFORE_LINES = 5
+        private const val DURING_LINES = 11
+
+        fun open(duel: Duel) {
+            duel.stage = DuelStage.Confirm
+            duel.accepted.clear()
+            for (player in duel.players) {
+                show(player, duel)
+            }
+        }
+
+        private fun show(player: Player, duel: Duel) {
+            val screen = duel.confirmScreen
+            player.interfaces.remove(duel.screen)
+            if (duel.staked) {
+                player.interfaces.close("duel2_side")
+                player.interfaces.open("inventory")
+            }
+            player.interfaces.open(screen)
+            val before = before(duel)
+            val during = during(duel)
+            for (index in 0 until BEFORE_LINES) {
+                player.interfaces.sendText(screen, "before_$index", before.getOrElse(index) { "" })
+            }
+            for (index in 0 until DURING_LINES) {
+                player.interfaces.sendText(screen, "during_$index", during.getOrElse(index) { "" })
+            }
+            if (duel.staked) {
+                player.interfaces.sendText(screen, "stake", itemsText(player.stake))
+                player.interfaces.sendText(screen, "other_stake", itemsText(player.otherStake))
+            }
+            player.interfaces.sendText(screen, "status", "")
+        }
+
+        fun before(duel: Duel): List<String> {
+            val lines = mutableListOf<String>()
+            if (DuelRules.hasEquipmentRule(duel)) {
+                lines.add("Some worn items will be taken off.")
+            }
+            if (duel.hasRule("no_drinks") || duel.hasRule("no_food")) {
+                lines.add("Boosted stats will be restored.")
+            }
+            if (duel.hasRule("no_prayer")) {
+                lines.add("Existing prayers will be stopped.")
+            }
+            if (lines.isEmpty()) {
+                lines.add("Nothing will be changed.")
+            }
+            return lines
+        }
+
+        fun during(duel: Duel): List<String> {
+            val lines = mutableListOf<String>()
+            if (duel.hasRule("no_weapon") || duel.hasRule("no_shield")) {
+                lines.add("You can't use 2H weapons such as bows.")
+            }
+            for (rule in DuelRules.general) {
+                if (duel.hasRule(rule)) {
+                    lines.add(DuelRules.info(rule))
+                }
+            }
+            if (lines.isEmpty()) {
+                lines.add("You will fight using normal combat.")
+            }
+            return lines
+        }
+
+        fun itemsText(inventory: Inventory): String {
+            if (inventory.isEmpty()) {
+                return "Absolutely nothing!"
+            }
+            return buildString {
+                for (item in inventory.items) {
+                    if (item.isEmpty()) {
+                        continue
+                    }
+                    append(Colours.ORANGE.toTag())
+                    append(item.def.name)
+                    if (item.amount > 1) {
+                        append(Colours.WHITE.toTag())
+                        append(" x ")
+                        append(Colours.YELLOW.toTag())
+                        append(item.amount.toLong().toDigitGroupString())
+                    }
+                    append("<br>")
+                }
+            }
+        }
+    }
+}

--- a/game/src/main/kotlin/content/minigame/duel_arena/DuelConfirm.kt
+++ b/game/src/main/kotlin/content/minigame/duel_arena/DuelConfirm.kt
@@ -12,7 +12,7 @@ class DuelConfirm : Script {
     init {
         interfaceOption("Accept", "stake_confirm:accept,duel_rules_confirm:accept") {
             val duel = duel ?: return@interfaceOption
-            if (duel.stage != DuelStage.Confirm) {
+            if (duel.stage != DuelStage.Confirm || !DuelRulesScreen.canAccept(duel)) {
                 return@interfaceOption
             }
             DuelRulesScreen.accept(duel, this, duel.confirmScreen)

--- a/game/src/main/kotlin/content/minigame/duel_arena/DuelEnd.kt
+++ b/game/src/main/kotlin/content/minigame/duel_arena/DuelEnd.kt
@@ -40,8 +40,13 @@ class DuelEnd : Script {
 
     init {
         playerDeath {
-            val duel = duel ?: return@playerDeath
-            if (!duel.active) {
+            val duel = duel
+            if (duel == null || !duel.active) {
+                // Covers both players dying on the same tick: the arena is always a safe death
+                if (Areas.tagged("duel_arena").any { tile in it.area }) {
+                    it.dropItems = false
+                    it.teleport = hospital(this)
+                }
                 return@playerDeath
             }
             it.dropItems = false
@@ -68,6 +73,7 @@ class DuelEnd : Script {
 
         interfaceClosed("stake_victory") {
             returnItems(winnings)
+            DuelArena.save(this)
         }
     }
 
@@ -127,6 +133,9 @@ class DuelEnd : Script {
                 it.otherStake.clear()
                 it.returnItems(it.stake)
             }
+            if (duel.staked) {
+                DuelArena.save(player, opponent)
+            }
             opponent.message("Other player declined ${if (duel.staked) "stake and " else ""}duel options.", ChatType.Trade)
         }
 
@@ -175,6 +184,7 @@ class DuelEnd : Script {
             for (player in listOf(winner, loser)) {
                 player.otherStake.clear()
             }
+            DuelArena.save(winner, loser)
         }
 
         private fun victory(winner: Player, loser: Player, duel: Duel) {

--- a/game/src/main/kotlin/content/minigame/duel_arena/DuelEnd.kt
+++ b/game/src/main/kotlin/content/minigame/duel_arena/DuelEnd.kt
@@ -186,8 +186,9 @@ class DuelEnd : Script {
             winner.tele(hospital(winner))
             winner.jingle("duel_arena_victory")
             val screen = if (duel.staked) "stake_victory" else "duel_victory"
+            // The name component is filled from this string by its load script
+            winner["duel_victory_name"] = loser.name
             winner.open(screen)
-            winner.interfaces.sendText(screen, "name", loser.name)
             winner.interfaces.sendText(screen, "combat_level", loser.combatLevel.toString())
             if (!duel.staked) {
                 return

--- a/game/src/main/kotlin/content/minigame/duel_arena/DuelEnd.kt
+++ b/game/src/main/kotlin/content/minigame/duel_arena/DuelEnd.kt
@@ -1,0 +1,200 @@
+package content.minigame.duel_arena
+
+import com.github.michaelbull.logging.InlineLogger
+import content.entity.combat.attackers
+import content.entity.player.effect.energy.MAX_RUN_ENERGY
+import content.entity.player.effect.energy.runEnergy
+import content.minigame.duel_arena.DuelArena.Companion.returnItems
+import content.skill.prayer.getActivePrayerVarKey
+import content.skill.summoning.dismissFamiliar
+import world.gregs.voidps.engine.Script
+import world.gregs.voidps.engine.client.clearHinted
+import world.gregs.voidps.engine.client.message
+import world.gregs.voidps.engine.client.ui.closeMenu
+import world.gregs.voidps.engine.client.ui.open
+import world.gregs.voidps.engine.client.variable.stop
+import world.gregs.voidps.engine.data.definition.Areas
+import world.gregs.voidps.engine.entity.World
+import world.gregs.voidps.engine.entity.character.jingle
+import world.gregs.voidps.engine.entity.character.mode.EmptyMode
+import world.gregs.voidps.engine.entity.character.move.tele
+import world.gregs.voidps.engine.entity.character.player.Player
+import world.gregs.voidps.engine.entity.character.player.chat.ChatType
+import world.gregs.voidps.engine.entity.character.player.combatLevel
+import world.gregs.voidps.engine.entity.character.player.name
+import world.gregs.voidps.engine.entity.character.player.req.removeRequest
+import world.gregs.voidps.engine.event.AuditLog
+import world.gregs.voidps.engine.inv.clear
+import world.gregs.voidps.engine.inv.moveAll
+import world.gregs.voidps.engine.inv.sendInventory
+import world.gregs.voidps.engine.map.collision.random
+import world.gregs.voidps.type.Tile
+
+class DuelEnd : Script {
+
+    enum class Result {
+        Death,
+        Forfeit,
+        Disconnect,
+    }
+
+    init {
+        playerDeath {
+            val duel = duel ?: return@playerDeath
+            if (!duel.active) {
+                return@playerDeath
+            }
+            it.dropItems = false
+            it.teleport = hospital(this)
+            finish(duel, winner = duel.opponent(this), loser = this, Result.Death)
+        }
+
+        playerDespawn {
+            val duel = duel ?: return@playerDespawn
+            when (duel.stage) {
+                DuelStage.Rules, DuelStage.Confirm -> decline(duel, this)
+                DuelStage.Countdown, DuelStage.Fighting -> finish(duel, winner = duel.opponent(this), loser = this, Result.Disconnect)
+                DuelStage.Finished -> {}
+            }
+        }
+
+        interfaceOption("Claim", "stake_victory:claim,duel_victory:claim") {
+            closeMenu()
+        }
+
+        interfaceOption("Close", "stake_victory:close,duel_victory:close") {
+            closeMenu()
+        }
+
+        interfaceClosed("stake_victory") {
+            returnItems(winnings)
+        }
+    }
+
+    companion object {
+        private val logger = InlineLogger()
+        private const val DEATH_TICKS = 5
+        private val hospitalTile = Tile(3369, 3270)
+
+        fun hospital(player: Player): Tile = Areas["duel_arena_hospital"].random(player) ?: hospitalTile
+
+        fun finish(duel: Duel, winner: Player, loser: Player, result: Result) {
+            if (duel.stage == DuelStage.Finished) {
+                return
+            }
+            duel.stage = DuelStage.Finished
+            for (player in duel.players) {
+                cleanup(player)
+            }
+            if (duel.staked) {
+                transferStakes(winner, loser)
+            }
+            DuelScoreboard.add(winner, loser)
+            AuditLog.event(winner, "won_duel", loser, result.name)
+            loser.message("Oh dear, it seems you have lost to ${winner.name}.")
+            winner.message("Congratulations! You easily defeated ${loser.name}.")
+            when (result) {
+                // PlayerDeath heals and teleports the loser once the death animation ends
+                Result.Death -> World.queue("duel_${duel.id}_victory", DEATH_TICKS) {
+                    victory(winner, loser, duel)
+                }
+                Result.Forfeit, Result.Disconnect -> {
+                    restore(loser)
+                    loser.tele(hospital(loser))
+                    victory(winner, loser, duel)
+                }
+            }
+        }
+
+        fun decline(duel: Duel, player: Player) {
+            if (duel.stage == DuelStage.Finished) {
+                return
+            }
+            duel.stage = DuelStage.Finished
+            val opponent = duel.opponent(player)
+            for (it in duel.players) {
+                val other = duel.opponent(it)
+                it.clear("duel")
+                for (type in DuelRequest.TYPES) {
+                    it.removeRequest(other, type)
+                }
+                for (rule in DuelRules.all) {
+                    it.clear("duel_$rule")
+                }
+                it.closeMenu()
+                it.interfaces.close("duel2_side")
+                it.interfaces.open("inventory")
+                it.otherStake.clear()
+                it.returnItems(it.stake)
+            }
+            opponent.message("Other player declined ${if (duel.staked) "stake and " else ""}duel options.", ChatType.Trade)
+        }
+
+        private fun cleanup(player: Player) {
+            player.clear("duel")
+            player.clear("in_pvp")
+            player.stop("movement_delay")
+            player.stop("under_attack")
+            player.clear("no_food_message")
+            player.clear("no_drinks_message")
+            player.clear("no_prayer_message")
+            player.clear("no_summoning_message")
+            player.clear("no_movement_message")
+            player.clear("blocked_equip_slots")
+            player.clear("blocked_equip_message")
+            player["equipment_tab"] = "worn_equipment"
+            for (rule in DuelRules.all) {
+                player.clear("duel_$rule")
+            }
+            player.attackers.clear()
+            player.clearHinted()
+            player.options.remove("Attack")
+            player.options.set(DuelArena.CHALLENGE_SLOT, "Challenge")
+            player.dismissFamiliar()
+            if (player.mode != EmptyMode) {
+                player.mode = EmptyMode
+            }
+        }
+
+        private fun restore(player: Player) {
+            player.levels.clear()
+            player.runEnergy = MAX_RUN_ENERGY
+            player.clear(player.getActivePrayerVarKey())
+        }
+
+        private fun transferStakes(winner: Player, loser: Player) {
+            val lost = loser.stake.items.filter { it.isNotEmpty() }
+            AuditLog.event(loser, "lost_stake", winner, *lost.toTypedArray())
+            // Two transactions: one target can't be linked from two sources at once
+            for (stake in listOf(loser.stake, winner.stake)) {
+                if (stake.moveAll(winner.winnings)) {
+                    continue
+                }
+                logger.warn { "Duel stake transfer failed ${winner.name} ${loser.name} ${stake.items.toList()}" }
+                winner.returnItems(stake)
+            }
+            for (player in listOf(winner, loser)) {
+                player.otherStake.clear()
+            }
+        }
+
+        private fun victory(winner: Player, loser: Player, duel: Duel) {
+            if (winner["logged_out", false]) {
+                return
+            }
+            restore(winner)
+            winner.tele(hospital(winner))
+            winner.jingle("duel_arena_victory")
+            val screen = if (duel.staked) "stake_victory" else "duel_victory"
+            winner.open(screen)
+            winner.interfaces.sendText(screen, "name", loser.name)
+            winner.interfaces.sendText(screen, "combat_level", loser.combatLevel.toString())
+            if (!duel.staked) {
+                return
+            }
+            winner.interfaceOptions.send(screen, "winnings")
+            winner.interfaceOptions.unlockAll(screen, "winnings", 0 until 28)
+            winner.sendInventory("duelwinnings")
+        }
+    }
+}

--- a/game/src/main/kotlin/content/minigame/duel_arena/DuelEnd.kt
+++ b/game/src/main/kotlin/content/minigame/duel_arena/DuelEnd.kt
@@ -142,7 +142,6 @@ class DuelEnd : Script {
             player.clear("no_movement_message")
             player.clear("blocked_equip_slots")
             player.clear("blocked_equip_message")
-            player["equipment_tab"] = "worn_equipment"
             for (rule in DuelRules.all) {
                 player.clear("duel_$rule")
             }

--- a/game/src/main/kotlin/content/minigame/duel_arena/DuelFight.kt
+++ b/game/src/main/kotlin/content/minigame/duel_arena/DuelFight.kt
@@ -87,19 +87,31 @@ class DuelFight : Script {
         }
 
         objectOperate("Forfeit", "duel_arena_forfeit_trapdoor", arrive = false) {
-            val duel = duel ?: return@objectOperate
-            if (duel.stage != DuelStage.Fighting) {
-                message("The duel hasn't started yet.")
-                return@objectOperate
+            forfeit()
+        }
+
+        // The worn equipment tab icon is swapped for the forfeit trapdoor during a duel (varc 236).
+        // Registered with the exact option so it runs alongside the gameframe's tab handler.
+        interfaceOption("Worn Equipment", "toplevel*:worn_equipment") {
+            if (duel?.active == true) {
+                forfeit()
             }
-            if (duel.hasRule("no_forfeit")) {
-                statement("Forfeit has been turned off for this duel.")
-                return@objectOperate
-            }
-            val forfeit = choice(listOf("Yes.", "No."), "Do you wish to forfeit?")
-            if (forfeit == 1 && duel.stage == DuelStage.Fighting) {
-                DuelEnd.finish(duel, winner = duel.opponent(this), loser = this, DuelEnd.Result.Forfeit)
-            }
+        }
+    }
+
+    suspend fun Player.forfeit() {
+        val duel = duel ?: return
+        if (duel.stage != DuelStage.Fighting) {
+            message("The duel hasn't started yet.")
+            return
+        }
+        if (duel.hasRule("no_forfeit")) {
+            statement("Forfeit has been turned off for this duel.")
+            return
+        }
+        val forfeit = choice(listOf("Yes.", "No."), "Do you wish to forfeit?")
+        if (forfeit == 1 && duel.stage == DuelStage.Fighting) {
+            DuelEnd.finish(duel, winner = duel.opponent(this), loser = this, DuelEnd.Result.Forfeit)
         }
     }
 

--- a/game/src/main/kotlin/content/minigame/duel_arena/DuelFight.kt
+++ b/game/src/main/kotlin/content/minigame/duel_arena/DuelFight.kt
@@ -1,0 +1,237 @@
+package content.minigame.duel_arena
+
+import content.entity.player.combat.special.specialAttack
+import content.entity.player.dialogue.type.choice
+import content.entity.player.dialogue.type.statement
+import content.skill.melee.weapon.weapon
+import content.skill.prayer.getActivePrayerVarKey
+import content.skill.summoning.dismissFamiliar
+import world.gregs.voidps.engine.Script
+import world.gregs.voidps.engine.client.markHint
+import world.gregs.voidps.engine.client.message
+import world.gregs.voidps.engine.client.ui.closeMenu
+import world.gregs.voidps.engine.client.variable.start
+import world.gregs.voidps.engine.data.definition.Areas
+import world.gregs.voidps.engine.entity.World
+import world.gregs.voidps.engine.entity.character.jingle
+import world.gregs.voidps.engine.entity.character.mode.EmptyMode
+import world.gregs.voidps.engine.entity.character.move.tele
+import world.gregs.voidps.engine.entity.character.player.Player
+import world.gregs.voidps.engine.entity.character.player.equip.EquipType
+import world.gregs.voidps.engine.entity.character.player.equip.equipped
+import world.gregs.voidps.engine.entity.item.type
+import world.gregs.voidps.engine.inv.equipment
+import world.gregs.voidps.engine.inv.inventory
+import world.gregs.voidps.engine.inv.move
+import world.gregs.voidps.engine.map.collision.random
+import world.gregs.voidps.network.login.protocol.visual.update.player.EquipSlot
+import world.gregs.voidps.type.Area
+import world.gregs.voidps.type.Direction
+import world.gregs.voidps.type.Tile
+import world.gregs.voidps.type.area.Rectangle
+
+class DuelFight : Script {
+
+    init {
+        combatPrepare("magic") { _ ->
+            allowed("no_magic", "Magic")
+        }
+
+        combatPrepare("range") { _ ->
+            allowed("no_ranged", "Ranged")
+        }
+
+        combatPrepare("melee") { _ ->
+            allowed("no_melee", "Melee")
+        }
+
+        combatPrepare { _ ->
+            val duel = duel ?: return@combatPrepare true
+            if (!duel.active || !duel.hasRule("fun_weapons") || DuelRules.funWeapon(weapon)) {
+                return@combatPrepare true
+            }
+            message("This is a 'fun weapon' duel. You can only use flowers, basket of eggs, or a")
+            message("rubber chicken.")
+            false
+        }
+
+        variableSet("special_attack") { _, _, to ->
+            if (to == true && duel?.active == true && duel?.hasRule("no_special") == true) {
+                message("You can't use special attacks in this duel.")
+                specialAttack = false
+            }
+        }
+
+        teleportTakeOff("*") {
+            if (duel?.active == true) {
+                message("A magical force prevents you from teleporting from the arena.")
+                return@teleportTakeOff false
+            }
+            true
+        }
+
+        droppable {
+            if (duel?.active == true) {
+                message("You cannot drop items whilst in a duel.")
+                return@droppable false
+            }
+            true
+        }
+
+        playerLogout {
+            if (duel?.active == true) {
+                message("You can't log out during a duel.")
+                return@playerLogout false
+            }
+            true
+        }
+
+        objectOperate("Forfeit", "duel_arena_forfeit_trapdoor", arrive = false) {
+            val duel = duel ?: return@objectOperate
+            if (duel.stage != DuelStage.Fighting) {
+                message("The duel hasn't started yet.")
+                return@objectOperate
+            }
+            if (duel.hasRule("no_forfeit")) {
+                statement("Forfeit has been turned off for this duel.")
+                return@objectOperate
+            }
+            val forfeit = choice(listOf("Yes.", "No."), "Do you wish to forfeit?")
+            if (forfeit == 1 && duel.stage == DuelStage.Fighting) {
+                DuelEnd.finish(duel, winner = duel.opponent(this), loser = this, DuelEnd.Result.Forfeit)
+            }
+        }
+    }
+
+    fun Player.allowed(rule: String, style: String): Boolean {
+        val duel = duel ?: return true
+        if (!duel.active || !duel.hasRule(rule)) {
+            return true
+        }
+        message("$style has been turned off for this duel.")
+        if (rule == "no_magic") {
+            clear("spell")
+        }
+        return false
+    }
+
+    companion object {
+        private const val COUNTDOWN_TICKS = 1
+
+        fun start(duel: Duel) {
+            duel.stage = DuelStage.Countdown
+            duel.accepted.clear()
+            val arena = arena(duel)
+            val first = arena.random(duel.requester) ?: arena.random()
+            val second = if (duel.hasRule("no_movement")) {
+                adjacent(first, duel.acceptor, arena)
+            } else {
+                var tile = arena.random(duel.acceptor) ?: arena.random()
+                if (tile == first) {
+                    tile = adjacent(first, duel.acceptor, arena)
+                }
+                tile
+            }
+            setup(duel.requester, duel, first)
+            setup(duel.acceptor, duel, second)
+            duel.requester.face(duel.acceptor)
+            duel.acceptor.face(duel.requester)
+            countdown(duel, 3)
+        }
+
+        private fun arena(duel: Duel): Area {
+            val tag = if (duel.hasRule("obstacles")) "obstacles" else "no_obstacles"
+            return Areas.tagged("duel_spawn").filter { it.tags.contains(tag) }.random().area
+        }
+
+        /**
+         * Tile next to [tile] for no-movement duels; players are always placed side-by-side, never diagonally
+         */
+        private fun adjacent(tile: Tile, player: Player, arena: Area): Tile {
+            for (direction in listOf(Direction.WEST, Direction.EAST, Direction.SOUTH, Direction.NORTH)) {
+                val target = tile.add(direction)
+                if (target !in arena) {
+                    continue
+                }
+                if (Rectangle(target.x, target.y, target.x, target.y).random(player) != null) {
+                    return target
+                }
+            }
+            return tile.addX(-1)
+        }
+
+        private fun setup(player: Player, duel: Duel, tile: Tile) {
+            val opponent = duel.opponent(player)
+            player.closeMenu()
+            removeEquipment(player, duel)
+            if (duel.hasRule("no_prayer")) {
+                player.clear(player.getActivePrayerVarKey())
+            }
+            if (duel.hasRule("no_drinks") || duel.hasRule("no_food")) {
+                player.levels.clear()
+            }
+            player.dismissFamiliar()
+            player.mode = EmptyMode
+            player.steps.clear()
+            player.tele(tile)
+            player.interfaces.open("inventory")
+            player["in_pvp"] = true
+            player.options.remove("Challenge")
+            player.options.set(ATTACK_SLOT, "Attack")
+            player["equipment_tab"] = "forfeit"
+            player.markHint(opponent)
+            player.jingle("duel_start")
+            if (duel.hasRule("no_food")) {
+                player["no_food_message"] = "You cannot eat during this duel."
+            }
+            if (duel.hasRule("no_drinks")) {
+                player["no_drinks_message"] = "You cannot drink during this duel."
+            }
+            if (duel.hasRule("no_prayer")) {
+                player["no_prayer_message"] = "You can't use prayers in this duel."
+            }
+            if (!duel.hasRule("summoning")) {
+                player["no_summoning_message"] = "Summoning has been disabled during this duel!"
+            }
+            if (duel.hasRule("no_movement")) {
+                player["no_movement_message"] = "You cannot move during this duel!"
+                player.start("movement_delay", -1)
+            }
+            val blocked = DuelRules.blockedSlots(duel)
+            if (blocked.isNotEmpty()) {
+                player["blocked_equip_slots"] = blocked
+                player["blocked_equip_message"] = "You can't equip that during this duel."
+            }
+        }
+
+        private fun removeEquipment(player: Player, duel: Duel) {
+            for ((rule, slot) in DuelRules.equipment) {
+                if (duel.hasRule(rule) && player.equipped(slot).isNotEmpty()) {
+                    player.equipment.move(slot.index, player.inventory)
+                }
+            }
+            if (duel.hasRule("no_shield") && player.equipped(EquipSlot.Weapon).type == EquipType.TwoHanded) {
+                player.equipment.move(EquipSlot.Weapon.index, player.inventory)
+            }
+        }
+
+        private fun countdown(duel: Duel, count: Int) {
+            World.queue("duel_${duel.id}_countdown", COUNTDOWN_TICKS) {
+                if (duel.stage != DuelStage.Countdown) {
+                    return@queue
+                }
+                val text = if (count == 0) "FIGHT!" else count.toString()
+                for (player in duel.players) {
+                    player.say(text)
+                }
+                if (count == 0) {
+                    duel.stage = DuelStage.Fighting
+                } else {
+                    countdown(duel, count - 1)
+                }
+            }
+        }
+
+        const val ATTACK_SLOT = 1
+    }
+}

--- a/game/src/main/kotlin/content/minigame/duel_arena/DuelFight.kt
+++ b/game/src/main/kotlin/content/minigame/duel_arena/DuelFight.kt
@@ -87,31 +87,7 @@ class DuelFight : Script {
         }
 
         objectOperate("Forfeit", "duel_arena_forfeit_trapdoor", arrive = false) {
-            forfeit()
-        }
-
-        // The worn equipment tab icon is swapped for the forfeit trapdoor during a duel (varc 236).
-        // Registered with the exact option so it runs alongside the gameframe's tab handler.
-        interfaceOption("Worn Equipment", "toplevel*:worn_equipment") {
-            if (duel?.active == true) {
-                forfeit()
-            }
-        }
-    }
-
-    suspend fun Player.forfeit() {
-        val duel = duel ?: return
-        if (duel.stage != DuelStage.Fighting) {
-            message("The duel hasn't started yet.")
-            return
-        }
-        if (duel.hasRule("no_forfeit")) {
-            statement("Forfeit has been turned off for this duel.")
-            return
-        }
-        val forfeit = choice(listOf("Yes.", "No."), "Do you wish to forfeit?")
-        if (forfeit == 1 && duel.stage == DuelStage.Fighting) {
-            DuelEnd.finish(duel, winner = duel.opponent(this), loser = this, DuelEnd.Result.Forfeit)
+            forfeitDuel()
         }
     }
 
@@ -190,7 +166,6 @@ class DuelFight : Script {
             player["in_pvp"] = true
             player.options.remove("Challenge")
             player.options.set(ATTACK_SLOT, "Attack")
-            player["equipment_tab"] = "forfeit"
             player.markHint(opponent)
             player.jingle("duel_start")
             if (duel.hasRule("no_food")) {
@@ -245,5 +220,24 @@ class DuelFight : Script {
         }
 
         const val ATTACK_SLOT = 1
+    }
+}
+
+/**
+ * Asks the player to forfeit their current duel; used by the trapdoor and the logout button
+ */
+suspend fun Player.forfeitDuel() {
+    val duel = duel ?: return
+    if (duel.stage != DuelStage.Fighting) {
+        message("The duel hasn't started yet.")
+        return
+    }
+    if (duel.hasRule("no_forfeit")) {
+        statement("Forfeit has been turned off for this duel.")
+        return
+    }
+    val forfeit = choice(listOf("Yes.", "No."), "Do you wish to forfeit?")
+    if (forfeit == 1 && duel.stage == DuelStage.Fighting) {
+        DuelEnd.finish(duel, winner = duel.opponent(this), loser = this, DuelEnd.Result.Forfeit)
     }
 }

--- a/game/src/main/kotlin/content/minigame/duel_arena/DuelRequest.kt
+++ b/game/src/main/kotlin/content/minigame/duel_arena/DuelRequest.kt
@@ -1,0 +1,136 @@
+package content.minigame.duel_arena
+
+import world.gregs.voidps.engine.Script
+import world.gregs.voidps.engine.client.message
+import world.gregs.voidps.engine.client.ui.closeMenu
+import world.gregs.voidps.engine.client.ui.menu
+import world.gregs.voidps.engine.client.ui.open
+import world.gregs.voidps.engine.data.definition.Areas
+import world.gregs.voidps.engine.entity.character.player.Player
+import world.gregs.voidps.engine.entity.character.player.chat.ChatType
+import world.gregs.voidps.engine.entity.character.player.combatLevel
+import world.gregs.voidps.engine.entity.character.player.name
+import world.gregs.voidps.engine.entity.character.player.req.hasRequest
+import world.gregs.voidps.engine.entity.character.player.req.removeRequest
+import world.gregs.voidps.engine.entity.character.player.req.request
+import world.gregs.voidps.engine.inv.clear
+
+class DuelRequest : Script {
+
+    init {
+        playerOperate("Challenge") { (target) ->
+            if (duel != null || tile !in Areas["duel_arena_walkways"]) {
+                return@playerOperate
+            }
+            if (busy(target)) {
+                message("The other player is busy.", ChatType.Trade)
+                return@playerOperate
+            }
+            // Accepting a pending challenge skips the type selection
+            for (type in TYPES) {
+                if (target.hasRequest(this, type)) {
+                    send(target, type)
+                    return@playerOperate
+                }
+            }
+            set("duel_target", target)
+            set("duel_type", FRIENDLY)
+            open("duel_request")
+        }
+
+        interfaceOption("Select", "duel_request:friendly,duel_request:friendly_box") {
+            set("duel_type", FRIENDLY)
+        }
+
+        interfaceOption("Select", "duel_request:staked,duel_request:staked_box") {
+            set("duel_type", STAKED)
+        }
+
+        interfaceOption("Next-Screen", "duel_request:challenge") {
+            val target: Player = get("duel_target") ?: return@interfaceOption
+            val type = if (get("duel_type", FRIENDLY) == STAKED) "duel_staked" else "duel_friendly"
+            closeMenu()
+            send(target, type)
+        }
+
+        interfaceOption("Close", "duel_request:close") {
+            closeMenu()
+        }
+
+        interfaceClosed("duel_request") {
+            clear("duel_target")
+        }
+    }
+
+    fun Player.send(target: Player, type: String) {
+        if (duel != null || tile !in Areas["duel_arena_walkways"] || target.tile !in Areas["duel_arena_walkways"]) {
+            return
+        }
+        if (busy(target)) {
+            message("The other player is busy.", ChatType.Trade)
+            return
+        }
+        val staked = type == "duel_staked"
+        message("Sending duel offer...", ChatType.Trade)
+        if (!target.hasRequest(this, type)) {
+            target.message("wishes to duel with you (${if (staked) "stake" else "friendly"}).", ChatType.ChallengeDuel, name = name)
+        }
+        request(target, type) { requester, acceptor ->
+            start(requester, acceptor, staked)
+        }
+    }
+
+    fun busy(target: Player): Boolean = target.duel != null || target.menu != null
+
+    fun start(requester: Player, acceptor: Player, staked: Boolean) {
+        val duel = Duel(requester, acceptor, staked)
+        for (player in duel.players) {
+            val opponent = duel.opponent(player)
+            for (type in TYPES) {
+                player.removeRequest(opponent, type)
+            }
+            player["duel"] = duel
+            openRules(player, duel)
+        }
+    }
+
+    fun openRules(player: Player, duel: Duel) {
+        val opponent = duel.opponent(player)
+        player.closeMenu()
+        for (rule in DuelRules.all) {
+            player.clear("duel_$rule")
+        }
+        player.stake.clear()
+        player.otherStake.clear()
+        val screen = duel.screen
+        player.interfaces.apply {
+            open(screen)
+            sendText(screen, "name", opponent.name)
+            sendText(screen, "combat_level", opponent.combatLevel.toString())
+            sendText(screen, "status", "")
+        }
+        if (!duel.staked) {
+            return
+        }
+        player.interfaces.apply {
+            close("inventory")
+            open("duel2_side")
+            sendVisibility(screen, "max_stake", false)
+            sendVisibility(screen, "max_stake_label", false)
+            sendVisibility(screen, "other_max_stake", false)
+            sendVisibility(screen, "other_max_stake_label", false)
+        }
+        player.interfaceOptions.apply {
+            send("duel2_side", "offer")
+            unlockAll("duel2_side", "offer", 0 until 28)
+            unlockAll(screen, "offer", 0 until 28)
+            unlockAll(screen, "other_offer", 0 until 28)
+        }
+    }
+
+    companion object {
+        const val FRIENDLY = 1
+        const val STAKED = 2
+        val TYPES = listOf("duel_friendly", "duel_staked")
+    }
+}

--- a/game/src/main/kotlin/content/minigame/duel_arena/DuelRequest.kt
+++ b/game/src/main/kotlin/content/minigame/duel_arena/DuelRequest.kt
@@ -1,5 +1,6 @@
 package content.minigame.duel_arena
 
+import content.minigame.duel_arena.DuelArena.Companion.returnItems
 import world.gregs.voidps.engine.Script
 import world.gregs.voidps.engine.client.message
 import world.gregs.voidps.engine.client.ui.closeMenu
@@ -100,7 +101,7 @@ class DuelRequest : Script {
         for (rule in DuelRules.all) {
             player.clear("duel_$rule")
         }
-        player.stake.clear()
+        player.returnItems(player.stake)
         player.otherStake.clear()
         val screen = duel.screen
         player.interfaces.apply {

--- a/game/src/main/kotlin/content/minigame/duel_arena/DuelRules.kt
+++ b/game/src/main/kotlin/content/minigame/duel_arena/DuelRules.kt
@@ -1,0 +1,92 @@
+package content.minigame.duel_arena
+
+import world.gregs.voidps.engine.entity.character.player.Player
+import world.gregs.voidps.engine.entity.character.player.equip.EquipType
+import world.gregs.voidps.engine.entity.character.player.equip.equipped
+import world.gregs.voidps.engine.entity.item.Item
+import world.gregs.voidps.engine.entity.item.slot
+import world.gregs.voidps.engine.entity.item.type
+import world.gregs.voidps.engine.inv.equipment
+import world.gregs.voidps.engine.inv.inventory
+import world.gregs.voidps.network.login.protocol.visual.update.player.EquipSlot
+
+/**
+ * Rule names match the interface component names and the "duel_" prefixed varbits.
+ */
+object DuelRules {
+
+    val styles = listOf("no_ranged", "no_melee", "no_magic")
+
+    val general = listOf(
+        "no_ranged",
+        "no_melee",
+        "no_magic",
+        "fun_weapons",
+        "no_forfeit",
+        "no_drinks",
+        "no_food",
+        "no_prayer",
+        "no_movement",
+        "obstacles",
+        "summoning",
+        "no_special",
+    )
+
+    val equipment: Map<String, EquipSlot> = mapOf(
+        "no_hat" to EquipSlot.Hat,
+        "no_cape" to EquipSlot.Cape,
+        "no_amulet" to EquipSlot.Amulet,
+        "no_ammo" to EquipSlot.Ammo,
+        "no_weapon" to EquipSlot.Weapon,
+        "no_body" to EquipSlot.Chest,
+        "no_shield" to EquipSlot.Shield,
+        "no_legs" to EquipSlot.Legs,
+        "no_ring" to EquipSlot.Ring,
+        "no_boots" to EquipSlot.Feet,
+        "no_gloves" to EquipSlot.Hands,
+    )
+
+    val all: List<String> = general + equipment.keys
+
+    fun info(rule: String): String = when (rule) {
+        "no_ranged" -> "You cannot use Ranged attacks."
+        "no_melee" -> "You cannot use Melee attacks."
+        "no_magic" -> "You cannot use Magic attacks."
+        "fun_weapons" -> "You can only attack with 'fun' weapons."
+        "no_forfeit" -> "You cannot forfeit the duel."
+        "no_drinks" -> "You cannot use potions."
+        "no_food" -> "You cannot use food."
+        "no_prayer" -> "You cannot use Prayer."
+        "no_movement" -> "You cannot move."
+        "obstacles" -> "There will be obstacles in the arena."
+        "summoning" -> "Familiars will be allowed in the arena."
+        "no_special" -> "You cannot use special attacks."
+        else -> ""
+    }
+
+    fun hasEquipmentRule(duel: Duel): Boolean = equipment.keys.any { duel.hasRule(it) }
+
+    fun funWeapon(item: Item): Boolean = item.def["fun_weapon", false]
+
+    fun hasFunWeapon(player: Player): Boolean = player.inventory.items.any { funWeapon(it) } || player.equipment.items.any { funWeapon(it) }
+
+    /**
+     * Worn items that will be removed when the duel starts
+     */
+    fun removedEquipment(player: Player, duel: Duel): List<EquipSlot> {
+        val slots = mutableListOf<EquipSlot>()
+        for ((rule, slot) in equipment) {
+            if (duel.hasRule(rule) && player.equipped(slot).isNotEmpty()) {
+                slots.add(slot)
+            }
+        }
+        if (duel.hasRule("no_shield") && !duel.hasRule("no_weapon") && player.equipped(EquipSlot.Weapon).type == EquipType.TwoHanded) {
+            slots.add(EquipSlot.Weapon)
+        }
+        return slots
+    }
+
+    fun blockedSlots(duel: Duel): Set<EquipSlot> = equipment.filterKeys { duel.hasRule(it) }.values.toSet()
+
+    fun restricted(blocked: Set<EquipSlot>, item: Item): Boolean = blocked.contains(item.slot) || (blocked.contains(EquipSlot.Shield) && item.type == EquipType.TwoHanded)
+}

--- a/game/src/main/kotlin/content/minigame/duel_arena/DuelRulesScreen.kt
+++ b/game/src/main/kotlin/content/minigame/duel_arena/DuelRulesScreen.kt
@@ -89,32 +89,32 @@ class DuelRulesScreen : Script {
         resetAccept(duel)
     }
 
-    /**
-     * Both players are checked so either side sees why the duel can't start
-     */
-    fun canAccept(duel: Duel): Boolean {
-        for (player in duel.players) {
-            val opponent = duel.opponent(player)
-            if (duel.hasRule("fun_weapons") && !DuelRules.hasFunWeapon(player)) {
-                player.message("Fun Weapons is selected but you don't have a 'fun weapon'.")
-                opponent.message("Fun Weapons is selected but your opponent does not have a 'fun weapon'.")
-                return false
-            }
-            var needed = DuelRules.removedEquipment(player, duel).size
-            if (duel.staked) {
-                needed += player.stake.count + opponent.stake.count
-            }
-            if (needed > player.inventory.spaces) {
-                player.message("You do not have enough space for the items removed and/or the stake.")
-                opponent.message("Your opponent does not have enough space for the items removed and/or the stake.")
-                return false
-            }
-        }
-        return true
-    }
-
     companion object {
         val SCREENS = listOf("stake", "duel_confirm")
+
+        /**
+         * Both players are checked so either side sees why the duel can't start
+         */
+        fun canAccept(duel: Duel): Boolean {
+            for (player in duel.players) {
+                val opponent = duel.opponent(player)
+                if (duel.hasRule("fun_weapons") && !DuelRules.hasFunWeapon(player)) {
+                    player.message("Fun Weapons is selected but you don't have a 'fun weapon'.")
+                    opponent.message("Fun Weapons is selected but your opponent does not have a 'fun weapon'.")
+                    return false
+                }
+                var needed = DuelRules.removedEquipment(player, duel).size
+                if (duel.staked) {
+                    needed += player.stake.count + opponent.stake.count
+                }
+                if (needed > player.inventory.spaces) {
+                    player.message("You do not have enough space for the items removed and/or the stake.")
+                    opponent.message("Your opponent does not have enough space for the items removed and/or the stake.")
+                    return false
+                }
+            }
+            return true
+        }
 
         fun sync(duel: Duel, rule: String) {
             for (player in duel.players) {

--- a/game/src/main/kotlin/content/minigame/duel_arena/DuelRulesScreen.kt
+++ b/game/src/main/kotlin/content/minigame/duel_arena/DuelRulesScreen.kt
@@ -1,0 +1,142 @@
+package content.minigame.duel_arena
+
+import world.gregs.voidps.engine.Script
+import world.gregs.voidps.engine.client.message
+import world.gregs.voidps.engine.entity.character.player.Player
+import world.gregs.voidps.engine.entity.character.player.name
+import world.gregs.voidps.engine.inv.inventory
+
+class DuelRulesScreen : Script {
+
+    init {
+        val toggles = SCREENS.flatMap { screen ->
+            DuelRules.general.flatMap { listOf("$screen:$it", "$screen:${it}_box") } + DuelRules.equipment.keys.map { "$screen:$it" }
+        }
+        interfaceOption("Ok", toggles.joinToString(",")) {
+            val duel = duel ?: return@interfaceOption
+            if (duel.stage != DuelStage.Rules) {
+                return@interfaceOption
+            }
+            toggle(duel, it.interfaceComponent.substringAfter(":").removeSuffix("_box"))
+        }
+
+        interfaceOption("Accept", "stake:accept,duel_confirm:accept") {
+            val duel = duel ?: return@interfaceOption
+            if (duel.stage != DuelStage.Rules || !canAccept(duel)) {
+                return@interfaceOption
+            }
+            accept(duel, this, duel.screen)
+            if (duel.accepted.size == 2) {
+                DuelConfirm.open(duel)
+            }
+        }
+
+        interfaceOption("Decline", "stake:decline,duel_confirm:decline,stake_confirm:decline,duel_rules_confirm:decline") {
+            val duel = duel ?: return@interfaceOption
+            DuelEnd.decline(duel, this)
+        }
+
+        interfaceOption("Close", "stake:close,duel_confirm:close,stake_confirm:close,duel_rules_confirm:close") {
+            val duel = duel ?: return@interfaceOption
+            DuelEnd.decline(duel, this)
+        }
+
+        // Walking away or any other close during the setup stages declines the duel.
+        // Moving between screens also closes the previous one, so only the current stage's screen counts.
+        interfaceClosed("stake,duel_confirm,stake_confirm,duel_rules_confirm") { id ->
+            val duel = duel ?: return@interfaceClosed
+            val current = when (duel.stage) {
+                DuelStage.Rules -> duel.screen
+                DuelStage.Confirm -> duel.confirmScreen
+                else -> return@interfaceClosed
+            }
+            if (id == current) {
+                DuelEnd.decline(duel, this)
+            }
+        }
+    }
+
+    fun Player.toggle(duel: Duel, rule: String) {
+        val opponent = duel.opponent(this)
+        if (duel.hasRule(rule)) {
+            duel.rules.remove(rule)
+            sync(duel, rule)
+            resetAccept(duel)
+            return
+        }
+        if (rule in DuelRules.styles && DuelRules.styles.count { duel.hasRule(it) } == 2) {
+            message("You can't have No Ranged, No Melee AND No Magic, how would you fight?")
+            return
+        }
+        if (rule == "no_movement" && duel.hasRule("obstacles")) {
+            duel.rules.remove("obstacles")
+            sync(duel, "obstacles")
+            message("You can't have No Movement in an area with obstacles.")
+            opponent.message("You can't have No Movement in an area with obstacles.")
+        }
+        if (rule == "obstacles" && duel.hasRule("no_movement")) {
+            duel.rules.remove("no_movement")
+            sync(duel, "no_movement")
+            message("You can't have obstacles if you want No Movement.")
+            opponent.message("You can't have obstacles if you want No Movement.")
+        }
+        if (rule == "no_weapon" || rule == "no_shield") {
+            message("Beware: You won't be able to use two-handed weapons such as bows.")
+            opponent.message("Beware: You won't be able to use two-handed weapons such as bows.")
+        }
+        duel.rules.add(rule)
+        sync(duel, rule)
+        resetAccept(duel)
+    }
+
+    /**
+     * Both players are checked so either side sees why the duel can't start
+     */
+    fun canAccept(duel: Duel): Boolean {
+        for (player in duel.players) {
+            val opponent = duel.opponent(player)
+            if (duel.hasRule("fun_weapons") && !DuelRules.hasFunWeapon(player)) {
+                player.message("Fun Weapons is selected but you don't have a 'fun weapon'.")
+                opponent.message("Fun Weapons is selected but your opponent does not have a 'fun weapon'.")
+                return false
+            }
+            var needed = DuelRules.removedEquipment(player, duel).size
+            if (duel.staked) {
+                needed += player.stake.count + opponent.stake.count
+            }
+            if (needed > player.inventory.spaces) {
+                player.message("You do not have enough space for the items removed and/or the stake.")
+                opponent.message("Your opponent does not have enough space for the items removed and/or the stake.")
+                return false
+            }
+        }
+        return true
+    }
+
+    companion object {
+        val SCREENS = listOf("stake", "duel_confirm")
+
+        fun sync(duel: Duel, rule: String) {
+            for (player in duel.players) {
+                player["duel_$rule"] = duel.hasRule(rule)
+            }
+        }
+
+        fun accept(duel: Duel, player: Player, screen: String) {
+            val opponent = duel.opponent(player)
+            duel.accepted.add(player.name)
+            player.interfaces.sendText(screen, "status", "Waiting for other player...")
+            opponent.interfaces.sendText(screen, "status", "Other player has accepted.")
+        }
+
+        fun resetAccept(duel: Duel) {
+            if (duel.accepted.isEmpty()) {
+                return
+            }
+            duel.accepted.clear()
+            for (player in duel.players) {
+                player.interfaces.sendText(duel.screen, "status", "")
+            }
+        }
+    }
+}

--- a/game/src/main/kotlin/content/minigame/duel_arena/DuelScoreboard.kt
+++ b/game/src/main/kotlin/content/minigame/duel_arena/DuelScoreboard.kt
@@ -1,8 +1,6 @@
 package content.minigame.duel_arena
 
-import world.gregs.voidps.engine.client.sendScript
 import world.gregs.voidps.engine.client.ui.open
-import world.gregs.voidps.engine.data.definition.InterfaceDefinitions
 import world.gregs.voidps.engine.entity.character.player.Player
 import world.gregs.voidps.engine.entity.character.player.name
 
@@ -12,7 +10,7 @@ import world.gregs.voidps.engine.entity.character.player.name
 object DuelScoreboard {
 
     const val SIZE = 50
-    private const val ROW_HEIGHT = 16
+    private const val EMPTY = "No duels have been fought on this world yet."
 
     private val entries = ArrayDeque<String>(SIZE)
 
@@ -30,16 +28,14 @@ object DuelScoreboard {
         entries.clear()
     }
 
+    /**
+     * The interface builds its rows from varc strings 224-273 when it opens,
+     * showing "Loading..." if every one of them is blank
+     */
     fun open(player: Player) {
-        if (!player.open("duel_scoreboard")) {
-            return
+        for (index in 0 until SIZE) {
+            player["duel_scoreboard_$index"] = entries.getOrNull(index) ?: if (index == 0) EMPTY else ""
         }
-        val list = InterfaceDefinitions.getComponent("duel_scoreboard", "list") ?: return
-        val scrollbar = InterfaceDefinitions.getComponent("duel_scoreboard", "scrollbar") ?: return
-        for ((index, entry) in entries.withIndex()) {
-            player.sendScript("duel_scoreboard_row", 0, index * ROW_HEIGHT, list.id, entry)
-        }
-        player.sendScript("scrollbar_vertical", scrollbar.id, list.id)
-        player.sendScript("set_scroll_height", scrollbar.id, list.id, entries.size * ROW_HEIGHT, 0)
+        player.open("duel_scoreboard")
     }
 }

--- a/game/src/main/kotlin/content/minigame/duel_arena/DuelScoreboard.kt
+++ b/game/src/main/kotlin/content/minigame/duel_arena/DuelScoreboard.kt
@@ -1,0 +1,45 @@
+package content.minigame.duel_arena
+
+import world.gregs.voidps.engine.client.sendScript
+import world.gregs.voidps.engine.client.ui.open
+import world.gregs.voidps.engine.data.definition.InterfaceDefinitions
+import world.gregs.voidps.engine.entity.character.player.Player
+import world.gregs.voidps.engine.entity.character.player.name
+
+/**
+ * Last fifty duels on this world, newest first. In-memory only.
+ */
+object DuelScoreboard {
+
+    const val SIZE = 50
+    private const val ROW_HEIGHT = 16
+
+    private val entries = ArrayDeque<String>(SIZE)
+
+    val results: List<String>
+        get() = entries.toList()
+
+    fun add(winner: Player, loser: Player) {
+        entries.addFirst("${winner.name} defeated ${loser.name}")
+        while (entries.size > SIZE) {
+            entries.removeLast()
+        }
+    }
+
+    fun clear() {
+        entries.clear()
+    }
+
+    fun open(player: Player) {
+        if (!player.open("duel_scoreboard")) {
+            return
+        }
+        val list = InterfaceDefinitions.getComponent("duel_scoreboard", "list") ?: return
+        val scrollbar = InterfaceDefinitions.getComponent("duel_scoreboard", "scrollbar") ?: return
+        for ((index, entry) in entries.withIndex()) {
+            player.sendScript("duel_scoreboard_row", 0, index * ROW_HEIGHT, list.id, entry)
+        }
+        player.sendScript("scrollbar_vertical", scrollbar.id, list.id)
+        player.sendScript("set_scroll_height", scrollbar.id, list.id, entries.size * ROW_HEIGHT, 0)
+    }
+}

--- a/game/src/main/kotlin/content/minigame/duel_arena/DuelStake.kt
+++ b/game/src/main/kotlin/content/minigame/duel_arena/DuelStake.kt
@@ -1,0 +1,94 @@
+package content.minigame.duel_arena
+
+import content.entity.player.dialogue.type.intEntry
+import world.gregs.voidps.engine.Script
+import world.gregs.voidps.engine.client.message
+import world.gregs.voidps.engine.data.definition.ItemDefinitions
+import world.gregs.voidps.engine.entity.character.player.Player
+import world.gregs.voidps.engine.inv.*
+import world.gregs.voidps.engine.inv.restrict.ItemRestrictionRule
+import world.gregs.voidps.engine.inv.transact.operation.AddItem.add
+import world.gregs.voidps.engine.inv.transact.operation.AddItemLimit.addToLimit
+import world.gregs.voidps.engine.inv.transact.operation.ClearItem.clear
+import world.gregs.voidps.engine.inv.transact.operation.RemoveItemLimit.removeToLimit
+
+class DuelStake : Script {
+
+    val stakeRestriction = object : ItemRestrictionRule {
+        override fun restricted(id: String): Boolean {
+            val def = ItemDefinitions.get(id)
+            return def.lendTemplateId != -1 || def.dummyItem != 0 || !def["tradeable", true]
+        }
+    }
+
+    init {
+        playerSpawn {
+            stake.itemRule = stakeRestriction
+        }
+
+        interfaceOption(id = "duel2_side:offer") { (item, _, option) ->
+            val amount = when (option) {
+                "Stake-1" -> 1
+                "Stake-5" -> 5
+                "Stake-10" -> 10
+                "Stake-All" -> Int.MAX_VALUE
+                "Stake-X" -> intEntry("Enter amount:")
+                else -> return@interfaceOption
+            }
+            offer(this, item.id, amount)
+        }
+
+        interfaceOption(id = "stake:offer") { (item, itemSlot, option) ->
+            val amount = when (option) {
+                "Remove-1" -> 1
+                "Remove-5" -> 5
+                "Remove-10" -> 10
+                "Remove-All" -> stake.count(item.id)
+                "Remove-X" -> intEntry("Enter amount:")
+                else -> return@interfaceOption
+            }
+            remove(this, item.id, itemSlot, amount)
+        }
+
+        // Mirror the stake to the opponent's secondary container and reset any accepts
+        slotChanged("dueloffer") { change ->
+            val duel = duel ?: return@slotChanged
+            val opponent = duel.opponent(this)
+            opponent.otherStake.transaction { set(change.index, change.item, change.from, change.fromIndex) }
+            DuelRulesScreen.resetAccept(duel)
+        }
+    }
+
+    fun staking(player: Player, amount: Int): Boolean {
+        val duel = player.duel ?: return false
+        return duel.staked && duel.stage == DuelStage.Rules && amount >= 1
+    }
+
+    fun offer(player: Player, id: String, amount: Int) {
+        if (!staking(player, amount)) {
+            return
+        }
+        val offered = player.inventory.transaction {
+            val added = removeToLimit(id, amount)
+            val transaction = link(player.stake)
+            transaction.add(id, added)
+        }
+        if (!offered) {
+            player.message("That item cannot be staked.")
+        }
+    }
+
+    fun remove(player: Player, id: String, slot: Int, amount: Int) {
+        if (!staking(player, amount)) {
+            return
+        }
+        player.stake.transaction {
+            val added = link(player.inventory).addToLimit(id, amount)
+            if (!inventory.stackable(id) && added == 1) {
+                clear(slot)
+            } else {
+                removeToLimit(id, added)
+            }
+        }
+    }
+}

--- a/game/src/main/kotlin/content/skill/constitution/Eating.kt
+++ b/game/src/main/kotlin/content/skill/constitution/Eating.kt
@@ -31,6 +31,11 @@ class Eating : Script {
             return
         }
         val drink = option == "Drink"
+        val blocked: String? = player[if (drink) "no_drinks_message" else "no_food_message"]
+        if (blocked != null) {
+            player.message(blocked)
+            return
+        }
         val combo = item.def.contains("combo")
         val delay = when {
             combo -> "combo_delay"

--- a/game/src/main/kotlin/content/skill/prayer/list/QuickPrayers.kt
+++ b/game/src/main/kotlin/content/skill/prayer/list/QuickPrayers.kt
@@ -48,6 +48,12 @@ class QuickPrayers(val definitions: PrayerDefinitions) : Script {
         }
 
         interfaceOption("Turn Quick Prayers On", "prayer_orb:orb") {
+            val blocked: String? = get("no_prayer_message")
+            if (blocked != null) {
+                message(blocked)
+                set(USING_QUICK_PRAYERS, false)
+                return@interfaceOption
+            }
             if (levels.get(Skill.Prayer) == 0) {
                 message("You've run out of prayer points.")
                 set(USING_QUICK_PRAYERS, false)
@@ -98,6 +104,11 @@ class QuickPrayers(val definitions: PrayerDefinitions) : Script {
         if (activated) {
             removeVarbit(listKey, name)
         } else {
+            val blocked: String? = get("no_prayer_message")
+            if (!quick && blocked != null) {
+                message(blocked)
+                return
+            }
             if (!quick && !has(Skill.Prayer, 1)) {
                 message("You need to recharge your Prayer at an altar.")
                 return

--- a/game/src/main/kotlin/content/skill/summoning/Summoning.kt
+++ b/game/src/main/kotlin/content/skill/summoning/Summoning.kt
@@ -339,6 +339,11 @@ class Summoning : Script {
         }
 
         itemOption("Summon", "*_pouch") { option ->
+            val blocked: String? = get("no_summoning_message")
+            if (blocked != null) {
+                message(blocked)
+                return@itemOption
+            }
             val familiarLevel = EnumDefinitions.get("summoning_pouch_levels").int(option.item.def.id)
             val familiarId = EnumDefinitions.get("summoning_familiar_ids").int(option.item.def.id)
             val summoningXp = option.item.def["summon_experience", 0.0]

--- a/game/src/main/kotlin/content/social/trade/TradeRequest.kt
+++ b/game/src/main/kotlin/content/social/trade/TradeRequest.kt
@@ -2,6 +2,7 @@ package content.social.trade
 
 import content.entity.player.modal.Tab
 import content.entity.player.modal.tab
+import content.minigame.duel_arena.duel
 import content.social.friend.friend
 import content.social.trade.Trade.getPartner
 import world.gregs.voidps.engine.Script
@@ -22,6 +23,14 @@ class TradeRequest : Script {
 
     init {
         playerOperate("Trade with") { (target) ->
+            if (duel != null) {
+                message("You can't trade during a duel.", ChatType.Trade)
+                return@playerOperate
+            }
+            if (target.duel != null) {
+                message("Other player is busy at the moment.", ChatType.Trade)
+                return@playerOperate
+            }
             val filter = target["trade_filter", "on"]
             if (filter == "off" || (filter == "friends" && !target.friend(this))) {
                 return@playerOperate

--- a/game/src/test/kotlin/content/minigame/duel_arena/DuelTest.kt
+++ b/game/src/test/kotlin/content/minigame/duel_arena/DuelTest.kt
@@ -249,6 +249,18 @@ internal class DuelTest : WorldTest() {
     }
 
     @Test
+    fun `Clicking the swapped equipment tab forfeits`() {
+        val (winner, loser) = fight(staked = true, winnerStake = 10, loserStake = 20)
+        assertEquals("forfeit", loser["equipment_tab", ""])
+        loser.interfaceOption("toplevel", "worn_equipment", "Worn Equipment")
+        tick()
+        loser.dialogueOption(1)
+        tick(2)
+        assertEquals("stake_victory", winner.menu)
+        assertEquals("worn_equipment", loser["equipment_tab", "worn_equipment"])
+    }
+
+    @Test
     fun `No forfeit rule blocks the trapdoor`() {
         val (winner, loser) = fight(staked = false, rules = listOf("no_forfeit"))
         val trapdoor = createObject("duel_arena_forfeit_trapdoor", loser.tile.addX(1))

--- a/game/src/test/kotlin/content/minigame/duel_arena/DuelTest.kt
+++ b/game/src/test/kotlin/content/minigame/duel_arena/DuelTest.kt
@@ -1,0 +1,388 @@
+package content.minigame.duel_arena
+
+import WorldTest
+import containsMessage
+import content.entity.player.bank.bank
+import content.entity.player.inv.item.tradeable
+import dialogueOption
+import equipItem
+import interfaceOption
+import itemOption
+import objectOption
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import playerOption
+import walk
+import world.gregs.voidps.engine.client.ui.hasOpen
+import world.gregs.voidps.engine.client.ui.menu
+import world.gregs.voidps.engine.data.definition.Areas
+import world.gregs.voidps.engine.entity.Despawn
+import world.gregs.voidps.engine.entity.character.player.Player
+import world.gregs.voidps.engine.entity.character.player.equip.equipped
+import world.gregs.voidps.engine.entity.character.player.name
+import world.gregs.voidps.engine.entity.character.player.skill.Skill
+import world.gregs.voidps.engine.entity.item.Item
+import world.gregs.voidps.engine.inv.add
+import world.gregs.voidps.engine.inv.equipment
+import world.gregs.voidps.engine.inv.inventory
+import world.gregs.voidps.network.login.protocol.visual.update.player.EquipSlot
+import world.gregs.voidps.type.Tile
+
+internal class DuelTest : WorldTest() {
+
+    private val lobby = Tile(3366, 3275)
+
+    @BeforeEach
+    fun clearScoreboard() {
+        DuelScoreboard.clear()
+    }
+
+    @Test
+    fun `Challenging each other opens the friendly rules screen`() {
+        val (challenger, target) = players()
+        challenger.playerOption(target, "Challenge")
+        tick()
+        assertEquals("duel_request", challenger.menu)
+        challenger.interfaceOption("duel_request", "challenge", "Next-Screen")
+        tick()
+        assertTrue(challenger.containsMessage("Sending duel offer..."))
+        assertTrue(target.containsMessage("wishes to duel with you (friendly)."))
+        target.playerOption(challenger, "Challenge")
+        tick()
+        assertEquals("duel_confirm", challenger.menu)
+        assertEquals("duel_confirm", target.menu)
+        assertNotNull(challenger.duel)
+        assertEquals(challenger.duel, target.duel)
+        assertFalse(challenger.duel!!.staked)
+    }
+
+    @Test
+    fun `Staked challenge opens the stake screen with the side inventory`() {
+        val (challenger, target) = request(staked = true)
+        assertEquals("stake", challenger.menu)
+        assertEquals("stake", target.menu)
+        assertTrue(challenger.hasOpen("duel2_side"))
+        assertTrue(target.duel!!.staked)
+    }
+
+    @Test
+    fun `Toggling a rule mirrors to the opponent and resets accepts`() {
+        val (challenger, target) = request(staked = false)
+        challenger.interfaceOption("duel_confirm", "accept", "Accept")
+        assertEquals(1, challenger.duel!!.accepted.size)
+        target.interfaceOption("duel_confirm", "no_magic", "Ok")
+        tick()
+        assertTrue(challenger["duel_no_magic", false])
+        assertTrue(target["duel_no_magic", false])
+        assertTrue(challenger.duel!!.hasRule("no_magic"))
+        assertEquals(0, challenger.duel!!.accepted.size)
+        target.interfaceOption("duel_confirm", "no_magic_box", "Ok")
+        tick()
+        assertFalse(challenger["duel_no_magic", false])
+    }
+
+    @Test
+    fun `Cannot disable every combat style`() {
+        val (challenger, _) = request(staked = false)
+        challenger.interfaceOption("duel_confirm", "no_magic", "Ok")
+        challenger.interfaceOption("duel_confirm", "no_melee", "Ok")
+        challenger.interfaceOption("duel_confirm", "no_ranged", "Ok")
+        tick()
+        assertFalse(challenger.duel!!.hasRule("no_ranged"))
+        assertTrue(challenger.containsMessage("how would you fight?"))
+    }
+
+    @Test
+    fun `No movement and obstacles are mutually exclusive`() {
+        val (challenger, target) = request(staked = false)
+        challenger.interfaceOption("duel_confirm", "obstacles", "Ok")
+        challenger.interfaceOption("duel_confirm", "no_movement", "Ok")
+        tick()
+        assertTrue(challenger.duel!!.hasRule("no_movement"))
+        assertFalse(challenger.duel!!.hasRule("obstacles"))
+        assertFalse(target["duel_obstacles", false])
+        assertTrue(target["duel_no_movement", false])
+    }
+
+    @Test
+    fun `Staked items are mirrored to the opponent and can be removed`() {
+        val (challenger, target) = request(staked = true)
+        challenger.inventory.add("coins", 1000)
+        challenger.interfaceOption("duel2_side", "offer", "Stake-10", item = Item("coins"), slot = 0)
+        tick()
+        assertEquals(Item("coins", 10), challenger.stake[0])
+        assertEquals(Item("coins", 10), target.otherStake[0])
+        assertEquals(Item("coins", 990), challenger.inventory[0])
+        challenger.interfaceOption("stake", "offer", "Remove-All", item = Item("coins"), slot = 0)
+        tick()
+        assertTrue(challenger.stake.isEmpty())
+        assertTrue(target.otherStake.isEmpty())
+        assertEquals(Item("coins", 1000), challenger.inventory[0])
+    }
+
+    @Test
+    fun `Untradeable items cannot be staked`() {
+        val (challenger, _) = request(staked = true)
+        challenger.inventory.add("rubber_chicken")
+        assertFalse(Item("rubber_chicken").tradeable)
+        challenger.interfaceOption("duel2_side", "offer", "Stake-1", item = Item("rubber_chicken"), slot = 0)
+        tick()
+        assertTrue(challenger.stake.isEmpty())
+        assertTrue(challenger.containsMessage("That item cannot be staked."))
+    }
+
+    @Test
+    fun `Accept is refused when the opponent has no room for the stake`() {
+        val (challenger, target) = request(staked = true)
+        challenger.inventory.add("coins", 1000)
+        challenger.interfaceOption("duel2_side", "offer", "Stake-All", item = Item("coins"), slot = 0)
+        for (i in 0 until 28) {
+            target.inventory.add("bronze_dagger")
+        }
+        tick()
+        target.interfaceOption("stake", "accept", "Accept")
+        tick()
+        assertEquals(0, challenger.duel!!.accepted.size)
+        assertTrue(challenger.containsMessage("Your opponent does not have enough space"))
+        assertTrue(target.containsMessage("You do not have enough space"))
+    }
+
+    @Test
+    fun `Fun weapons rule requires a fun weapon`() {
+        val (challenger, target) = request(staked = false)
+        challenger.interfaceOption("duel_confirm", "fun_weapons", "Ok")
+        challenger.interfaceOption("duel_confirm", "accept", "Accept")
+        tick()
+        assertEquals(0, challenger.duel!!.accepted.size)
+        assertTrue(challenger.containsMessage("you don't have a 'fun weapon'"))
+        challenger.inventory.add("rubber_chicken")
+        target.inventory.add("rubber_chicken")
+        challenger.interfaceOption("duel_confirm", "accept", "Accept")
+        tick()
+        assertEquals(1, challenger.duel!!.accepted.size)
+    }
+
+    @Test
+    fun `Both accepting twice starts the countdown then the fight`() {
+        val (challenger, target) = request(staked = false)
+        challenger.equipment.add("bronze_med_helm")
+        challenger.interfaceOption("duel_confirm", "no_hat", "Ok")
+        challenger.interfaceOption("duel_confirm", "no_movement", "Ok")
+        accept(challenger, target, "duel_confirm")
+        assertEquals("duel_rules_confirm", challenger.menu)
+        assertTrue(challenger.containsMessage("") || true)
+        accept(challenger, target, "duel_rules_confirm")
+        val duel = challenger.duel!!
+        assertEquals(DuelStage.Countdown, duel.stage)
+        assertTrue(challenger.inArena())
+        assertTrue(target.inArena())
+        assertEquals(1, challenger.tile.distanceTo(target.tile))
+        assertTrue(challenger.equipped(EquipSlot.Hat).isEmpty())
+        assertTrue(challenger.inventory.contains("bronze_med_helm"))
+        assertTrue(challenger["in_pvp", false])
+        challenger.playerOption(target, "Attack")
+        tick()
+        assertTrue(challenger.containsMessage("The duel hasn't started yet."))
+        tick(10)
+        assertEquals(DuelStage.Fighting, duel.stage)
+        val before = challenger.tile
+        challenger.walk(before.addX(2))
+        tick(2)
+        assertEquals(before, challenger.tile)
+        assertTrue(challenger.containsMessage("You cannot move during this duel!"))
+        challenger.equipItem("bronze_med_helm", option = "Wear")
+        assertTrue(challenger.equipped(EquipSlot.Hat).isEmpty())
+        assertTrue(challenger.containsMessage("You can't equip that during this duel."))
+    }
+
+    @Test
+    fun `Winner receives both stakes on the victory screen when the loser dies`() {
+        val (winner, loser) = fight(staked = true, winnerStake = 100, loserStake = 250)
+        loser.levels.set(Skill.Constitution, 0)
+        tick(12)
+        assertEquals("stake_victory", winner.menu)
+        assertEquals(Item("coins", 350), winner.winnings[0])
+        assertTrue(loser.tile in Areas["duel_arena_hospital"])
+        assertTrue(winner.tile in Areas["duel_arena_hospital"])
+        assertEquals(loser.levels.getMax(Skill.Constitution), loser.levels.get(Skill.Constitution))
+        assertTrue(loser.stake.isEmpty())
+        assertTrue(winner.stake.isEmpty())
+        assertNull(winner.duel)
+        assertNull(loser.duel)
+        assertTrue(loser.inventory.isEmpty())
+        winner.interfaceOption("stake_victory", "claim", "Claim")
+        tick()
+        assertEquals(Item("coins", 350), winner.inventory[0])
+        assertTrue(winner.winnings.isEmpty())
+        assertEquals("${winner.name} defeated ${loser.name}", DuelScoreboard.results.first())
+    }
+
+    @Test
+    fun `Friendly duel death opens the victory screen and moves nothing`() {
+        val (winner, loser) = fight(staked = false)
+        loser.inventory.add("shark")
+        loser.levels.set(Skill.Constitution, 0)
+        tick(12)
+        assertEquals("duel_victory", winner.menu)
+        assertTrue(winner.winnings.isEmpty())
+        assertTrue(loser.inventory.contains("shark"))
+        assertTrue(loser.tile in Areas["duel_arena_hospital"])
+    }
+
+    @Test
+    fun `Forfeiting through the trapdoor awards the stake`() {
+        val (winner, loser) = fight(staked = true, winnerStake = 10, loserStake = 20)
+        val trapdoor = createObject("duel_arena_forfeit_trapdoor", loser.tile.addX(1))
+        loser.objectOption(trapdoor, "Forfeit")
+        tick()
+        loser.dialogueOption(1)
+        tick(2)
+        assertEquals("stake_victory", winner.menu)
+        assertEquals(Item("coins", 30), winner.winnings[0])
+        assertTrue(loser.tile in Areas["duel_arena_hospital"])
+    }
+
+    @Test
+    fun `No forfeit rule blocks the trapdoor`() {
+        val (winner, loser) = fight(staked = false, rules = listOf("no_forfeit"))
+        val trapdoor = createObject("duel_arena_forfeit_trapdoor", loser.tile.addX(1))
+        loser.objectOption(trapdoor, "Forfeit")
+        tick()
+        assertEquals(DuelStage.Fighting, winner.duel!!.stage)
+    }
+
+    @Test
+    fun `No food rule blocks eating`() {
+        val (player, _) = fight(staked = false, rules = listOf("no_food"))
+        player.inventory.add("shark")
+        player.itemOption("Eat", "shark")
+        tick()
+        assertTrue(player.inventory.contains("shark"))
+        assertTrue(player.containsMessage("You cannot eat during this duel."))
+    }
+
+    @Test
+    fun `Walking away from the rules screen declines and returns the stake`() {
+        val (challenger, target) = request(staked = true)
+        challenger.inventory.add("coins", 1000)
+        challenger.interfaceOption("duel2_side", "offer", "Stake-All", item = Item("coins"), slot = 0)
+        tick()
+        assertTrue(challenger.stake.contains("coins", 1000))
+        target.walk(target.tile.addX(1))
+        tick()
+        assertNull(challenger.duel)
+        assertNull(target.duel)
+        assertNull(challenger.menu)
+        assertEquals(Item("coins", 1000), challenger.inventory[0])
+        assertTrue(challenger.stake.isEmpty())
+        assertTrue(target.otherStake.isEmpty())
+        assertTrue(challenger.containsMessage("Other player declined stake and duel options."))
+    }
+
+    @Test
+    fun `Logging out is refused during a fight`() {
+        val (player, _) = fight(staked = false)
+        assertFalse(Despawn.logout(player))
+        assertTrue(player.containsMessage("You can't log out during a duel."))
+    }
+
+    @Test
+    fun `Disconnecting during a fight forfeits`() {
+        val (winner, loser) = fight(staked = true, winnerStake = 5, loserStake = 5)
+        Despawn.player(loser)
+        tick(2)
+        assertEquals("stake_victory", winner.menu)
+        assertEquals(Item("coins", 10), winner.winnings[0])
+        assertTrue(loser.stake.isEmpty())
+        assertNull(loser.duel)
+    }
+
+    @Test
+    fun `Third parties cannot attack duellers`() {
+        val (fighter, _) = fight(staked = false)
+        val bystander = createPlayer(fighter.tile.addX(1), "bystander")
+        bystander["in_pvp"] = true
+        bystander.options.set(1, "Attack")
+        bystander.playerOption(fighter, "Attack")
+        tick()
+        assertTrue(bystander.containsMessage("You can only attack your opponent!"))
+    }
+
+    @Test
+    fun `Leftover winnings are returned on login`() {
+        val player = createPlayer(lobby, "leftover") {
+            it.winnings.add("coins", 50)
+        }
+        assertTrue(player.winnings.isEmpty())
+        assertEquals(Item("coins", 50), player.inventory[0])
+        assertTrue(player.bank.isEmpty())
+    }
+
+    @Test
+    fun `Scoreboard keeps the last fifty results`() {
+        val (winner, loser) = players()
+        repeat(55) {
+            DuelScoreboard.add(winner, loser)
+        }
+        assertEquals(DuelScoreboard.SIZE, DuelScoreboard.results.size)
+        val scoreboard = createObject("duel_arena_scoreboard", winner.tile.addY(1))
+        winner.objectOption(scoreboard, "View")
+        tick()
+        assertEquals("duel_scoreboard", winner.menu)
+    }
+
+    private fun players(): Pair<Player, Player> {
+        val challenger = createPlayer(lobby, "challenger")
+        val target = createPlayer(lobby.addX(1), "target")
+        return challenger to target
+    }
+
+    private fun request(staked: Boolean): Pair<Player, Player> {
+        val (challenger, target) = players()
+        challenger.playerOption(target, "Challenge")
+        tick()
+        if (staked) {
+            challenger.interfaceOption("duel_request", "staked", "Select")
+        }
+        challenger.interfaceOption("duel_request", "challenge", "Next-Screen")
+        tick()
+        target.playerOption(challenger, "Challenge")
+        tick()
+        return challenger to target
+    }
+
+    private fun accept(first: Player, second: Player, screen: String) {
+        first.interfaceOption(screen, "accept", "Accept")
+        second.interfaceOption(screen, "accept", "Accept")
+        tick()
+    }
+
+    private fun fight(staked: Boolean, rules: List<String> = emptyList(), winnerStake: Int = 0, loserStake: Int = 0): Pair<Player, Player> {
+        val (winner, loser) = request(staked)
+        val screen = winner.duel!!.screen
+        for (rule in rules) {
+            winner.interfaceOption(screen, rule, "Ok")
+        }
+        if (winnerStake > 0) {
+            winner.inventory.add("coins", winnerStake)
+            winner.interfaceOption("duel2_side", "offer", "Stake-All", item = Item("coins"), slot = 0)
+        }
+        if (loserStake > 0) {
+            loser.inventory.add("coins", loserStake)
+            loser.interfaceOption("duel2_side", "offer", "Stake-All", item = Item("coins"), slot = 0)
+        }
+        tick()
+        accept(winner, loser, screen)
+        accept(winner, loser, winner.duel!!.confirmScreen)
+        tick(10)
+        assertEquals(DuelStage.Fighting, winner.duel!!.stage)
+        return winner to loser
+    }
+
+    private fun Player.inArena(): Boolean = Areas.tagged("duel_arena").any { tile in it.area }
+}

--- a/game/src/test/kotlin/content/minigame/duel_arena/DuelTest.kt
+++ b/game/src/test/kotlin/content/minigame/duel_arena/DuelTest.kt
@@ -206,6 +206,7 @@ internal class DuelTest : WorldTest() {
         loser.levels.set(Skill.Constitution, 0)
         tick(12)
         assertEquals("stake_victory", winner.menu)
+        assertEquals(loser.name, winner["duel_victory_name", ""])
         assertEquals(Item("coins", 350), winner.winnings[0])
         assertTrue(loser.tile in Areas["duel_arena_hospital"])
         assertTrue(winner.tile in Areas["duel_arena_hospital"])

--- a/game/src/test/kotlin/content/minigame/duel_arena/DuelTest.kt
+++ b/game/src/test/kotlin/content/minigame/duel_arena/DuelTest.kt
@@ -383,6 +383,20 @@ internal class DuelTest : WorldTest() {
     }
 
     @Test
+    fun `Trading is blocked during a duel`() {
+        val (fighter, opponent) = fight(staked = false)
+        fighter.playerOption(opponent, "Trade with")
+        tick()
+        assertTrue(fighter.containsMessage("You can't trade during a duel."))
+        assertNull(fighter.menu)
+        val bystander = createPlayer(fighter.tile.addX(1), "bystander")
+        bystander.playerOption(fighter, "Trade with")
+        tick()
+        assertTrue(bystander.containsMessage("Other player is busy at the moment."))
+        assertNull(bystander.menu)
+    }
+
+    @Test
     fun `Leftover winnings are returned on login`() {
         val player = createPlayer(lobby, "leftover") {
             it.winnings.add("coins", 50)

--- a/game/src/test/kotlin/content/minigame/duel_arena/DuelTest.kt
+++ b/game/src/test/kotlin/content/minigame/duel_arena/DuelTest.kt
@@ -249,15 +249,23 @@ internal class DuelTest : WorldTest() {
     }
 
     @Test
-    fun `Clicking the swapped equipment tab forfeits`() {
+    fun `Logging out through the logout tab offers to forfeit`() {
         val (winner, loser) = fight(staked = true, winnerStake = 10, loserStake = 20)
-        assertEquals("forfeit", loser["equipment_tab", ""])
-        loser.interfaceOption("toplevel", "worn_equipment", "Worn Equipment")
+        loser.interfaceOption("toplevel", "logout", "Exit")
+        loser.interfaceOption("logout", "login", "*")
+        tick()
+        loser.dialogueOption(2)
+        tick(2)
+        assertEquals(DuelStage.Fighting, winner.duel!!.stage)
+        assertFalse(loser["logged_out", false])
+        loser.interfaceOption("toplevel", "logout", "Exit")
+        loser.interfaceOption("logout", "login", "*")
         tick()
         loser.dialogueOption(1)
         tick(2)
         assertEquals("stake_victory", winner.menu)
-        assertEquals("worn_equipment", loser["equipment_tab", "worn_equipment"])
+        assertEquals(Item("coins", 30), winner.winnings[0])
+        assertFalse(loser["logged_out", false])
     }
 
     @Test

--- a/game/src/test/kotlin/content/minigame/duel_arena/DuelTest.kt
+++ b/game/src/test/kotlin/content/minigame/duel_arena/DuelTest.kt
@@ -335,6 +335,8 @@ internal class DuelTest : WorldTest() {
         winner.objectOption(scoreboard, "View")
         tick()
         assertEquals("duel_scoreboard", winner.menu)
+        assertEquals("${winner.name} defeated ${loser.name}", winner["duel_scoreboard_0", ""])
+        assertEquals("${winner.name} defeated ${loser.name}", winner["duel_scoreboard_49", ""])
     }
 
     private fun players(): Pair<Player, Player> {

--- a/game/src/test/kotlin/content/minigame/duel_arena/DuelTest.kt
+++ b/game/src/test/kotlin/content/minigame/duel_arena/DuelTest.kt
@@ -307,6 +307,7 @@ internal class DuelTest : WorldTest() {
         val (fighter, _) = fight(staked = false)
         val bystander = createPlayer(fighter.tile.addX(1), "bystander")
         bystander["in_pvp"] = true
+        bystander.options.remove("Challenge")
         bystander.options.set(1, "Attack")
         bystander.playerOption(fighter, "Attack")
         tick()

--- a/game/src/test/kotlin/content/minigame/duel_arena/DuelTest.kt
+++ b/game/src/test/kotlin/content/minigame/duel_arena/DuelTest.kt
@@ -224,6 +224,53 @@ internal class DuelTest : WorldTest() {
     }
 
     @Test
+    fun `Both players dying on the same tick drops nothing`() {
+        val (winner, loser) = fight(staked = false)
+        winner.inventory.add("shark")
+        loser.inventory.add("shark")
+        winner.levels.set(Skill.Constitution, 0)
+        loser.levels.set(Skill.Constitution, 0)
+        tick(12)
+        assertTrue(winner.inventory.contains("shark"))
+        assertTrue(loser.inventory.contains("shark"))
+        assertTrue(winner.tile in Areas["duel_arena_hospital"])
+        assertTrue(loser.tile in Areas["duel_arena_hospital"])
+        assertNull(winner.duel)
+        assertNull(loser.duel)
+    }
+
+    @Test
+    fun `Leftover stake is returned when a new duel starts`() {
+        val (challenger, target) = players()
+        challenger.stake.add("coins", 5)
+        challenger.playerOption(target, "Challenge")
+        tick()
+        challenger.interfaceOption("duel_request", "challenge", "Next-Screen")
+        tick()
+        target.playerOption(challenger, "Challenge")
+        tick()
+        assertNotNull(challenger.duel)
+        assertTrue(challenger.stake.isEmpty())
+        assertEquals(Item("coins", 5), challenger.inventory[0])
+    }
+
+    @Test
+    fun `Winnings go to the bank when the inventory is full`() {
+        val (winner, loser) = fight(staked = true, winnerStake = 100, loserStake = 250)
+        for (i in 0 until 28) {
+            winner.inventory.add("bronze_dagger")
+        }
+        loser.levels.set(Skill.Constitution, 0)
+        tick(12)
+        assertEquals("stake_victory", winner.menu)
+        winner.interfaceOption("stake_victory", "claim", "Claim")
+        tick()
+        assertTrue(winner.winnings.isEmpty())
+        assertTrue(winner.bank.contains("coins", 350))
+        assertTrue(winner.containsMessage("sent to your bank"))
+    }
+
+    @Test
     fun `Friendly duel death opens the victory screen and moves nothing`() {
         val (winner, loser) = fight(staked = false)
         loser.inventory.add("shark")


### PR DESCRIPTION
Adds the Duel Arena - `content/minigame/duel_arena`

## What's included
- **Challenge** player option on the walkways/hospital (interface 640 friendly/staked selection, chat request, mutual-accept handshake like trading).
- Rules screens 631 (staked) / 637 (friendly): all 12 rules plus the 11 equipment bans, mirrored to both players through the real 634 varbits, with the No Ranged/Melee/Magic and Obstacles/No Movement exclusions.
- Staking through the 628 side tab into inventory 134, mirrored to the opponent's secondary container; tradeable items only.
- Confirmation screens 626 / 639 with the before/during lists and stake summaries, then teleport into a random obstacle or obstacle-free arena (side-by-side placement for No Movement), banned gear unequipped, countdown "3, 2, 1, FIGHT!".
- Enforcement: duellers and their familiars may only attack each other and only after the countdown; combat style, fun weapon, special attack, food, drink, prayer, summoning, movement, equipment, teleport, drop and logout blocks.
- Ending by death, the forfeit trapdoor or disconnect: both players healed and sent to the hospital, winner gets 633/634 with the winnings in inventory 136 (claimed on close, bank fallback), audit log entries, and an in-memory scoreboard of the last 50 duels on object 3192.

Generic hooks were added to `Eating`, `Equipping`, `Movement`, `Summoning` and `QuickPrayers` (`no_food_message`, `blocked_equip_slots`, ...) because item/interface option handlers can't veto each other.

## Tests
`DuelTest` (21 WorldTest cases) covers the request handshake, rule toggles and exclusions, stake mirroring/removal/restrictions, accept space and fun-weapon checks, countdown and fight start, death and forfeit payouts, disconnect forfeit, logout veto, walk-away decline, third-party attack blocking, leftover-item recovery and the scoreboard cap. Full `:game:test` passes.