### PR TITLE
Creates an option in game.properties to disable player vs player activities

### DIFF
--- a/game/src/main/kotlin/content/entity/combat/Target.kt
+++ b/game/src/main/kotlin/content/entity/combat/Target.kt
@@ -15,6 +15,7 @@ import it.unimi.dsi.fastutil.objects.Object2IntOpenHashMap
 import it.unimi.dsi.fastutil.objects.ObjectArrayList
 import world.gregs.voidps.engine.client.message
 import world.gregs.voidps.engine.client.variable.hasClock
+import world.gregs.voidps.engine.data.Settings
 import world.gregs.voidps.engine.data.definition.NPCDefinitions
 import world.gregs.voidps.engine.entity.character.Character
 import world.gregs.voidps.engine.entity.character.mode.PauseMode
@@ -79,6 +80,10 @@ object Target {
             return false
         }
         if (source is Player && target is Player) {
+            if (Settings["combat.pvp", false]){
+                if (message) source.message("Player-vs-player has been disabled in this world.")
+                return false
+            }
             if (!source.inPvp && !source.inWilderness) {
                 if (message) source.message("You can only attack players in a player-vs-player area.")
                 return false

--- a/game/src/main/resources/game.properties
+++ b/game/src/main/resources/game.properties
@@ -165,6 +165,9 @@ combat.showSoak=true
 # Whether to spawn gravestones on death
 combat.gravestones=true
 
+# Whether player-vs-player is enabled
+combat.pvp=true
+
 #------- Agility -------
 
 # Disable players failing obstacles on agility courses


### PR DESCRIPTION
(Default is enabled)

I saw this wasn't a setting, thought it'd be useful to others too who don't enjoy pvp content. It also just adds another layer of customization for hosts.