### PR TITLE
Fix Yanille Magic Store Owner missing his shop and fix a Quest Journal typo for Cook's Assistant.

### DIFF
--- a/data/area/kandarin/yanille/yanille.npcs.toml
+++ b/data/area/kandarin/yanille/yanille.npcs.toml
@@ -55,6 +55,7 @@ examine = "A visiting gnome mage."
 
 [magic_store_owner]
 id = 461
+shop = "magic_guild_store_runes_and_staves"
 examine = "A Supplier of Magical items."
 
 [aleck]

--- a/game/src/main/kotlin/content/quest/free/cooks_assistant/CooksAssistant.kt
+++ b/game/src/main/kotlin/content/quest/free/cooks_assistant/CooksAssistant.kt
@@ -80,7 +80,7 @@ class CooksAssistant : Script {
                     "<maroon>kitchen <navy>of <maroon>Lumbridge Castle.",
                 )
             }
-            questJournal("Cook's Aassistant", lines)
+            questJournal("Cook's Assistant", lines)
         }
     }
 }


### PR DESCRIPTION
This is my first contribution.

The Magic Store Owner in Yanille already had a shop definition, but he was missing the `shop` variable in `yanille.npcs.toml`.
The Quest Journal title for Cook's Assistant was misspelled.